### PR TITLE
fix: multiple bugs around search and fast scrolls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,37 @@
 # Project Notes
 
-## Search input visibility (SearchBar + useSearchPill)
+## Search input visibility — things that break (non-obvious)
 
-The search input in `SearchBar.tsx` is wrapped in a div with inline `opacity: 0/1`
-controlled by two flags: `ready` and `showPill` from the `useSearchPill` hook.
+### Approaches that cause input flashes — do NOT use
 
-### How it works
-
-- `ready` starts `false`, becomes `true` when the IntersectionObserver fires
-- `showPill` is `true` when scrolled past the sentinel with an active search term
-- Input wrapper: `opacity: !ready || showPill ? 0 : 1`
-- Server renders `opacity: 0` (observer is client-only, so `ready` is always `false`)
-- After hydration, observer fires, `ready` becomes `true`, input appears
-
-### Known limitation
-
-If the Vercel serverless function or Neon DB cold-starts, the SSR HTML arrives with the
-input at `opacity: 0`. The input stays invisible until JS hydrates and the observer fires.
-During this time the skeleton cards show (from `HmrcResults` `isLoading` check, not the
-Suspense boundary) but the search input is hidden.
-
-This is acceptable because:
-- If the server is slow enough that the input is hidden, the user can't search anyway
-  (no JS = no interactivity)
-- The correct fix is graceful error handling on the query side (timeout/error boundary),
-  not visibility hacks on the input
-
-### Approaches that were tried and failed — do NOT use
-
-1. **`useLayoutEffect` to set opacity** (no inline style, server renders visible) — fixes
-   the cold-start visibility issue but causes the input to flash when reloading while
+1. **`useLayoutEffect` to set opacity** — causes the input to flash when reloading while
    scrolled down. `useLayoutEffect` is a no-op on the server so the HTML has no opacity
    style, and the input is visible for one frame before JS hides it.
-2. **Default `ready` to `true`** — causes a flash of the input when navigating back from
-   the company detail page while scrolled down.
-3. **Change opacity condition to `showPill || (!ready && isStuck)`** — causes the input
-   to flash on initial paint before hydration hides it, because the sentinel is briefly
-   in the viewport during layout before scroll position restores.
-4. **Synchronous `getBoundingClientRect` check in `useSearchPill` effect** — same flash
-   problem as #3. On back-navigation the sentinel is momentarily in-viewport before
-   scroll restores, so it incorrectly sets `ready=true`.
+2. **Default `ready` to `true`** — causes a flash when navigating back from the company
+   detail page while scrolled down.
+3. **`showPill || (!ready && isStuck)` opacity condition** — causes a flash on initial
+   paint because the sentinel is briefly in-viewport during layout before scroll restores.
+4. **Synchronous `getBoundingClientRect` in `useSearchPill` effect** — same flash as #3.
+   On back-navigation the sentinel is momentarily in-viewport before scroll restores.
 
-### Key files
-- `apps/web/src/components/SearchBar.tsx` — opacity logic (inline style)
-- `apps/web/src/hooks/useSearchPill.ts` — `ready` and `isStuck` state
-- `apps/web/src/components/HmrcResults.tsx` — skeleton shown via `isLoading`, not Suspense fallback
-- `apps/web/src/routes/index.tsx` — Suspense boundary wraps HmrcResults only, not SearchBar
+### Do NOT add `!pillClickedRef.current` guards in the observer
+
+The observer must always set `isStuck` and always reset `pillClicked` when the sentinel
+enters the viewport. Guards on these create a deadlock: `useSearchShortcut` sets
+`pillClicked = true` when a printable key is pressed with `activeElement: BODY` (happens
+on page load and back-navigation). The guard then prevents the observer from setting
+`isStuck = true`, and the only reset path (`onBlur`) requires `isStuck` to be `true`.
+Result: pill never shows. The `onActivate` callback must be conditional on
+`isStuckRef.current` to avoid this.
+
+### `isStuck = false` must be debounced
+
+When results reload, the page height changes (content → skeletons → new content) and can
+briefly pull the sentinel back into the viewport. Without debouncing, `isStuck` toggles
+rapidly and the input blinks between visible and pill mode (especially on iOS Safari).
+
+### `transform: translateZ(0)` on SearchInput — focus-within only
+
+Needed for iOS Safari cursor positioning in sticky containers, but applying it permanently
+causes iOS Safari's GPU compositor to garble rotating placeholder text. Must only apply
+via `:focus-within` in `SearchInput.module.css`. Do NOT add it as a permanent inline style.

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/apps/web/src/components/SearchInput.module.css
+++ b/apps/web/src/components/SearchInput.module.css
@@ -1,3 +1,7 @@
+.inputWrapper:focus-within {
+  transform: translateZ(0);
+}
+
 .input {
   transition: box-shadow 0.3s;
 }

