### PR TITLE
fix: streaming bug and the ui input being invisible.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,20 +25,33 @@ causing the streaming response to delay. The skeleton cards show (from `HmrcResu
 
 ### The fix
 
-The opacity condition was changed from:
-```
-!ready || showPill
-```
-to:
-```
-showPill || (!ready && isStuck)
-```
+The input wrapper has NO inline style. Visibility is controlled entirely by `useLayoutEffect`
+in `SearchBar.tsx`, which sets `opacity` and `pointerEvents` on the wrapper ref.
 
-This ensures:
-- **SSR/initial load**: `ready=false`, `isStuck=false` → input is visible (opacity: 1)
-- **Navigating back while scrolled**: `ready=false`, `isStuck=true` → input is hidden briefly
-  until observer fires, preventing the flash
-- **Pill showing**: `showPill=true` → input is hidden, pill takes over
+**Why `useLayoutEffect`:**
+- On the server, `useLayoutEffect` is a no-op — so the SSR HTML renders the input with
+  no inline style (visible by default). Users see the search input immediately, even
+  before JS loads.
+- On the client, `useLayoutEffect` runs synchronously before the browser paints — so when
+  navigating back from a company page while scrolled, it sets `opacity: 0` before the
+  user sees anything. No flash.
+- When the IntersectionObserver fires and sets `ready=true`, `useLayoutEffect` runs again
+  and sets `opacity: 1`.
+
+### Approaches that were tried and failed — do NOT use
+
+1. **Inline `style={{ opacity: !ready || showPill ? 0 : 1 }}`** — the server bakes
+   `opacity: 0` into the HTML since `ready` is always `false` on the server. Input is
+   invisible until JS hydrates, which is noticeable on slow connections or serverless
+   cold starts.
+2. **Default `ready` to `true`** — causes a flash of the input when navigating back
+   from the company detail page while scrolled down.
+3. **Change opacity condition to `showPill || (!ready && isStuck)`** — causes the input
+   to flash on initial paint before hydration hides it, because the sentinel is briefly
+   in the viewport during layout before scroll position restores.
+4. **Synchronous `getBoundingClientRect` check in `useSearchPill` effect** — same flash
+   problem as #3. On back-navigation the sentinel is momentarily in-viewport before
+   scroll restores, so it incorrectly sets `ready=true`.
 
 ### Key files
 - `src/components/SearchBar.tsx` — opacity logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# Project Notes
+
+## Search input visibility bug (SearchBar + useSearchPill)
+
+The search input in `SearchBar.tsx` is wrapped in a div with `opacity: 0/1` controlled by
+two flags: `ready` and `showPill` from the `useSearchPill` hook.
+
+### The `ready` flag
+
+`ready` starts as `false` and becomes `true` when the IntersectionObserver in `useSearchPill`
+fires for the first time. Its purpose is to prevent a flash where the full search input
+briefly appears before transitioning to the pill (compact header button) when navigating
+back to the search page while scrolled down.
+
+### The bug
+
+On SSR, `ready` is always `false` (IntersectionObserver is client-only). This means the
+server-rendered HTML has `opacity: 0` on the search input wrapper. If hydration or JS
+execution is slow (mobile devices, cold starts), the user sees a blank space where the
+search input should be.
+
+This is especially noticeable when the Neon DB has a cold start (auto-suspend on free tier),
+causing the streaming response to delay. The skeleton cards show (from `HmrcResults`
+`isLoading` check, not the Suspense boundary), but the search input is invisible.
+
+### The fix
+
+The opacity condition was changed from:
+```
+!ready || showPill
+```
+to:
+```
+showPill || (!ready && isStuck)
+```
+
+This ensures:
+- **SSR/initial load**: `ready=false`, `isStuck=false` → input is visible (opacity: 1)
+- **Navigating back while scrolled**: `ready=false`, `isStuck=true` → input is hidden briefly
+  until observer fires, preventing the flash
+- **Pill showing**: `showPill=true` → input is hidden, pill takes over
+
+### Key files
+- `src/components/SearchBar.tsx` — opacity logic
+- `src/hooks/useSearchPill.ts` — `ready` and `isStuck` state
+- `src/components/HmrcResults.tsx` — skeleton shown via `isLoading`, not Suspense fallback

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -67,11 +67,11 @@ export default function SearchBar({
 
   return (
     <div className="relative">
-      {/* Input — hidden until observer ready, hides when pill shows */}
+      {/* Input — hides when pill shows, or briefly hidden until observer is ready (client-only) */}
       <div
         style={{
-          opacity: !ready || showPill ? 0 : 1,
-          pointerEvents: !ready || showPill ? 'none' : 'auto',
+          opacity: showPill || (!ready && isStuck) ? 0 : 1,
+          pointerEvents: showPill || (!ready && isStuck) ? 'none' : 'auto',
         }}
       >
         <SearchInput

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,4 +1,10 @@
-import { type RefObject, useEffect, useRef, useState } from 'react';
+import {
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { getShortcutLabel, type Platform } from '../hooks/usePlatform';
 import { useRotatingPlaceholder } from '../hooks/useRotatingPlaceholder';
@@ -31,10 +37,26 @@ export default function SearchBar({
   const showPill = isStuck && !pillClicked && !!search;
   const shortcut = isMobile ? '' : getShortcutLabel(platform);
   const placeholder = useRotatingPlaceholder(shortcut, !!search);
+  const inputWrapRef = useRef<HTMLDivElement>(null);
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   useEffect(() => {
     setPortalTarget(document.getElementById('header-pill-portal'));
   }, []);
+
+  // Hide the input before the browser paints on the client.
+  // This runs before paint (useLayoutEffect) so there's no visible flash.
+  // On the server, useLayoutEffect is a no-op, so the HTML renders with opacity: 1.
+  useLayoutEffect(() => {
+    const el = inputWrapRef.current;
+    if (!el) return;
+    if (!ready || showPill) {
+      el.style.opacity = '0';
+      el.style.pointerEvents = 'none';
+    } else {
+      el.style.opacity = '1';
+      el.style.pointerEvents = 'auto';
+    }
+  }, [ready, showPill]);
 
   useEffect(() => {
     if (showPill) {
@@ -67,13 +89,8 @@ export default function SearchBar({
 
   return (
     <div className="relative">
-      {/* Input — hides when pill shows, or briefly hidden until observer is ready (client-only) */}
-      <div
-        style={{
-          opacity: showPill || (!ready && isStuck) ? 0 : 1,
-          pointerEvents: showPill || (!ready && isStuck) ? 'none' : 'auto',
-        }}
-      >
+      {/* Input — visible in SSR HTML, hidden by useLayoutEffect before paint on client */}
+      <div ref={inputWrapRef}>
         <SearchInput
           inputRef={inputRef}
           autoFocus={!isStuck && search.length < 3}


### PR DESCRIPTION
The claude.md file serves as an explanation to why this bug was caused for future context

This is what happens if a neon db cold start takes time, and the input button would never show as a result.

<img width="590" height="1278" alt="Skilled Worker Sponsor Search 2" src="https://github.com/user-attachments/assets/81cd4b70-1e5e-498f-a154-dbd47e78c72e" />
