### PR TITLE
fix: the canonical url issue on google page ranks

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -73,10 +73,7 @@ export const Route = createFileRoute('/company/$id/$slug')({
       links: [
         {
           rel: 'canonical',
-          href: buildCanonical(
-            match.pathname,
-            match.search as Record<string, string>,
-          ),
+          href: buildCanonical(match.pathname),
         },
       ],
     };

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -23,10 +23,7 @@ export const Route = createFileRoute('/')({
     links: [
       {
         rel: 'canonical',
-        href: buildCanonical(
-          match.pathname,
-          match.search as Record<string, string>,
-        ),
+        href: buildCanonical(match.pathname),
       },
     ],
   }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified canonical link generation to exclude query string parameters from canonical URLs, ensuring cleaner and more consistent URL handling for SEO purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->