### PR TITLE
feat: handle old 404 urls on company details page to now redirect either to search or the new company page

### DIFF
--- a/apps/web/scripts/ingest-hmrc-csv.ts
+++ b/apps/web/scripts/ingest-hmrc-csv.ts
@@ -1,5 +1,6 @@
 import { neon } from '@ss/db/client';
 import { parse } from 'csv-parse/sync';
+import { slugify } from '../src/utils';
 import { setGitHubOutput } from './ci-utils';
 
 const EXPECTED_COLUMNS = [
@@ -88,6 +89,7 @@ await sql`
     "id" serial PRIMARY KEY NOT NULL,
     "hash" varchar(11) NOT NULL UNIQUE,
     "organisation_name" varchar(255) NOT NULL,
+    "name_slug" varchar(255) NOT NULL,
     "town_city" varchar(100),
     "county" varchar(100),
     "type_rating" varchar(100) NOT NULL,
@@ -126,6 +128,7 @@ function computeHash(
 type CleanedRow = {
   hash: string;
   orgName: string;
+  nameSlug: string;
   townCity: string | null;
   county: string | null;
   typeRating: string;
@@ -142,10 +145,19 @@ for (const r of records) {
   const typeRating = r['Type & Rating'].trim();
   const route = r.Route.trim();
   const hash = computeHash(orgName, townCity, county, typeRating, route);
+  const nameSlug = slugify(orgName);
 
   if (!seen.has(hash)) {
     seen.add(hash);
-    dedupedRows.push({ hash, orgName, townCity, county, typeRating, route });
+    dedupedRows.push({
+      hash,
+      orgName,
+      nameSlug,
+      townCity,
+      county,
+      typeRating,
+      route,
+    });
   }
 }
 
@@ -160,15 +172,23 @@ for (let i = 0; i < dedupedRows.length; i += BATCH_SIZE) {
 
   for (let j = 0; j < batch.length; j++) {
     const r = batch[j];
-    const offset = j * 6;
+    const offset = j * 7;
     placeholders.push(
-      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6})`,
+      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7})`,
     );
-    values.push(r.hash, r.orgName, r.townCity, r.county, r.typeRating, r.route);
+    values.push(
+      r.hash,
+      r.orgName,
+      r.nameSlug,
+      r.townCity,
+      r.county,
+      r.typeRating,
+      r.route,
+    );
   }
 
   await sql.query(
-    `INSERT INTO "hmrc_skilled_workers_staging" ("hash", "organisation_name", "town_city", "county", "type_rating", "route") VALUES ${placeholders.join(', ')}`,
+    `INSERT INTO "hmrc_skilled_workers_staging" ("hash", "organisation_name", "name_slug", "town_city", "county", "type_rating", "route") VALUES ${placeholders.join(', ')}`,
     values,
   );
 
@@ -181,6 +201,7 @@ for (let i = 0; i < dedupedRows.length; i += BATCH_SIZE) {
 console.log('Building indexes on staging table...');
 await Promise.all([
   sql`CREATE INDEX "stg_idx_hmrc_org_name" ON "hmrc_skilled_workers_staging" USING btree ("organisation_name")`,
+  sql`CREATE INDEX "stg_idx_hmrc_name_slug" ON "hmrc_skilled_workers_staging" USING btree ("name_slug")`,
   sql`CREATE INDEX "stg_idx_hmrc_town_city" ON "hmrc_skilled_workers_staging" USING btree ("town_city")`,
   sql`CREATE INDEX "stg_idx_hmrc_route" ON "hmrc_skilled_workers_staging" USING btree ("route")`,
   sql`CREATE INDEX "stg_idx_hmrc_org_name_trgm" ON "hmrc_skilled_workers_staging" USING gin ("organisation_name" gin_trgm_ops)`,
@@ -194,6 +215,7 @@ await sql.transaction([
   sql`DROP TABLE "hmrc_skilled_workers"`,
   sql`ALTER TABLE "hmrc_skilled_workers_staging" RENAME TO "hmrc_skilled_workers"`,
   sql`ALTER INDEX "stg_idx_hmrc_org_name" RENAME TO "idx_hmrc_org_name"`,
+  sql`ALTER INDEX "stg_idx_hmrc_name_slug" RENAME TO "idx_hmrc_name_slug"`,
   sql`ALTER INDEX "stg_idx_hmrc_town_city" RENAME TO "idx_hmrc_town_city"`,
   sql`ALTER INDEX "stg_idx_hmrc_route" RENAME TO "idx_hmrc_route"`,
   sql`ALTER INDEX "stg_idx_hmrc_org_name_trgm" RENAME TO "idx_hmrc_org_name_trgm"`,

--- a/apps/web/scripts/ingest-hmrc-csv.ts
+++ b/apps/web/scripts/ingest-hmrc-csv.ts
@@ -145,7 +145,7 @@ for (const r of records) {
   const typeRating = r['Type & Rating'].trim();
   const route = r.Route.trim();
   const hash = computeHash(orgName, townCity, county, typeRating, route);
-  const nameSlug = slugify(orgName);
+  const nameSlug = slugify(orgName) || hash;
 
   if (!seen.has(hash)) {
     seen.add(hash);

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -35,6 +35,7 @@ export const searchHmrc = createServerFn()
       .select({
         slugId: hmrcSkilledWorkers.hash,
         organisationName: hmrcSkilledWorkers.organisationName,
+        nameSlug: hmrcSkilledWorkers.nameSlug,
         townCity: hmrcSkilledWorkers.townCity,
         county: hmrcSkilledWorkers.county,
         typeRating: hmrcSkilledWorkers.typeRating,
@@ -97,6 +98,29 @@ export const hmrcBySlugIdQueryOptions = (slugId: string) =>
     queryKey: ['hmrc-by-slug-id', slugId],
     queryFn: () => getHmrcBySlugId({ data: { slugId } }),
     staleTime: Number.POSITIVE_INFINITY,
+  });
+
+/**
+ * Server fn returning `hmrc_skilled_workers` rows whose `name_slug` matches
+ * the given slug. Fallback for stale `/company/$id/$slug` URLs: when the hash
+ * lookup 404s, the loader checks whether the name still maps to a current row
+ * and 301s to its new hash. Capped at 2 since callers only branch on 0 / 1 / many.
+ * Not wrapped in queryOptions — only the loader calls it, and the redirect
+ * moves the user off this page so there's no second reader for the result.
+ */
+export const getHmrcBySlug = createServerFn()
+  .inputValidator((input: unknown) => input as { slug: string })
+  .handler(async ({ data: { slug } }) => {
+    if (!/^[a-z0-9-]{1,100}$/.test(slug)) return [];
+    const rows = await db
+      .select({
+        slugId: hmrcSkilledWorkers.hash,
+        organisationName: hmrcSkilledWorkers.organisationName,
+      })
+      .from(hmrcSkilledWorkers)
+      .where(eq(hmrcSkilledWorkers.nameSlug, slug))
+      .limit(2);
+    return rows;
   });
 
 /**

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -111,7 +111,7 @@ export const hmrcBySlugIdQueryOptions = (slugId: string) =>
 export const getHmrcBySlug = createServerFn()
   .inputValidator((input: unknown) => input as { slug: string })
   .handler(async ({ data: { slug } }) => {
-    if (!/^[a-z0-9-]{1,100}$/.test(slug)) return [];
+    if (!/^[a-z0-9-]{1,255}$/.test(slug)) return [];
     const rows = await db
       .select({
         slugId: hmrcSkilledWorkers.hash,

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import type { HmrcRow } from '../api/hmrc';
-import { slugify, titleCase } from '../utils';
+import { titleCase } from '../utils';
 import RatingIcon from './RatingIcon';
 
 /**
@@ -21,7 +21,7 @@ export default function HmrcCard({
       to="/company/$id/$slug"
       params={{
         id: row.slugId,
-        slug: slugify(row.organisationName),
+        slug: row.nameSlug,
       }}
       search={{ search }}
       className="block no-underline py-2"

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -2,11 +2,12 @@ import {
   createFileRoute,
   Link,
   notFound,
+  redirect,
   stripSearchParams,
 } from '@tanstack/react-router';
 import { ExternalLink, MapPin } from 'lucide-react';
 import { companyProfileQueryOptions } from '../api/companiesHouse';
-import { hmrcBySlugIdQueryOptions } from '../api/hmrc';
+import { getHmrcBySlug, hmrcBySlugIdQueryOptions } from '../api/hmrc';
 import { StatusBadge } from '../components/StatusBadge';
 import { formatAddress, formatDate, titleCase } from '../utils';
 import { buildCanonical } from '../utils/canonical';
@@ -24,6 +25,22 @@ export const Route = createFileRoute('/company/$id/$slug')({
     );
 
     if (!sponsor) {
+      const matches = await getHmrcBySlug({ data: { slug: params.slug } });
+      if (matches.length === 1) {
+        throw redirect({
+          to: '/company/$id/$slug',
+          params: { id: matches[0].slugId, slug: params.slug },
+          search: (prev) => ({ search: prev.search ?? '' }),
+          statusCode: 301,
+        });
+      }
+      if (matches.length > 1) {
+        throw redirect({
+          to: '/',
+          search: { search: matches[0].organisationName },
+          statusCode: 302,
+        });
+      }
       throw notFound();
     }
 

--- a/apps/web/src/utils.ts
+++ b/apps/web/src/utils.ts
@@ -28,6 +28,7 @@ export function titleCase(str: string | null) {
 /**
  * Lowercase and replace runs of non-alphanumeric characters with `-`,
  * trimming leading/trailing dashes. Used to build URL-safe path segments.
+ * Shared with the Bun ingestion script — keep browser-only APIs out.
  */
 export function slugify(str: string): string {
   return str

--- a/packages/db/migrations/0020_typical_marten_broadcloak.sql
+++ b/packages/db/migrations/0020_typical_marten_broadcloak.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "hmrc_skilled_workers" ADD COLUMN "name_slug" varchar(255);--> statement-breakpoint
+UPDATE "hmrc_skilled_workers" SET "name_slug" = regexp_replace(regexp_replace(lower("organisation_name"), '[^a-z0-9]+', '-', 'g'), '^-|-$', '', 'g');--> statement-breakpoint
+ALTER TABLE "hmrc_skilled_workers" ALTER COLUMN "name_slug" SET NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_hmrc_name_slug" ON "hmrc_skilled_workers" USING btree ("name_slug");

--- a/packages/db/migrations/0021_backfill_empty_name_slug_with_hash.sql
+++ b/packages/db/migrations/0021_backfill_empty_name_slug_with_hash.sql
@@ -1,0 +1,1 @@
+UPDATE "hmrc_skilled_workers" SET "name_slug" = "hash" WHERE "name_slug" = '';

--- a/packages/db/migrations/meta/0020_snapshot.json
+++ b/packages/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,640 @@
+{
+  "id": "1483c733-4441-4172-ad48-df49c150c26a",
+  "prevId": "c32db84f-10fe-4523-9fc2-3a97ca8cf253",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ch_stream_state": {
+      "name": "ch_stream_state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_timepoint": {
+          "name": "last_timepoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profile_cache": {
+      "name": "companies_house_profile_cache",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_trail_id": {
+          "name": "last_trail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profile_trails": {
+      "name": "companies_house_profile_trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_trail_company_number": {
+          "name": "idx_ch_trail_company_number",
+          "columns": [
+            {
+              "expression": "company_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_trail_created_at": {
+          "name": "idx_ch_trail_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profiles": {
+      "name": "companies_house_profiles",
+      "schema": "",
+      "columns": {
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_status": {
+          "name": "company_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_creation": {
+          "name": "date_of_creation",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sic_codes": {
+          "name": "sic_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "accounts_next_made_up_to": {
+          "name": "accounts_next_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_last_made_up_to": {
+          "name": "accounts_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_overdue": {
+          "name": "accounts_overdue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_been_liquidated": {
+          "name": "has_been_liquidated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_insolvency_history": {
+          "name": "has_insolvency_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_charges": {
+          "name": "has_charges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_company_names": {
+          "name": "previous_company_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "confirmation_statement_last_made_up_to": {
+          "name": "confirmation_statement_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_company_name": {
+          "name": "idx_ch_company_name",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_status": {
+          "name": "idx_ch_company_status",
+          "columns": [
+            {
+              "expression": "company_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_type": {
+          "name": "idx_ch_company_type",
+          "columns": [
+            {
+              "expression": "company_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_sic_codes": {
+          "name": "idx_ch_sic_codes",
+          "columns": [
+            {
+              "expression": "sic_codes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_ch_jurisdiction": {
+          "name": "idx_ch_jurisdiction",
+          "columns": [
+            {
+              "expression": "jurisdiction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_previous_names": {
+          "name": "idx_ch_previous_names",
+          "columns": [
+            {
+              "expression": "previous_company_names",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_company_mapping": {
+      "name": "hmrc_company_mapping",
+      "schema": "",
+      "columns": {
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_ingestion_meta": {
+      "name": "hmrc_ingestion_meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "csv_url": {
+          "name": "csv_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_skilled_workers": {
+      "name": "hmrc_skilled_workers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_slug": {
+          "name": "name_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_city": {
+          "name": "town_city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_rating": {
+          "name": "type_rating",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_hmrc_org_name": {
+          "name": "idx_hmrc_org_name",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_name_slug": {
+          "name": "idx_hmrc_name_slug",
+          "columns": [
+            {
+              "expression": "name_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_town_city": {
+          "name": "idx_hmrc_town_city",
+          "columns": [
+            {
+              "expression": "town_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_route": {
+          "name": "idx_hmrc_route",
+          "columns": [
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_org_name_trgm": {
+          "name": "idx_hmrc_org_name_trgm",
+          "columns": [
+            {
+              "expression": "\"organisation_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmrc_skilled_workers_hash_unique": {
+          "name": "hmrc_skilled_workers_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sic_codes": {
+      "name": "sic_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1777026426819,
       "tag": "0020_typical_marten_broadcloak",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1777030679962,
+      "tag": "0021_backfill_empty_name_slug_with_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776263333413,
       "tag": "0019_needy_mockingbird",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777026426819,
+      "tag": "0020_typical_marten_broadcloak",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -17,6 +17,7 @@ export const hmrcSkilledWorkers = pgTable(
     id: serial('id').primaryKey(),
     hash: varchar('hash', { length: 11 }).notNull().unique(),
     organisationName: varchar('organisation_name', { length: 255 }).notNull(),
+    nameSlug: varchar('name_slug', { length: 255 }).notNull(),
     townCity: varchar('town_city', { length: 100 }),
     county: varchar('county', { length: 100 }),
     typeRating: varchar('type_rating', { length: 100 }).notNull(),
@@ -24,6 +25,7 @@ export const hmrcSkilledWorkers = pgTable(
   },
   (table) => [
     index('idx_hmrc_org_name').on(table.organisationName),
+    index('idx_hmrc_name_slug').on(table.nameSlug),
     index('idx_hmrc_town_city').on(table.townCity),
     index('idx_hmrc_route').on(table.route),
     index('idx_hmrc_org_name_trgm').using(


### PR DESCRIPTION
 handle old urls being a 404, we now have a mechanism to redirect to a new page or go back to the search page if the results are ambigous

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Company listings and search now include stable slug identifiers for direct linking.
  * Slugs are backfilled for existing records and indexed to enable fast lookups.

* **Bug Fixes / UX**
  * Company detail route auto-resolves and redirects via slug when ID lookup fails, preserving query params or providing sensible fallbacks.

* **Documentation**
  * Notes clarify slug utility and shared usage between ingestion and web logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->