### PR TITLE
feat: Pr auto merging sitemap changes to main

### DIFF
--- a/.github/workflows/hmrc-ingestion.yaml
+++ b/.github/workflows/hmrc-ingestion.yaml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,10 +68,20 @@ jobs:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
         run: bun run sitemap:generate
 
-      - name: Commit updated sitemaps
+      - name: Commit updated sitemaps and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add public/sitemap*.xml
-          git diff --staged --quiet || git commit -m "chore: regenerate sitemaps after ingestion"
-          git push
+          if git diff --staged --quiet; then
+            echo "No sitemap changes to commit"
+            exit 0
+          fi
+          BRANCH="chore/update-sitemaps-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: regenerate sitemaps after ingestion"
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create --title "chore: regenerate sitemaps after ingestion" --body "Automated sitemap update from HMRC ingestion workflow." --base main)
+          gh pr merge "$PR_URL" --squash --auto


### PR DESCRIPTION
Their was a scheduled run that failed because of GitHub branch protection rules.
Nothing can commit to main unless a PR is created for it.