### PR TITLE
fix: skip sitemap generation when no csv checksums have changed

### DIFF
--- a/.github/workflows/hmrc-ingestion.yaml
+++ b/.github/workflows/hmrc-ingestion.yaml
@@ -60,18 +60,21 @@ jobs:
         working-directory: apps/web
 
       - name: Run ingestion
+        id: ingest
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
         run: bun run db:ingest "${{ needs.discover-csv-url.outputs.csv-url }}" ${{ github.event.inputs.force-ingest == 'true' && '--force' || '' }}
         working-directory: apps/web
 
       - name: Regenerate sitemaps
+        if: steps.ingest.outputs.data-changed == 'true'
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
         run: bun run sitemap:generate
         working-directory: apps/web
 
       - name: Commit updated sitemaps and create PR
+        if: steps.ingest.outputs.data-changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/apps/web/scripts/ci-utils.ts
+++ b/apps/web/scripts/ci-utils.ts
@@ -1,0 +1,6 @@
+export function setGitHubOutput(key: string, value: string) {
+  const ghOutput = process.env.GITHUB_OUTPUT;
+  if (ghOutput) {
+    Bun.file(ghOutput).writer().write(`${key}=${value}\n`);
+  }
+}

--- a/apps/web/scripts/ingest-hmrc-csv.ts
+++ b/apps/web/scripts/ingest-hmrc-csv.ts
@@ -1,5 +1,6 @@
 import { neon } from '@neondatabase/serverless';
 import { parse } from 'csv-parse/sync';
+import { setGitHubOutput } from './ci-utils';
 
 const EXPECTED_COLUMNS = [
   'Organisation Name',
@@ -38,11 +39,7 @@ const [lastIngestion] =
   await sql`SELECT "checksum" FROM "hmrc_ingestion_meta" ORDER BY "ingested_at" DESC LIMIT 1`;
 if (!force && lastIngestion?.checksum === checksum) {
   console.log('CSV unchanged since last ingestion — skipping.');
-  const ghOutput = process.env.GITHUB_OUTPUT;
-  if (ghOutput) {
-    const fs = await import('node:fs');
-    fs.appendFileSync(ghOutput, 'data-changed=false\n');
-  }
+  setGitHubOutput('data-changed', 'false');
   process.exit(0);
 }
 if (force) console.log('Force flag set — skipping checksum comparison.');
@@ -207,9 +204,4 @@ await sql.transaction([
 await sql`INSERT INTO "hmrc_ingestion_meta" ("csv_url", "checksum", "record_count") VALUES (${url}, ${checksum}, ${dedupedRows.length})`;
 
 console.log(`Done! Ingested ${dedupedRows.length} records with zero downtime.`);
-
-const ghOutput = process.env.GITHUB_OUTPUT;
-if (ghOutput) {
-  const fs = await import('node:fs');
-  fs.appendFileSync(ghOutput, 'data-changed=true\n');
-}
+setGitHubOutput('data-changed', 'true');

--- a/apps/web/scripts/ingest-hmrc-csv.ts
+++ b/apps/web/scripts/ingest-hmrc-csv.ts
@@ -38,6 +38,11 @@ const [lastIngestion] =
   await sql`SELECT "checksum" FROM "hmrc_ingestion_meta" ORDER BY "ingested_at" DESC LIMIT 1`;
 if (!force && lastIngestion?.checksum === checksum) {
   console.log('CSV unchanged since last ingestion — skipping.');
+  const ghOutput = process.env.GITHUB_OUTPUT;
+  if (ghOutput) {
+    const fs = await import('node:fs');
+    fs.appendFileSync(ghOutput, 'data-changed=false\n');
+  }
   process.exit(0);
 }
 if (force) console.log('Force flag set — skipping checksum comparison.');
@@ -202,3 +207,9 @@ await sql.transaction([
 await sql`INSERT INTO "hmrc_ingestion_meta" ("csv_url", "checksum", "record_count") VALUES (${url}, ${checksum}, ${dedupedRows.length})`;
 
 console.log(`Done! Ingested ${dedupedRows.length} records with zero downtime.`);
+
+const ghOutput = process.env.GITHUB_OUTPUT;
+if (ghOutput) {
+  const fs = await import('node:fs');
+  fs.appendFileSync(ghOutput, 'data-changed=true\n');
+}


### PR DESCRIPTION
In the past we did have workloads whereby no csv checksums had changed but the sitemap generation pr got generated anyways.
However if the --force flag is passed, sitemap generation will happen along with database swaps.
This PR fixes that.