### PR TITLE
feat: cleanup the way estimateSize is used

### DIFF
--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -10,11 +10,7 @@ export default function HmrcResults({ search }: { search: string }) {
   const { results, isLoading, hasMore, loadingMore, fetchMore } =
     useHmrcSearch(search);
   const listRef = useRef<HTMLDivElement>(null);
-  const {
-    estimateSize: estimateCardHeight,
-    ready,
-    contentWidth,
-  } = useVirtualTextLayout(results, {
+  const { estimateSize, ready, contentWidth } = useVirtualTextLayout(results, {
     fields: [
       {
         getText: (row) => titleCase(row.organisationName),
@@ -34,7 +30,7 @@ export default function HmrcResults({ search }: { search: string }) {
 
   const virtualizer = useWindowVirtualizer({
     count: ready ? results.length : 0,
-    estimateSize: (index) => estimateCardHeight(index),
+    estimateSize,
     gap: 24,
     overscan: 5,
     scrollMargin: listRef.current?.offsetTop ?? 0,


### PR DESCRIPTION
The earlier implementation was too verbose, this cleans it up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved component code structure by simplifying internal implementation details, enhancing code maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->