### PR TITLE
fix: update sitemap to use nameSlug from the db instead 

### DIFF
--- a/apps/web/scripts/generate-sitemap.ts
+++ b/apps/web/scripts/generate-sitemap.ts
@@ -8,6 +8,12 @@ const BASE_URL = 'https://sponsorsearch.co.uk';
 const BATCH_SIZE = 45000;
 const OUT_DIR = join(import.meta.dirname, '..', 'public');
 
+/**
+ * Regenerate the full sitemap set from scratch: the index (`sitemap.xml`),
+ * a static-pages file (`sitemap-0.xml`), and paginated company sitemaps
+ * over `BATCH_SIZE` chunks of `hmrc_skilled_workers`. Reads `name_slug` from
+ * the DB so URLs stay consistent with HmrcCard and the detail-route loader.
+ */
 async function generate() {
   console.log('Generating sitemap...');
 

--- a/apps/web/scripts/generate-sitemap.ts
+++ b/apps/web/scripts/generate-sitemap.ts
@@ -3,7 +3,6 @@ import { hmrcSkilledWorkers } from '@ss/db';
 import { Glob } from 'bun';
 import { sql } from 'drizzle-orm';
 import { db } from '../src/db.server';
-import { slugify } from '../src/utils';
 
 const BASE_URL = 'https://sponsorsearch.co.uk';
 const BATCH_SIZE = 45000;
@@ -67,7 +66,7 @@ ${Array.from(
     const rows = await db
       .select({
         hash: hmrcSkilledWorkers.hash,
-        organisationName: hmrcSkilledWorkers.organisationName,
+        nameSlug: hmrcSkilledWorkers.nameSlug,
       })
       .from(hmrcSkilledWorkers)
       .orderBy(hmrcSkilledWorkers.hash)
@@ -79,8 +78,8 @@ ${Array.from(
 ${rows
   .map(
     (row) => `  <url>
-    <loc>${BASE_URL}/company/${row.hash}/${slugify(row.organisationName)}</loc>
-    <changefreq>weekly</changefreq>
+    <loc>${BASE_URL}/company/${row.hash}/${row.nameSlug}</loc>
+    <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>`,
   )


### PR DESCRIPTION
- update the cadence to daily (if the seo crawlers care about it, however most crawlers ignore this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved company sitemap so company page URLs now match the app's routing, ensuring consistent links.
  * Increased sitemap update frequency from weekly to daily to improve search engine indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->