### PR TITLE
feat: Avoid hitting the company house api due to rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Project Notes
+
+## Search input visibility (SearchBar + useSearchPill)
+
+The search input in `SearchBar.tsx` is wrapped in a div with inline `opacity: 0/1`
+controlled by two flags: `ready` and `showPill` from the `useSearchPill` hook.
+
+### How it works
+
+- `ready` starts `false`, becomes `true` when the IntersectionObserver fires
+- `showPill` is `true` when scrolled past the sentinel with an active search term
+- Input wrapper: `opacity: !ready || showPill ? 0 : 1`
+- Server renders `opacity: 0` (observer is client-only, so `ready` is always `false`)
+- After hydration, observer fires, `ready` becomes `true`, input appears
+
+### Known limitation
+
+If the Vercel serverless function or Neon DB cold-starts, the SSR HTML arrives with the
+input at `opacity: 0`. The input stays invisible until JS hydrates and the observer fires.
+During this time the skeleton cards show (from `HmrcResults` `isLoading` check, not the
+Suspense boundary) but the search input is hidden.
+
+This is acceptable because:
+- If the server is slow enough that the input is hidden, the user can't search anyway
+  (no JS = no interactivity)
+- The correct fix is graceful error handling on the query side (timeout/error boundary),
+  not visibility hacks on the input
+
+### Approaches that were tried and failed — do NOT use
+
+1. **`useLayoutEffect` to set opacity** (no inline style, server renders visible) — fixes
+   the cold-start visibility issue but causes the input to flash when reloading while
+   scrolled down. `useLayoutEffect` is a no-op on the server so the HTML has no opacity
+   style, and the input is visible for one frame before JS hides it.
+2. **Default `ready` to `true`** — causes a flash of the input when navigating back from
+   the company detail page while scrolled down.
+3. **Change opacity condition to `showPill || (!ready && isStuck)`** — causes the input
+   to flash on initial paint before hydration hides it, because the sentinel is briefly
+   in the viewport during layout before scroll position restores.
+4. **Synchronous `getBoundingClientRect` check in `useSearchPill` effect** — same flash
+   problem as #3. On back-navigation the sentinel is momentarily in-viewport before
+   scroll restores, so it incorrectly sets `ready=true`.
+
+### Key files
+- `src/components/SearchBar.tsx` — opacity logic (inline style)
+- `src/hooks/useSearchPill.ts` — `ready` and `isStuck` state
+- `src/components/HmrcResults.tsx` — skeleton shown via `isLoading`, not Suspense fallback
+- `src/routes/index.tsx` — Suspense boundary wraps HmrcResults only, not SearchBar

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@tanstack/router-plugin": "^1.132.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/edge": "^1.2.2",
+        "@vercel/functions": "^3.4.3",
         "@vercel/speed-insights": "^2.0.0",
         "csv-parse": "^6.2.1",
         "dotenv": "^17.4.0",
@@ -507,6 +508,10 @@
     "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@vercel/edge": ["@vercel/edge@1.2.2", "", {}, "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA=="],
