### PR TITLE
feat: switch ingestion times based on observation of cadence irl

### DIFF
--- a/.github/workflows/hmrc-ingestion.yaml
+++ b/.github/workflows/hmrc-ingestion.yaml
@@ -2,8 +2,8 @@ name: HMRC Sponsor List Ingestion
 
 on:
   schedule:
-    # Every day at 5:00 AM and 5:00 PM UTC
-    - cron: "0 5,17 * * *"
+    # 12:30 & 00:30 BST (11:30 & 23:30 GMT)
+    - cron: "30 11,23 * * *"
   workflow_dispatch:
     inputs:
       force-ingest:

--- a/.github/workflows/hmrc-ingestion.yaml
+++ b/.github/workflows/hmrc-ingestion.yaml
@@ -2,8 +2,9 @@ name: HMRC Sponsor List Ingestion
 
 on:
   schedule:
-    # 12:30 & 00:30 BST (11:30 & 23:30 GMT)
-    - cron: "30 11,23 * * *"
+    # 12:30 & 18:00 BST (11:30 & 17:00 GMT)
+    - cron: "30 11 * * *"
+    - cron: "0 17 * * *"
   workflow_dispatch:
     inputs:
       force-ingest:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the schedule for an automated background process to run twice daily at 12:30 and 18:00 BST (11:30 and 17:00 GMT) to better distribute execution across the day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->