### PR TITLE
fix: Company House stream passing HTML instead of JSON down the stream

### DIFF
--- a/apps/ch-stream/src/stream.ts
+++ b/apps/ch-stream/src/stream.ts
@@ -57,15 +57,13 @@ export async function connectStream(
 
       for (const line of lines) {
         const trimmed = line.trim();
-        if (trimmed === '') continue;
+        if (trimmed === '' || trimmed.startsWith('<')) continue;
         try {
           const event = JSON.parse(trimmed) as CHStreamEvent;
           await onEvent(event);
-        } catch (e) {
-          console.error(
-            'Failed to parse event line:',
-            trimmed.slice(0, 200),
-            e,
+        } catch {
+          console.warn(
+            `[ch-stream] Failed to parse event: ${trimmed.slice(0, 100)}`,
           );
         }
       }


### PR DESCRIPTION
when the company house streaming service has internal server errors the stream recieves html

The internal 50x error on the CH side passes HTML to all down stream listeners resulting in polluting the listeners logs with parsing errors. This pr fixes that.