+
+    "@vercel/functions": ["@vercel/functions@3.4.3", "", { "dependencies": { "@vercel/oidc": "3.2.0" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw=="],
+
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vercel/postgres": ["@vercel/postgres@0.10.0", "", { "dependencies": { "@neondatabase/serverless": "^0.9.3", "bufferutil": "^4.0.8", "ws": "^8.17.1" } }, "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg=="],
 

--- a/drizzle/0014_wild_sauron.sql
+++ b/drizzle/0014_wild_sauron.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "companies_house_profiles" (
+	"company_number" varchar(20) PRIMARY KEY NOT NULL,
+	"company_name" varchar(255) NOT NULL,
+	"company_status" varchar(50),
+	"company_type" varchar(100),
+	"date_of_creation" date,
+	"address_line_1" varchar(255),
+	"address_line_2" varchar(255),
+	"locality" varchar(100),
+	"region" varchar(100),
+	"postal_code" varchar(20),
+	"country" varchar(100),
+	"sic_codes" text[] DEFAULT '{}'::text[],
+	"accounts_next_made_up_to" date,
+	"accounts_last_made_up_to" date,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_ch_company_name" ON "companies_house_profiles" USING btree ("company_name");--> statement-breakpoint
+CREATE INDEX "idx_ch_company_status" ON "companies_house_profiles" USING btree ("company_status");--> statement-breakpoint
+CREATE INDEX "idx_ch_company_type" ON "companies_house_profiles" USING btree ("company_type");--> statement-breakpoint
+CREATE INDEX "idx_ch_sic_codes" ON "companies_house_profiles" USING gin ("sic_codes");

--- a/drizzle/0015_mean_felicia_hardy.sql
+++ b/drizzle/0015_mean_felicia_hardy.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "companies_house_profiles" ADD COLUMN "accounts_overdue" boolean;--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "jurisdiction" varchar(100);--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "has_been_liquidated" boolean;--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "has_insolvency_history" boolean;--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "has_charges" boolean;--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "previous_company_names" text[] DEFAULT '{}'::text[];--> statement-breakpoint
+ALTER TABLE "companies_house_profiles" ADD COLUMN "confirmation_statement_last_made_up_to" date;--> statement-breakpoint
+CREATE INDEX "idx_ch_jurisdiction" ON "companies_house_profiles" USING btree ("jurisdiction");--> statement-breakpoint
+CREATE INDEX "idx_ch_previous_names" ON "companies_house_profiles" USING gin ("previous_company_names");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,420 @@
+{
+  "id": "9da97cb0-187a-47d2-9363-73a815e8bd0e",
+  "prevId": "180ce4a3-2783-418f-b405-edb81565c530",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.companies_house_profiles": {
+      "name": "companies_house_profiles",
+      "schema": "",
+      "columns": {
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_status": {
+          "name": "company_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_creation": {
+          "name": "date_of_creation",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sic_codes": {
+          "name": "sic_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "accounts_next_made_up_to": {
+          "name": "accounts_next_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_last_made_up_to": {
+          "name": "accounts_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_company_name": {
+          "name": "idx_ch_company_name",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_status": {
+          "name": "idx_ch_company_status",
+          "columns": [
+            {
+              "expression": "company_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_type": {
+          "name": "idx_ch_company_type",
+          "columns": [
+            {
+              "expression": "company_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_sic_codes": {
+          "name": "idx_ch_sic_codes",
+          "columns": [
+            {
+              "expression": "sic_codes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_ingestion_meta": {
+      "name": "hmrc_ingestion_meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "csv_url": {
+          "name": "csv_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_skilled_workers": {
+      "name": "hmrc_skilled_workers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_city": {
+          "name": "town_city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_rating": {
+          "name": "type_rating",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_hmrc_org_name": {
+          "name": "idx_hmrc_org_name",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_town_city": {
+          "name": "idx_hmrc_town_city",
+          "columns": [
+            {
+              "expression": "town_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_route": {
+          "name": "idx_hmrc_route",
+          "columns": [
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_org_name_trgm": {
+          "name": "idx_hmrc_org_name_trgm",
+          "columns": [
+            {
+              "expression": "\"organisation_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmrc_skilled_workers_hash_unique": {
+          "name": "hmrc_skilled_workers_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sic_codes": {
+      "name": "sic_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,493 @@
+{
+  "id": "f51f08be-cdd5-40e3-97ba-f901be9895dc",
+  "prevId": "9da97cb0-187a-47d2-9363-73a815e8bd0e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.companies_house_profiles": {
+      "name": "companies_house_profiles",
+      "schema": "",
+      "columns": {
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_status": {
+          "name": "company_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_creation": {
+          "name": "date_of_creation",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sic_codes": {
+          "name": "sic_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "accounts_next_made_up_to": {
+          "name": "accounts_next_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_last_made_up_to": {
+          "name": "accounts_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_overdue": {
+          "name": "accounts_overdue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_been_liquidated": {
+          "name": "has_been_liquidated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_insolvency_history": {
+          "name": "has_insolvency_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_charges": {
+          "name": "has_charges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_company_names": {
+          "name": "previous_company_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "confirmation_statement_last_made_up_to": {
+          "name": "confirmation_statement_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_company_name": {
+          "name": "idx_ch_company_name",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_status": {
+          "name": "idx_ch_company_status",
+          "columns": [
+            {
+              "expression": "company_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_type": {
+          "name": "idx_ch_company_type",
+          "columns": [
+            {
+              "expression": "company_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_sic_codes": {
+          "name": "idx_ch_sic_codes",
+          "columns": [
+            {
+              "expression": "sic_codes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_ch_jurisdiction": {
+          "name": "idx_ch_jurisdiction",
+          "columns": [
+            {
+              "expression": "jurisdiction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_previous_names": {
+          "name": "idx_ch_previous_names",
+          "columns": [
+            {
+              "expression": "previous_company_names",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_ingestion_meta": {
+      "name": "hmrc_ingestion_meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "csv_url": {
+          "name": "csv_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_skilled_workers": {
+      "name": "hmrc_skilled_workers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_city": {
+          "name": "town_city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_rating": {
+          "name": "type_rating",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_hmrc_org_name": {
+          "name": "idx_hmrc_org_name",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_town_city": {
+          "name": "idx_hmrc_town_city",
+          "columns": [
+            {
+              "expression": "town_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_route": {
+          "name": "idx_hmrc_route",
+          "columns": [
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_org_name_trgm": {
+          "name": "idx_hmrc_org_name_trgm",
+          "columns": [
+            {
+              "expression": "\"organisation_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmrc_skilled_workers_hash_unique": {
+          "name": "hmrc_skilled_workers_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sic_codes": {
+      "name": "sic_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775849138158,
       "tag": "0014_wild_sauron",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775856115133,
+      "tag": "0015_mean_felicia_hardy",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775665979251,
       "tag": "0013_messy_sentinels",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1775849138158,
+      "tag": "0014_wild_sauron",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:ingest": "bun scripts/ingest-hmrc-csv.ts",
     "hmrc:find-csv": "bun scripts/find-hmrc-csv-url.ts",
     "company:lookup": "bun scripts/lookup-company.ts",
+    "seed:companies-house": "bun scripts/seed-companies-house.ts",
     "sitemap:generate": "bun scripts/generate-sitemap.ts",
     "sic:fetch": "bun scripts/fetch-sic-codes.ts",
     "db:seed-sic": "bun scripts/seed-sic-codes.ts"
@@ -40,6 +41,7 @@
     "@tanstack/router-plugin": "^1.132.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/edge": "^1.2.2",
+    "@vercel/functions": "^3.4.3",
     "@vercel/speed-insights": "^2.0.0",
     "csv-parse": "^6.2.1",
     "dotenv": "^17.4.0",

--- a/scripts/seed-companies-house.ts
+++ b/scripts/seed-companies-house.ts
@@ -10,24 +10,24 @@
  * - Logs progress every 100 companies
  */
 
-import { neon } from "@neondatabase/serverless";
-import dotenv from "dotenv";
-import { drizzle } from "drizzle-orm/neon-http";
-import { companiesHouseProfiles } from "../src/db/schema";
+import { neon } from '@neondatabase/serverless';
+import dotenv from 'dotenv';
+import { drizzle } from 'drizzle-orm/neon-http';
+import { companiesHouseProfiles } from '../src/db/schema';
 
-dotenv.config({ path: ".env.local" });
+dotenv.config({ path: '.env.local' });
 
 const sql = neon(process.env.POSTGRES_URL as string);
 const db = drizzle({ client: sql });
 
-const BASE_URL = "https://api.company-information.service.gov.uk";
+const BASE_URL = 'https://api.company-information.service.gov.uk';
 const API_KEY = process.env.COMPANIES_HOUSE_SEED_API_KEY as string;
 if (!API_KEY)
   throw new Error(
-    "Set COMPANIES_HOUSE_SEED_API_KEY in .env.local (use a separate key from production)",
+    'Set COMPANIES_HOUSE_SEED_API_KEY in .env.local (use a separate key from production)',
   );
 
-const AUTH_HEADER = `Basic ${Buffer.from(`${API_KEY}:`).toString("base64")}`;
+const AUTH_HEADER = `Basic ${Buffer.from(`${API_KEY}:`).toString('base64')}`;
 
 // ~2 requests per second to stay within 600/5min
 const DELAY_MS = 550;
@@ -43,7 +43,7 @@ async function fetchApi(path: string): Promise<unknown | null> {
 
   if (res.status === 429) {
     // Rate limited — back off for 60 seconds then retry
-    console.log("  Rate limited, backing off for 60s...");
+    console.log('  Rate limited, backing off for 60s...');
     await sleep(60_000);
     return fetchApi(path);
   }
@@ -144,6 +144,15 @@ for (const row of allOrgs) {
     accounts?: {
       next_made_up_to?: string;
       last_accounts?: { made_up_to?: string };
+      overdue?: boolean;
+    };
+    jurisdiction?: string;
+    has_been_liquidated?: boolean;
+    has_insolvency_history?: boolean;
+    has_charges?: boolean;
+    previous_company_names?: { name: string }[];
+    confirmation_statement?: {
+      last_made_up_to?: string;
     };
   } | null;
 
@@ -173,6 +182,15 @@ for (const row of allOrgs) {
       sicCodes: profile.sic_codes ?? [],
       accountsNextMadeUpTo: profile.accounts?.next_made_up_to || null,
       accountsLastMadeUpTo: profile.accounts?.last_accounts?.made_up_to || null,
+      accountsOverdue: profile.accounts?.overdue ?? null,
+      jurisdiction: profile.jurisdiction || null,
+      hasBeenLiquidated: profile.has_been_liquidated ?? null,
+      hasInsolvencyHistory: profile.has_insolvency_history ?? null,
+      hasCharges: profile.has_charges ?? null,
+      previousCompanyNames:
+        profile.previous_company_names?.map((p) => p.name) ?? [],
+      confirmationStatementLastMadeUpTo:
+        profile.confirmation_statement?.last_made_up_to || null,
       updatedAt: new Date(),
     })
     .onConflictDoUpdate({
@@ -181,6 +199,19 @@ for (const row of allOrgs) {
         companyName: profile.company_name,
         companyStatus: profile.company_status || null,
         companyType: profile.type || null,
+        sicCodes: profile.sic_codes ?? [],
+        accountsNextMadeUpTo: profile.accounts?.next_made_up_to || null,
+        accountsLastMadeUpTo:
+          profile.accounts?.last_accounts?.made_up_to || null,
+        accountsOverdue: profile.accounts?.overdue ?? null,
+        jurisdiction: profile.jurisdiction || null,
+        hasBeenLiquidated: profile.has_been_liquidated ?? null,
+        hasInsolvencyHistory: profile.has_insolvency_history ?? null,
+        hasCharges: profile.has_charges ?? null,
+        previousCompanyNames:
+          profile.previous_company_names?.map((p) => p.name) ?? [],
+        confirmationStatementLastMadeUpTo:
+          profile.confirmation_statement?.last_made_up_to || null,
         updatedAt: new Date(),
       },
     });

--- a/scripts/seed-companies-house.ts
+++ b/scripts/seed-companies-house.ts
@@ -1,0 +1,198 @@
+/**
+ * Seed script: fetches Companies House profiles for all HMRC sponsors.
+ *
+ * Run locally with:  bun scripts/seed-companies-house.ts
+ *
+ * - Fetches distinct org names from hmrc_skilled_workers
+ * - For each, searches Companies House API → fetches full profile → upserts into DB
+ * - Throttled to ~2 req/sec (600 requests per 5 min rate limit)
+ * - Resumable: skips companies already in companies_house_profiles
+ * - Logs progress every 100 companies
+ */
+
+import { neon } from "@neondatabase/serverless";
+import dotenv from "dotenv";
+import { drizzle } from "drizzle-orm/neon-http";
+import { companiesHouseProfiles } from "../src/db/schema";
+
+dotenv.config({ path: ".env.local" });
+
+const sql = neon(process.env.POSTGRES_URL as string);
+const db = drizzle({ client: sql });
+
+const BASE_URL = "https://api.company-information.service.gov.uk";
+const API_KEY = process.env.COMPANIES_HOUSE_SEED_API_KEY as string;
+if (!API_KEY)
+  throw new Error(
+    "Set COMPANIES_HOUSE_SEED_API_KEY in .env.local (use a separate key from production)",
+  );
+
+const AUTH_HEADER = `Basic ${Buffer.from(`${API_KEY}:`).toString("base64")}`;
+
+// ~2 requests per second to stay within 600/5min
+const DELAY_MS = 550;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchApi(path: string): Promise<unknown | null> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { Authorization: AUTH_HEADER },
+  });
+
+  if (res.status === 429) {
+    // Rate limited — back off for 60 seconds then retry
+    console.log("  Rate limited, backing off for 60s...");
+    await sleep(60_000);
+    return fetchApi(path);
+  }
+
+  if (!res.ok) {
+    return null;
+  }
+
+  return res.json();
+}
+
+// Get all distinct org names
+const allOrgs = await sql`
+  SELECT DISTINCT organisation_name
+  FROM hmrc_skilled_workers
+  ORDER BY organisation_name
+`;
+console.log(`Found ${allOrgs.length} unique organisations`);
+
+// Get already-cached company names to skip
+const cached = await sql`SELECT company_name FROM companies_house_profiles`;
+const cachedNames = new Set(
+  cached.map((r) => (r.company_name as string).toUpperCase()),
+);
+console.log(`Already cached: ${cachedNames.size} — skipping those`);
+
+let processed = 0;
+let inserted = 0;
+let skipped = 0;
+let failed = 0;
+const startTime = Date.now();
+const remaining = allOrgs.length - cachedNames.size;
+
+function formatEta(ms: number) {
+  const secs = Math.floor(ms / 1000);
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function logProgress() {
+  const elapsed = Date.now() - startTime;
+  const apiCalls = inserted + failed; // only non-skipped items hit the API
+  const rate = apiCalls > 0 ? elapsed / apiCalls : DELAY_MS * 2;
+  const left = remaining - apiCalls;
+  const eta = formatEta(left * rate);
+  console.log(
+    `[${processed}/${allOrgs.length}] inserted=${inserted} skipped=${skipped} failed=${failed} | ETA: ${eta}`,
+  );
+}
+
+for (const row of allOrgs) {
+  const orgName = row.organisation_name as string;
+  processed++;
+
+  // Skip if already cached (case-insensitive match)
+  if (cachedNames.has(orgName.toUpperCase())) {
+    skipped++;
+    if (processed % 100 === 0) {
+      logProgress();
+    }
+    continue;
+  }
+
+  // 1. Search for company number
+  await sleep(DELAY_MS);
+  const searchData = (await fetchApi(
+    `/search/companies?q=${encodeURIComponent(orgName)}&items_per_page=1`,
+  )) as { items?: { company_number: string }[] } | null;
+
+  if (!searchData?.items?.length) {
+    failed++;
+    if (processed % 100 === 0) {
+      logProgress();
+    }
+    continue;
+  }
+
+  const companyNumber = searchData.items[0].company_number;
+
+  // 2. Fetch full profile
+  await sleep(DELAY_MS);
+  const profile = (await fetchApi(`/company/${companyNumber}`)) as {
+    company_name: string;
+    company_number: string;
+    company_status?: string;
+    type?: string;
+    date_of_creation?: string;
+    registered_office_address?: {
+      address_line_1?: string;
+      address_line_2?: string;
+      locality?: string;
+      region?: string;
+      postal_code?: string;
+      country?: string;
+    };
+    sic_codes?: string[];
+    accounts?: {
+      next_made_up_to?: string;
+      last_accounts?: { made_up_to?: string };
+    };
+  } | null;
+
+  if (!profile) {
+    failed++;
+    if (processed % 100 === 0) {
+      logProgress();
+    }
+    continue;
+  }
+
+  // 3. Upsert into DB
+  await db
+    .insert(companiesHouseProfiles)
+    .values({
+      companyNumber: profile.company_number,
+      companyName: profile.company_name,
+      companyStatus: profile.company_status || null,
+      companyType: profile.type || null,
+      dateOfCreation: profile.date_of_creation || null,
+      addressLine1: profile.registered_office_address?.address_line_1 || null,
+      addressLine2: profile.registered_office_address?.address_line_2 || null,
+      locality: profile.registered_office_address?.locality || null,
+      region: profile.registered_office_address?.region || null,
+      postalCode: profile.registered_office_address?.postal_code || null,
+      country: profile.registered_office_address?.country || null,
+      sicCodes: profile.sic_codes ?? [],
+      accountsNextMadeUpTo: profile.accounts?.next_made_up_to || null,
+      accountsLastMadeUpTo: profile.accounts?.last_accounts?.made_up_to || null,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: companiesHouseProfiles.companyNumber,
+      set: {
+        companyName: profile.company_name,
+        companyStatus: profile.company_status || null,
+        companyType: profile.type || null,
+        updatedAt: new Date(),
+      },
+    });
+
+  inserted++;
+  cachedNames.add(profile.company_name.toUpperCase());
+
+  if (processed % 100 === 0) {
+    logProgress();
+  }
+}
+
+console.log(
+  `\nDone! Processed=${processed} Inserted=${inserted} Skipped=${skipped} Failed=${failed}`,
+);

--- a/src/api/companiesHouse.ts
+++ b/src/api/companiesHouse.ts
@@ -1,81 +1,185 @@
 import { createServerFn } from '@tanstack/react-start';
-import { inArray } from 'drizzle-orm';
+import { eq, ilike, inArray } from 'drizzle-orm';
 import { db } from '../db';
-import { sicCodes } from '../db/schema';
+import { companiesHouseProfiles, sicCodes } from '../db/schema';
 
 const BASE_URL = 'https://api.company-information.service.gov.uk';
+
+type CompanyProfile = {
+  company_name: string;
+  company_number: string;
+  company_status: string;
+  type: string;
+  date_of_creation: string;
+  registered_office_address: {
+    address_line_1?: string;
+    address_line_2?: string;
+    locality?: string;
+    region?: string;
+    postal_code?: string;
+    country?: string;
+  };
+  sic_codes?: string[];
+  accounts?: {
+    next_made_up_to?: string;
+    last_accounts?: { made_up_to?: string };
+  };
+};
+
+function dbRowToProfile(
+  row: typeof companiesHouseProfiles.$inferSelect,
+): CompanyProfile {
+  return {
+    company_name: row.companyName,
+    company_number: row.companyNumber,
+    company_status: row.companyStatus ?? '',
+    type: row.companyType ?? '',
+    date_of_creation: row.dateOfCreation ?? '',
+    registered_office_address: {
+      address_line_1: row.addressLine1 ?? undefined,
+      address_line_2: row.addressLine2 ?? undefined,
+      locality: row.locality ?? undefined,
+      region: row.region ?? undefined,
+      postal_code: row.postalCode ?? undefined,
+      country: row.country ?? undefined,
+    },
+    sic_codes: row.sicCodes ?? [],
+    accounts: {
+      next_made_up_to: row.accountsNextMadeUpTo ?? undefined,
+      last_accounts: {
+        made_up_to: row.accountsLastMadeUpTo ?? undefined,
+      },
+    },
+  };
+}
+
+function profileToDbRow(profile: CompanyProfile) {
+  return {
+    companyNumber: profile.company_number,
+    companyName: profile.company_name,
+    companyStatus: profile.company_status || null,
+    companyType: profile.type || null,
+    dateOfCreation: profile.date_of_creation || null,
+    addressLine1: profile.registered_office_address?.address_line_1 || null,
+    addressLine2: profile.registered_office_address?.address_line_2 || null,
+    locality: profile.registered_office_address?.locality || null,
+    region: profile.registered_office_address?.region || null,
+    postalCode: profile.registered_office_address?.postal_code || null,
+    country: profile.registered_office_address?.country || null,
+    sicCodes: profile.sic_codes ?? [],
+    accountsNextMadeUpTo: profile.accounts?.next_made_up_to || null,
+    accountsLastMadeUpTo: profile.accounts?.last_accounts?.made_up_to || null,
+    updatedAt: new Date(),
+  };
+}
+
+async function fetchFromApi(
+  path: string,
+): Promise<{ ok: true; data: unknown } | { ok: false; status: number }> {
+  const apiKey = process.env.COMPANIES_HOUSE_API_KEY;
+  if (!apiKey) throw new Error('COMPANIES_HOUSE_API_KEY is not set');
+
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
+    },
+  });
+
+  if (res.status === 429) {
+    return { ok: false, status: 429 };
+  }
+
+  if (!res.ok) {
+    return { ok: false, status: res.status };
+  }
+
+  return { ok: true, data: await res.json() };
+}
+
+async function upsertProfile(profile: CompanyProfile) {
+  const row = profileToDbRow(profile);
+  await db.insert(companiesHouseProfiles).values(row).onConflictDoUpdate({
+    target: companiesHouseProfiles.companyNumber,
+    set: row,
+  });
+}
 
 export const searchCompany = createServerFn()
   .inputValidator((input: unknown) => input as { query: string })
   .handler(async ({ data: { query } }) => {
-    const apiKey = process.env.COMPANIES_HOUSE_API_KEY;
-    if (!apiKey) throw new Error('COMPANIES_HOUSE_API_KEY is not set');
-
-    const res = await fetch(
-      `${BASE_URL}/search/companies?q=${encodeURIComponent(query)}&items_per_page=1`,
-      {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
-        },
-      },
+    const result = await fetchFromApi(
+      `/search/companies?q=${encodeURIComponent(query)}&items_per_page=1`,
     );
 
-    if (!res.ok) {
-      throw new Error(
-        `Companies House API error: ${res.status} ${res.statusText}`,
-      );
+    if (result.ok) {
+      const data = result.data as {
+        items?: {
+          company_number: string;
+          title: string;
+          company_status: string;
+          date_of_creation: string;
+          address_snippet: string;
+        }[];
+      };
+      if (!data.items?.length) return null;
+      return data.items[0];
     }
 
-    const data = await res.json();
-    if (!data.items?.length) return null;
+    // On 429 or other errors, fall back to cached data
+    const [cached] = await db
+      .select()
+      .from(companiesHouseProfiles)
+      .where(ilike(companiesHouseProfiles.companyName, query))
+      .limit(1);
 
-    return data.items[0] as {
-      company_number: string;
-      title: string;
-      company_status: string;
-      date_of_creation: string;
-      address_snippet: string;
-    };
+    if (cached) {
+      return {
+        company_number: cached.companyNumber,
+        title: cached.companyName,
+        company_status: cached.companyStatus ?? '',
+        date_of_creation: cached.dateOfCreation ?? '',
+        address_snippet: [
+          cached.addressLine1,
+          cached.locality,
+          cached.postalCode,
+        ]
+          .filter(Boolean)
+          .join(', '),
+      };
+    }
+
+    throw new Error(
+      `Companies House API error: ${result.status} and no cached data available`,
+    );
   });
 
 export const getCompanyProfile = createServerFn()
   .inputValidator((input: unknown) => input as { companyNumber: string })
   .handler(async ({ data: { companyNumber } }) => {
-    const apiKey = process.env.COMPANIES_HOUSE_API_KEY;
-    if (!apiKey) throw new Error('COMPANIES_HOUSE_API_KEY is not set');
+    const result = await fetchFromApi(`/company/${companyNumber}`);
 
-    const res = await fetch(`${BASE_URL}/company/${companyNumber}`, {
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
-      },
-    });
+    let profile: CompanyProfile;
 
-    if (!res.ok) {
-      throw new Error(
-        `Companies House API error: ${res.status} ${res.statusText}`,
-      );
+    if (result.ok) {
+      profile = result.data as CompanyProfile;
+      // Update cache in the background — don't block the response
+      upsertProfile(profile).catch(() => {});
+    } else {
+      // On 429 or other errors, fall back to cached data
+      const [cached] = await db
+        .select()
+        .from(companiesHouseProfiles)
+        .where(eq(companiesHouseProfiles.companyNumber, companyNumber))
+        .limit(1);
+
+      if (!cached) {
+        throw new Error(
+          `Companies House API error: ${result.status} and no cached data available`,
+        );
+      }
+
+      profile = dbRowToProfile(cached);
     }
-
-    const profile = (await res.json()) as {
-      company_name: string;
-      company_number: string;
-      company_status: string;
-      type: string;
-      date_of_creation: string;
-      registered_office_address: {
-        address_line_1?: string;
-        address_line_2?: string;
-        locality?: string;
-        region?: string;
-        postal_code?: string;
-        country?: string;
-      };
-      sic_codes?: string[];
-      accounts?: {
-        next_made_up_to?: string;
-        last_accounts?: { made_up_to?: string };
-      };
-    };
 
     // Look up SIC code descriptions from our database
     let sicDescriptions: { code: string; description: string }[] = [];

--- a/src/api/companiesHouse.ts
+++ b/src/api/companiesHouse.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
-import { eq, ilike, inArray } from 'drizzle-orm';
+import { waitUntil } from '@vercel/functions';
+import { ilike, inArray } from 'drizzle-orm';
 import { db } from '../db';
 import { companiesHouseProfiles, sicCodes } from '../db/schema';
 
@@ -23,6 +24,15 @@ type CompanyProfile = {
   accounts?: {
     next_made_up_to?: string;
     last_accounts?: { made_up_to?: string };
+    overdue?: boolean;
+  };
+  jurisdiction?: string;
+  has_been_liquidated?: boolean;
+  has_insolvency_history?: boolean;
+  has_charges?: boolean;
+  previous_company_names?: { name: string }[];
+  confirmation_statement?: {
+    last_made_up_to?: string;
   };
 };
 
@@ -49,6 +59,16 @@ function dbRowToProfile(
       last_accounts: {
         made_up_to: row.accountsLastMadeUpTo ?? undefined,
       },
+      overdue: row.accountsOverdue ?? undefined,
+    },
+    jurisdiction: row.jurisdiction ?? undefined,
+    has_been_liquidated: row.hasBeenLiquidated ?? undefined,
+    has_insolvency_history: row.hasInsolvencyHistory ?? undefined,
+    has_charges: row.hasCharges ?? undefined,
+    previous_company_names:
+      row.previousCompanyNames?.map((name) => ({ name })) ?? [],
+    confirmation_statement: {
+      last_made_up_to: row.confirmationStatementLastMadeUpTo ?? undefined,
     },
   };
 }
@@ -69,6 +89,15 @@ function profileToDbRow(profile: CompanyProfile) {
     sicCodes: profile.sic_codes ?? [],
     accountsNextMadeUpTo: profile.accounts?.next_made_up_to || null,
     accountsLastMadeUpTo: profile.accounts?.last_accounts?.made_up_to || null,
+    accountsOverdue: profile.accounts?.overdue ?? null,
+    jurisdiction: profile.jurisdiction || null,
+    hasBeenLiquidated: profile.has_been_liquidated ?? null,
+    hasInsolvencyHistory: profile.has_insolvency_history ?? null,
+    hasCharges: profile.has_charges ?? null,
+    previousCompanyNames:
+      profile.previous_company_names?.map((p) => p.name) ?? [],
+    confirmationStatementLastMadeUpTo:
+      profile.confirmation_statement?.last_made_up_to || null,
     updatedAt: new Date(),
   };
 }
@@ -104,81 +133,44 @@ async function upsertProfile(profile: CompanyProfile) {
   });
 }
 
-export const searchCompany = createServerFn()
-  .inputValidator((input: unknown) => input as { query: string })
-  .handler(async ({ data: { query } }) => {
-    const result = await fetchFromApi(
-      `/search/companies?q=${encodeURIComponent(query)}&items_per_page=1`,
-    );
-
-    if (result.ok) {
-      const data = result.data as {
-        items?: {
-          company_number: string;
-          title: string;
-          company_status: string;
-          date_of_creation: string;
-          address_snippet: string;
-        }[];
-      };
-      if (!data.items?.length) return null;
-      return data.items[0];
-    }
-
-    // On 429 or other errors, fall back to cached data
+export const getCompanyProfile = createServerFn()
+  .inputValidator((input: unknown) => input as { companyName: string })
+  .handler(async ({ data: { companyName } }) => {
+    // Check DB cache first
     const [cached] = await db
       .select()
       .from(companiesHouseProfiles)
-      .where(ilike(companiesHouseProfiles.companyName, query))
+      .where(ilike(companiesHouseProfiles.companyName, companyName))
       .limit(1);
-
-    if (cached) {
-      return {
-        company_number: cached.companyNumber,
-        title: cached.companyName,
-        company_status: cached.companyStatus ?? '',
-        date_of_creation: cached.dateOfCreation ?? '',
-        address_snippet: [
-          cached.addressLine1,
-          cached.locality,
-          cached.postalCode,
-        ]
-          .filter(Boolean)
-          .join(', '),
-      };
-    }
-
-    throw new Error(
-      `Companies House API error: ${result.status} and no cached data available`,
-    );
-  });
-
-export const getCompanyProfile = createServerFn()
-  .inputValidator((input: unknown) => input as { companyNumber: string })
-  .handler(async ({ data: { companyNumber } }) => {
-    const result = await fetchFromApi(`/company/${companyNumber}`);
 
     let profile: CompanyProfile;
 
-    if (result.ok) {
-      profile = result.data as CompanyProfile;
-      // Update cache in the background — don't block the response
-      upsertProfile(profile).catch(() => {});
-    } else {
-      // On 429 or other errors, fall back to cached data
-      const [cached] = await db
-        .select()
-        .from(companiesHouseProfiles)
-        .where(eq(companiesHouseProfiles.companyNumber, companyNumber))
-        .limit(1);
-
-      if (!cached) {
-        throw new Error(
-          `Companies House API error: ${result.status} and no cached data available`,
-        );
-      }
-
+    if (cached) {
+      console.log(`[Profile] cache hit: "${cached.companyName}"`);
       profile = dbRowToProfile(cached);
+    } else {
+      // Cache miss — search API for company number, then fetch profile
+      console.log(`[Profile] cache miss, calling API for: "${companyName}"`);
+      const searchResult = await fetchFromApi(
+        `/search/companies?q=${encodeURIComponent(companyName)}&items_per_page=1`,
+      );
+
+      if (!searchResult.ok) return null;
+
+      const searchData = searchResult.data as {
+        items?: { company_number: string }[];
+      };
+      if (!searchData.items?.length) return null;
+
+      const profileResult = await fetchFromApi(
+        `/company/${searchData.items[0].company_number}`,
+      );
+
+      if (!profileResult.ok) return null;
+
+      profile = profileResult.data as CompanyProfile;
+      // Save to cache after response is sent
+      waitUntil(upsertProfile(profile));
     }
 
     // Look up SIC code descriptions from our database
@@ -193,5 +185,19 @@ export const getCompanyProfile = createServerFn()
         .where(inArray(sicCodes.code, profile.sic_codes));
     }
 
-    return { ...profile, sicDescriptions };
+    return {
+      company_number: profile.company_number,
+      company_status: profile.company_status,
+      type: profile.type,
+      date_of_creation: profile.date_of_creation,
+      registered_office_address: profile.registered_office_address,
+      accounts: profile.accounts?.last_accounts?.made_up_to
+        ? {
+            last_accounts: {
+              made_up_to: profile.accounts.last_accounts.made_up_to,
+            },
+          }
+        : undefined,
+      sicDescriptions,
+    };
   });

--- a/src/api/hmrc.ts
+++ b/src/api/hmrc.ts
@@ -24,7 +24,7 @@ export const searchHmrc = createServerFn()
       END`;
     const rows = await db
       .select({
-        hash: hmrcSkilledWorkers.hash,
+        slugId: hmrcSkilledWorkers.hash,
         organisationName: hmrcSkilledWorkers.organisationName,
         townCity: hmrcSkilledWorkers.townCity,
         county: hmrcSkilledWorkers.county,
@@ -46,20 +46,17 @@ export const searchHmrc = createServerFn()
 
     const hasMore = rows.length > PAGE_SIZE;
     return {
-      rows: rows.slice(0, PAGE_SIZE).map((row) => ({
-        ...row,
-        slugId: row.hash,
-      })),
+      rows: rows.slice(0, PAGE_SIZE),
       hasMore,
     };
   });
 
-export const getHmrcById = createServerFn()
+export const getHmrcBySlugId = createServerFn()
   .inputValidator((input: unknown) => input as { slugId: string })
   .handler(async ({ data: { slugId } }) => {
     const [row] = await db
       .select({
-        hash: hmrcSkilledWorkers.hash,
+        slugId: hmrcSkilledWorkers.hash,
         organisationName: hmrcSkilledWorkers.organisationName,
         townCity: hmrcSkilledWorkers.townCity,
         county: hmrcSkilledWorkers.county,

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,16 @@
+import { titleCase } from '../utils';
+
+export function StatusBadge({ status }: { status: string }) {
+  const isActive = status === 'active';
+  return (
+    <span
+      className={`inline-block whitespace-nowrap rounded-full px-3 py-1 text-xs font-medium ${
+        isActive
+          ? 'border border-[#16a34a]/40 text-[#16a34a]'
+          : 'border border-[#dc2626]/40 text-[#dc2626]'
+      }`}
+    >
+      {titleCase(status)}
+    </span>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -46,6 +46,33 @@ export const sicCodes = pgTable('sic_codes', {
   description: text('description').notNull(),
 });
 
+export const companiesHouseProfiles = pgTable(
+  'companies_house_profiles',
+  {
+    companyNumber: varchar('company_number', { length: 20 }).primaryKey(),
+    companyName: varchar('company_name', { length: 255 }).notNull(),
+    companyStatus: varchar('company_status', { length: 50 }),
+    companyType: varchar('company_type', { length: 100 }),
+    dateOfCreation: date('date_of_creation'),
+    addressLine1: varchar('address_line_1', { length: 255 }),
+    addressLine2: varchar('address_line_2', { length: 255 }),
+    locality: varchar('locality', { length: 100 }),
+    region: varchar('region', { length: 100 }),
+    postalCode: varchar('postal_code', { length: 20 }),
+    country: varchar('country', { length: 100 }),
+    sicCodes: text('sic_codes').array().default(sql`'{}'::text[]`),
+    accountsNextMadeUpTo: date('accounts_next_made_up_to'),
+    accountsLastMadeUpTo: date('accounts_last_made_up_to'),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_ch_company_name').on(table.companyName),
+    index('idx_ch_company_status').on(table.companyStatus),
+    index('idx_ch_company_type').on(table.companyType),
+    index('idx_ch_sic_codes').using('gin', table.sicCodes),
+  ],
+);
+
 export const hmrcIngestionMeta = pgTable('hmrc_ingestion_meta', {
   id: serial('id').primaryKey(),
   csvUrl: text('csv_url').notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -63,6 +63,17 @@ export const companiesHouseProfiles = pgTable(
     sicCodes: text('sic_codes').array().default(sql`'{}'::text[]`),
     accountsNextMadeUpTo: date('accounts_next_made_up_to'),
     accountsLastMadeUpTo: date('accounts_last_made_up_to'),
+    accountsOverdue: boolean('accounts_overdue'),
+    jurisdiction: varchar('jurisdiction', { length: 100 }),
+    hasBeenLiquidated: boolean('has_been_liquidated'),
+    hasInsolvencyHistory: boolean('has_insolvency_history'),
+    hasCharges: boolean('has_charges'),
+    previousCompanyNames: text('previous_company_names')
+      .array()
+      .default(sql`'{}'::text[]`),
+    confirmationStatementLastMadeUpTo: date(
+      'confirmation_statement_last_made_up_to',
+    ),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => [
@@ -70,6 +81,8 @@ export const companiesHouseProfiles = pgTable(
     index('idx_ch_company_status').on(table.companyStatus),
     index('idx_ch_company_type').on(table.companyType),
     index('idx_ch_sic_codes').using('gin', table.sicCodes),
+    index('idx_ch_jurisdiction').on(table.jurisdiction),
+    index('idx_ch_previous_names').using('gin', table.previousCompanyNames),
   ],
 );
 

--- a/src/routes/company.$id.$slug.tsx
+++ b/src/routes/company.$id.$slug.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { ExternalLink, MapPin } from 'lucide-react';
-import { getCompanyProfile, searchCompany } from '../api/companiesHouse';
-import { getHmrcById } from '../api/hmrc';
-import { titleCase } from '../utils';
+import { getCompanyProfile } from '../api/companiesHouse';
+import { getHmrcBySlugId } from '../api/hmrc';
+import { StatusBadge } from '../components/StatusBadge';
+import { formatAddress, formatDate, titleCase } from '../utils';
 import { buildCanonical } from '../utils/canonical';
 
 export const Route = createFileRoute('/company/$id/$slug')({
@@ -10,21 +11,15 @@ export const Route = createFileRoute('/company/$id/$slug')({
     search: ((search.search as string) || '').trim(),
   }),
   loader: async ({ params }) => {
-    const sponsor = await getHmrcById({ data: { slugId: params.id } });
+    const sponsor = await getHmrcBySlugId({ data: { slugId: params.id } });
 
     if (!sponsor) {
       throw notFound();
     }
 
-    const searchResult = await searchCompany({
-      data: { query: sponsor.organisationName },
+    const profile = await getCompanyProfile({
+      data: { companyName: sponsor.organisationName },
     });
-
-    const profile = searchResult
-      ? await getCompanyProfile({
-          data: { companyNumber: searchResult.company_number },
-        })
-      : null;
 
     return { sponsor, profile };
   },
@@ -37,6 +32,9 @@ export const Route = createFileRoute('/company/$id/$slug')({
             county?: string | null;
             route: string;
           };
+          profile?: {
+            sicDescriptions?: { code: string; description: string }[];
+          } | null;
         }
       | undefined;
 
@@ -49,17 +47,28 @@ export const Route = createFileRoute('/company/$id/$slug')({
           .map(titleCase)
           .join(', ')
       : '';
+    const industry = loaderData?.profile?.sicDescriptions
+      ?.map((sic) => sic.description)
+      .join(', ');
+    const route = titleCase(loaderData?.sponsor.route ?? 'Skilled Worker');
+    const description = [
+      industry ? `${name} — ${industry}` : name,
+      location
+        ? `Licensed UK ${route} visa sponsor in ${location}`
+        : `Licensed UK ${route} visa sponsor`,
+    ].join('. ');
+
+    const pageTitle = `${name} - UK Visa Sponsor | SponsorSearch`;
+    const pageDescription = `${description}.`;
+
     return {
       meta: [
-        {
-          title: `${name} - UK Visa Sponsor | SponsorSearch`,
-        },
-        {
-          name: 'description',
-          content: location
-            ? `${name} in ${location} — licensed UK ${titleCase(loaderData?.sponsor.route ?? 'Skilled Worker')} visa sponsor. View sponsor details, ratings, and company information.`
-            : `${name} — licensed UK visa sponsor. View sponsor details, ratings, and company information.`,
-        },
+        { title: pageTitle },
+        { name: 'description', content: pageDescription },
+        { property: 'og:title', content: pageTitle },
+        { property: 'og:description', content: pageDescription },
+        { name: 'twitter:title', content: pageTitle },
+        { name: 'twitter:description', content: pageDescription },
       ],
       links: [
         {
@@ -74,55 +83,6 @@ export const Route = createFileRoute('/company/$id/$slug')({
   },
   component: CompanyDetail,
 });
-
-function formatAddress(
-  address?: {
-    address_line_1?: string;
-    address_line_2?: string;
-    locality?: string;
-    region?: string;
-    postal_code?: string;
-    country?: string;
-  } | null,
-) {
-  if (!address) return '';
-  return [
-    address.address_line_1,
-    address.address_line_2,
-    address.locality,
-    address.region,
-    address.postal_code,
-    address.country,
-  ]
-    .filter(Boolean)
-    .join(', ');
-}
-
-function formatDate(dateStr?: string | null) {
-  if (!dateStr) return '';
-  const d = new Date(dateStr);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const isActive = status === 'active';
-  return (
-    <span
-      className={`inline-block whitespace-nowrap rounded-full px-3 py-1 text-xs font-medium ${
-        isActive
-          ? 'border border-[#16a34a]/40 text-[#16a34a]'
-          : 'border border-[#dc2626]/40 text-[#dc2626]'
-      }`}
-    >
-      {titleCase(status)}
-    </span>
-  );
-}
 
 function CompanyDetail() {
   const { sponsor, profile } = Route.useLoaderData();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,3 +26,37 @@ export function slugify(str: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 }
+
+export function formatAddress(
+  address?: {
+    address_line_1?: string;
+    address_line_2?: string;
+    locality?: string;
+    region?: string;
+    postal_code?: string;
+    country?: string;
+  } | null,
+) {
+  if (!address) return '';
+  return [
+    address.address_line_1,
+    address.address_line_2,
+    address.locality,
+    address.region,
+    address.postal_code,
+    address.country,
+  ]
+    .filter(Boolean)
+    .join(', ');
+}
+
+export function formatDate(dateStr?: string | null) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}


### PR DESCRIPTION
Instead of hitting the company house api and getting rate limited we instead hit our db, if not available hit the company house api for the data. We then sync that into our db for future hits