### PR TITLE
fix: bun 1.3.13 package hoisting issue

### DIFF
--- a/apps/web/scripts/ingest-hmrc-csv.ts
+++ b/apps/web/scripts/ingest-hmrc-csv.ts
@@ -1,4 +1,4 @@
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@ss/db/client';
 import { parse } from 'csv-parse/sync';
 import { setGitHubOutput } from './ci-utils';
 

--- a/apps/web/scripts/seed-companies-house.ts
+++ b/apps/web/scripts/seed-companies-house.ts
@@ -10,15 +10,18 @@
  * - Logs progress every 100 companies
  */
 
-import { neon } from '@neondatabase/serverless';
-import { companiesHouseProfiles, hmrcCompanyMapping } from '@ss/db/schema';
+import { createClient } from '@ss/db/client';
+import {
+  companiesHouseProfiles,
+  hmrcCompanyMapping,
+  hmrcSkilledWorkers,
+} from '@ss/db/schema';
 import dotenv from 'dotenv';
-import { drizzle } from 'drizzle-orm/neon-http';
+import { eq, isNull, sql } from 'drizzle-orm';
 
 dotenv.config({ path: '.env.local' });
 
-const sql = neon(process.env.POSTGRES_URL as string);
-const db = drizzle({ client: sql });
+const db = createClient(process.env.POSTGRES_URL as string);
 
 const BASE_URL = 'https://api.company-information.service.gov.uk';
 const API_KEY = process.env.COMPANIES_HOUSE_SEED_API_KEY as string;
@@ -56,14 +59,15 @@ async function fetchApi(path: string): Promise<unknown | null> {
 }
 
 // Get only org names that aren't already cached
-const uncached = await sql`
-  SELECT DISTINCT h.organisation_name
-  FROM hmrc_skilled_workers h
-  LEFT JOIN companies_house_profiles c
-    ON UPPER(h.organisation_name) = UPPER(c.company_name)
-  WHERE c.company_number IS NULL
-  ORDER BY h.organisation_name
-`;
+const uncached = await db
+  .selectDistinct({ organisationName: hmrcSkilledWorkers.organisationName })
+  .from(hmrcSkilledWorkers)
+  .leftJoin(
+    companiesHouseProfiles,
+    sql`UPPER(${hmrcSkilledWorkers.organisationName}) = UPPER(${companiesHouseProfiles.companyName})`,
+  )
+  .where(isNull(companiesHouseProfiles.companyNumber))
+  .orderBy(hmrcSkilledWorkers.organisationName);
 console.log(`Found ${uncached.length} uncached organisations to fetch`);
 
 let processed = 0;
@@ -92,15 +96,15 @@ function logProgress() {
 }
 
 for (const row of uncached) {
-  const orgName = row.organisation_name as string;
+  const orgName = row.organisationName;
   processed++;
 
   // Check if a crawler cached this while the seed was running
-  const [alreadyCached] = await sql`
-    SELECT 1 FROM hmrc_company_mapping
-    WHERE organisation_name = ${orgName}
-    LIMIT 1
-  `;
+  const [alreadyCached] = await db
+    .select()
+    .from(hmrcCompanyMapping)
+    .where(eq(hmrcCompanyMapping.organisationName, orgName))
+    .limit(1);
   if (alreadyCached) {
     skipped++;
     if (processed % 100 === 0) {

--- a/apps/web/scripts/seed-sic-codes.ts
+++ b/apps/web/scripts/seed-sic-codes.ts
@@ -1,29 +1,22 @@
-import { neon } from '@neondatabase/serverless';
-import sicCodes from '../data/sic-codes.json';
+import { createClient } from '@ss/db/client';
+import { sicCodes } from '@ss/db/schema';
+import { sql } from 'drizzle-orm';
+import sicCodeData from '../data/sic-codes.json';
 
-const sql = neon(process.env.POSTGRES_URL as string);
+const db = createClient(process.env.POSTGRES_URL as string);
 
-const entries = Object.entries(sicCodes);
+const entries = Object.entries(sicCodeData);
 console.log(`Seeding ${entries.length} SIC codes...`);
 
-await sql`TRUNCATE TABLE "sic_codes"`;
+await db.execute(sql`TRUNCATE TABLE ${sicCodes}`);
 
 const BATCH_SIZE = 500;
 for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-  const batch = entries.slice(i, i + BATCH_SIZE);
-  const placeholders: string[] = [];
-  const values: string[] = [];
+  const batch = entries
+    .slice(i, i + BATCH_SIZE)
+    .map(([code, description]) => ({ code, description }));
 
-  for (let j = 0; j < batch.length; j++) {
-    const offset = j * 2;
-    placeholders.push(`($${offset + 1}, $${offset + 2})`);
-    values.push(batch[j][0], batch[j][1]);
-  }
-
-  await sql.query(
-    `INSERT INTO "sic_codes" ("code", "description") VALUES ${placeholders.join(', ')}`,
-    values,
-  );
+  await db.insert(sicCodes).values(batch);
 
   console.log(
     `  Inserted ${Math.min(i + BATCH_SIZE, entries.length)}/${entries.length}`,

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,6 +1,8 @@
 import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 
+export { neon } from '@neondatabase/serverless';
+
 /**
  * Build a Drizzle client backed by Neon's serverless HTTP driver. The returned
  * instance is safe for one-shot queries in edge/serverless handlers and does


### PR DESCRIPTION
bun workspace issue + re-write seed-sic, seed-companies using the drizzle orm. keep ingest at driver level

the ingest script stays at driver level because those are much harder to do with drizzle, while the other 2 translate easily over to drizzle. By exporting the neon driver straight out of @ss/db we can opt-into it when it makes sense (like ingest-hmrc-csv.ts) needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated database client initialization and imports across multiple internal data processing scripts to ensure consistent usage patterns.
  * Refactored database operations to utilize a unified client factory approach for improved consistency and maintainability.
  * Updated the database client module with additional export options to support evolving infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->