--- a/apps/web/src/components/SearchInput.tsx
+++ b/apps/web/src/components/SearchInput.tsx
@@ -73,7 +73,7 @@ export default memo(function SearchInput({
   }, [defaultValue]);
 
   return (
-    <div className="relative" style={{ transform: 'translateZ(0)' }}>
+    <div className={`relative ${styles.inputWrapper}`}>
       <input
         ref={inputRef}
         type="text"

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -9,6 +9,7 @@ export function useSearchPill(
   const [ready, setReady] = useState(false);
   const [pillClicked, setPillClicked] = useState(false);
   const pillClickedRef = useRef(false);
+  const isStuckRef = useRef(false);
 
   useEffect(() => {
     pillClickedRef.current = pillClicked;
@@ -27,13 +28,15 @@ export function useSearchPill(
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
     const observer = new IntersectionObserver(
-      ([entry]) => {
+      (entries) => {
+        // Use the last entry — fast scrolling can batch multiple threshold
+        // crossings into a single callback; only the final one is current.
+        const entry = entries[entries.length - 1];
         setReady(true);
-        if (!pillClickedRef.current) {
-          setIsStuck(!entry.isIntersecting);
-        }
-        if (entry.isIntersecting && !pillClickedRef.current)
-          setPillClicked(false);
+        const stuck = !entry.isIntersecting;
+        setIsStuck(stuck);
+        isStuckRef.current = stuck;
+        if (entry.isIntersecting) setPillClicked(false);
       },
       { threshold: 0 },
     );
@@ -41,7 +44,10 @@ export function useSearchPill(
     return () => observer.disconnect();
   }, [sentinelRef]);
 
-  useSearchShortcut(inputRef, () => setPillClicked(true));
+  // Only activate pill mode when scrolled past the sentinel
+  useSearchShortcut(inputRef, () => {
+    if (isStuckRef.current) setPillClicked(true);
+  });
 
   return {
     isStuck,

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -24,6 +24,8 @@ export function useSearchPill(
     }
   }, [pillClicked, sentinelRef]);
 
+  const unstickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
@@ -33,15 +35,37 @@ export function useSearchPill(
         // crossings into a single callback; only the final one is current.
         const entry = entries[entries.length - 1];
         setReady(true);
-        const stuck = !entry.isIntersecting;
-        setIsStuck(stuck);
-        isStuckRef.current = stuck;
-        if (entry.isIntersecting) setPillClicked(false);
+
+        if (!entry.isIntersecting) {
+          // Sentinel left viewport — stick immediately
+          if (unstickTimerRef.current) {
+            clearTimeout(unstickTimerRef.current);
+            unstickTimerRef.current = null;
+          }
+          setIsStuck(true);
+          isStuckRef.current = true;
+        } else {
+          // Sentinel re-entered viewport — defer the reset to filter out
+          // transient reflows (results reloading can briefly shrink the page,
+          // pulling the sentinel back into view before new content pushes it
+          // out again). Without this, isStuck toggles rapidly → the input
+          // blinks between visible and pill mode on iOS Safari.
+          if (unstickTimerRef.current) clearTimeout(unstickTimerRef.current);
+          unstickTimerRef.current = setTimeout(() => {
+            setIsStuck(false);
+            isStuckRef.current = false;
+            setPillClicked(false);
+            unstickTimerRef.current = null;
+          }, 150);
+        }
       },
       { threshold: 0 },
     );
     observer.observe(sentinel);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (unstickTimerRef.current) clearTimeout(unstickTimerRef.current);
+    };
   }, [sentinelRef]);
 
   // Only activate pill mode when scrolled past the sentinel


### PR DESCRIPTION
- Pill never appears on type + fast scroll — useSearchShortcut set pillClicked = true whenever a key was pressed with the input unfocused (activeElement: BODY). The observer's !pillClickedRef.current guards then skipped setting isStuck, and the only reset path required isStuck to already be true — a deadlock that kept the pill permanently hidden.

- Input blinks between visible and pill mode on iOS Safari — When the debounced navigate fires, results reload and the page height changes (content → skeletons → new content). This briefly pulls the sentinel back into the viewport, toggling isStuck rapidly. Fixed by debouncing isStuck = false by 150ms so transient reflows are filtered out.

- Garbled rotating placeholder on iOS Safari — transform: translateZ(0) on the SearchInput wrapper (needed for cursor positioning in sticky containers) caused iOS Safari's GPU compositor to corrupt placeholder text during rotation. Fixed by applying the transform only via :focus-within in CSS so it's active when typing but not when the placeholder is visible.

- Cursor floats outside input on iOS Safari — Removing translateZ(0) entirely fixed the placeholder but broke cursor positioning. The :focus-within approach solves both: cursor is correctly positioned when focused, placeholder renders cleanly when idle.

- Biome config version mismatch — biome.json referenced schema 2.4.10 while CLI was 2.4.11. Ran biome migrate --write to sync.