### PR TITLE
fix: this sorts out the bug whereby clicking an input, leaving it and…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,13 @@ with `!important` (needed to beat React's inline opacity). This lets React defau
 
 ### Cross-file invariants
 
-- **`pagehide` listener in `useSearchPill` is load-bearing**: at script-time on the
-  next load the browser hasn't restored scroll yet, so `window.scrollY` is still 0.
-  Without `sessionStorage['hmrc-scroll-y']` saved on `pagehide`, reload-while-scrolled
-  flashes the input.
+- **`pagehide` listener in `HmrcResults` is load-bearing AND must be conditioned on
+  `results.length > 0`**: at script-time on the next load the browser hasn't restored
+  scroll yet, so `window.scrollY` is still 0. Without `sessionStorage['hmrc-scroll-y']`
+  saved on `pagehide`, reload-while-scrolled flashes the input. But registering the
+  listener unconditionally breaks iOS: the soft keyboard auto-scrolls on input focus,
+  which `pagehide` would persist with no consumer to clear it (HmrcResults early-returns
+  on empty search), leaving the input hidden forever after reload.
 - **Safety-net cleanup must NOT remove `hmrc-scroll-y`**: `HmrcResults` owns key
   consumption, and its `ready` gate (data + fonts + width) can take many frames.
   Clearing the key here races scroll-restore on back-nav.

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -61,6 +61,21 @@ export default function HmrcResults({ search }: { search: string }) {
     }
   }, [virtualItems, results.length, hasMore, loadingMore, fetchMore]);
 
+  // Save scroll position on pagehide so the pre-hydration script in <head> can
+  // hide the input on the next load. Only registered when there are results to
+  // scroll past — otherwise iOS keyboard auto-scroll on input focus would write
+  // a meaningless value that nothing consumes, leaving the input hidden.
+  useEffect(() => {
+    if (results.length === 0) return;
+    const onPageHide = () => {
+      if (window.scrollY > 0) {
+        sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
+      }
+    };
+    window.addEventListener('pagehide', onPageHide);
+    return () => window.removeEventListener('pagehide', onPageHide);
+  }, [results.length]);
+
   if (search.length === 0) return null;
 
   if (search.length < 3) {

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -91,20 +91,6 @@ export function useSearchPill(
     if (isStuck) clearHideAttribute();
   }, [isStuck]);
 
-  // Save scroll position on pagehide so the pre-hydration inline script can
-  // detect "reload while scrolled" on the next load. The script runs before
-  // the browser has restored scroll, so window.scrollY is 0 at that point —
-  // sessionStorage is the only signal that survives the reload boundary.
-  useEffect(() => {
-    const onPageHide = () => {
-      if (window.scrollY > 0) {
-        sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
-      }
-    };
-    window.addEventListener('pagehide', onPageHide);
-    return () => window.removeEventListener('pagehide', onPageHide);
-  }, []);
-
   // Safety net: if the inline script set the attribute but we end up at the
   // top of the page with nothing to restore (rare — e.g., the script fired
   // during a transient scroll that was then reset), remove it after two


### PR DESCRIPTION
… reloading hides the input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position persistence on page reload
  * Fixed iOS issue where input field visibility was incorrect after reload

* **Refactoring**
  * Reorganized scroll state management logic across components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->