### PR TITLE
feat: add safari / chrome targetted browser page transitions 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,30 @@ from fallback font measurements or missing width data.
 
 The `hmrc-scroll-y` sessionStorage restore runs in a `useEffect([ready])` — it must wait
 for items to be in the DOM at correct heights before calling `window.scrollTo`.
+
+## Page transitions live in `transitions.css`, not `styles.css`
+
+All View Transitions API rules — keyframes, `view-transition-name` declarations on
+`.page-flip-listing` / `.page-flip-details`, `::view-transition-*(active-card)` and
+`::view-transition-*(root)` styling, `:active-view-transition-type(forward|back)`
+direction-keyed animations, and `html[data-browser="…"]` browser-targeted overrides —
+live in `apps/web/src/transitions.css`. It's imported from `styles.css` at the top.
+
+When adding or editing transition behaviour, edit `transitions.css`. Do not put view-
+transition rules back into `styles.css` — the split exists so the (substantial) transition
+logic doesn't tangle with base tokens, utilities, and component styles.
+
+### Cross-file moving parts to know about
+
+- `HmrcCard` sets `style={{ viewTransitionName: 'active-card' }}` on the clicked card via
+  React state in `HmrcResults` (`flushSync` on click so the DOM is committed before
+  TanStack Router calls `startViewTransition`). Safari overrides the active-card name to
+  `none` via `[style*="view-transition-name"] { ... !important }` because that's the only
+  way to beat an inline style from CSS.
+- The `data-browser` attribute on `<html>` is stamped pre-hydration by
+  `scripts/browser-init.ts`. Generic mechanism — add `html[data-browser="chrome"] { … }`
+  rules in `transitions.css` for future per-browser tweaks.
+- Forward navigation passes `viewTransition={{ types: ['forward'] }}` on the `Link` in
+  `HmrcCard`; back navigation passes `['back']` on the back link in `company.$id.$slug.tsx`.
+  Other navigations (e.g. search-param updates) deliberately do NOT pass `viewTransition`
+  so they don't trigger animations.

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -6,15 +6,21 @@ import RatingIcon from './RatingIcon';
 /**
  * Single HMRC sponsor result card, rendered as a link into the company detail
  * route. Persists `window.scrollY` to sessionStorage on click so `HmrcResults`
- * can restore the list position on back-nav. `search` is forwarded so the
- * "back to search" link on the detail page preserves the current query.
+ * can restore the list position on back-nav. When `isActive` is true the card
+ * is given `view-transition-name: active-card`, which carves it out of the
+ * `results-listing` snapshot so it can run its own slide animation while the
+ * remaining cards fade.
  */
 export default function HmrcCard({
   row,
   search,
+  isActive,
+  onActivate,
 }: {
   row: HmrcRow;
   search: string;
+  isActive: boolean;
+  onActivate: () => void;
 }) {
   return (
     <Link
@@ -26,9 +32,12 @@ export default function HmrcCard({
       search={{ search }}
       viewTransition={{ types: ['forward'] }}
       className="block no-underline py-2"
-      onClick={() =>
-        sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY))
-      }
+      style={isActive ? { viewTransitionName: 'active-card' } : undefined}
+      onClick={() => {
+        sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
+        sessionStorage.setItem('hmrc-active-id', row.slugId);
+        onActivate();
+      }}
     >
       <h3 className="heading-card text-base font-semibold text-(--sea-ink)">
         {titleCase(row.organisationName)}

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -1,5 +1,6 @@
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { useVirtualTextLayout } from 'virtual-text-layout';
 import { useHmrcSearch } from '../hooks/useHmrcSearch';
 import { titleCase } from '../utils';
@@ -18,6 +19,21 @@ export default function HmrcResults({ search }: { search: string }) {
   const { results, isLoading, hasMore, loadingMore, fetchMore } =
     useHmrcSearch(search);
   const listRef = useRef<HTMLDivElement>(null);
+  // `activeId` only gets set when the user clicks a card on this very
+  // mount (via flushSync below). On a remount after back-nav we leave it
+  // null on purpose — that way the listing's matching card does *not*
+  // receive `view-transition-name: active-card`, so the browser won't
+  // pair it with the details wrapper and morph back. Back-nav uses a
+  // page-level slide instead (see styles.css).
+  const [activeId, setActiveId] = useState<string | null>(null);
+  // `eagerRender` is true when sessionStorage indicates we just came
+  // from a card click — that's enough signal to render the cards
+  // immediately (skipping the `ready` gate) so the slide-in animation
+  // doesn't show skeletons during back-nav.
+  const [eagerRender] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return sessionStorage.getItem('hmrc-active-id') !== null;
+  });
   const { estimateSize, ready, contentWidth } = useVirtualTextLayout(results, {
     fields: [
       {
@@ -37,8 +53,15 @@ export default function HmrcResults({ search }: { search: string }) {
     containerRef: listRef,
   });
 
+  // On back-nav we have a known activeId — render the cards immediately
+  // (even before width is measured) so the matching card has its
+  // `view-transition-name: active-card` in the DOM when the browser
+  // captures the NEW snapshot. Without this the snapshot would be of
+  // skeletons, the morph would have no target, and the back transition
+  // would just be a fade with the live page leaking through underneath.
+  const showCards = ready || eagerRender;
   const virtualizer = useWindowVirtualizer({
-    count: ready ? results.length : 0,
+    count: showCards ? results.length : 0,
     estimateSize,
     gap: 24,
     overscan: 5,
@@ -95,7 +118,7 @@ export default function HmrcResults({ search }: { search: string }) {
     );
   }
 
-  if (isLoading || !ready) {
+  if (isLoading || !showCards) {
     return (
       <>
         <SkeletonCards />
@@ -143,7 +166,20 @@ export default function HmrcResults({ search }: { search: string }) {
               transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
             }}
           >
-            <HmrcCard row={results[virtualRow.index]} search={search} />
+            <HmrcCard
+              row={results[virtualRow.index]}
+              search={search}
+              isActive={activeId === results[virtualRow.index].slugId}
+              onActivate={() => {
+                // flushSync forces React to commit the state update before
+                // TanStack Router's click handler triggers
+                // startViewTransition — otherwise the OLD snapshot would be
+                // captured before the active card has its name applied.
+                flushSync(() => {
+                  setActiveId(results[virtualRow.index].slugId);
+                });
+              }}
+            />
           </div>
         ))}
       </div>

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -63,9 +63,15 @@ export default function HmrcResults({ search }: { search: string }) {
     if (!ready) return;
     const savedY = sessionStorage.getItem('hmrc-scroll-y');
     if (savedY) {
-      sessionStorage.removeItem('hmrc-scroll-y');
+      // Scroll first, then clear the key — in that order, atomically inside
+      // a single rAF. If we cleared the key before the rAF fired, there
+      // would be a one-frame window where `scrollY === 0` AND the key is
+      // gone, which `useSearchPill`'s safety-net poll reads as "nothing to
+      // restore" and clears `data-hide-search-input` prematurely. That would
+      // briefly unhide the input on a scrolled back-nav restore.
       requestAnimationFrame(() => {
         window.scrollTo(0, Number.parseInt(savedY, 10));
+        sessionStorage.removeItem('hmrc-scroll-y');
       });
     }
   }, [ready]);

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -26,14 +26,6 @@ export default function HmrcResults({ search }: { search: string }) {
   // pair it with the details wrapper and morph back. Back-nav uses a
   // page-level slide instead (see styles.css).
   const [activeId, setActiveId] = useState<string | null>(null);
-  // `eagerRender` is true when sessionStorage indicates we just came
-  // from a card click — that's enough signal to render the cards
-  // immediately (skipping the `ready` gate) so the slide-in animation
-  // doesn't show skeletons during back-nav.
-  const [eagerRender] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return sessionStorage.getItem('hmrc-active-id') !== null;
-  });
   const { estimateSize, ready, contentWidth } = useVirtualTextLayout(results, {
     fields: [
       {
@@ -53,15 +45,8 @@ export default function HmrcResults({ search }: { search: string }) {
     containerRef: listRef,
   });
 
-  // On back-nav we have a known activeId — render the cards immediately
-  // (even before width is measured) so the matching card has its
-  // `view-transition-name: active-card` in the DOM when the browser
-  // captures the NEW snapshot. Without this the snapshot would be of
-  // skeletons, the morph would have no target, and the back transition
-  // would just be a fade with the live page leaking through underneath.
-  const showCards = ready || eagerRender;
   const virtualizer = useWindowVirtualizer({
-    count: showCards ? results.length : 0,
+    count: ready ? results.length : 0,
     estimateSize,
     gap: 24,
     overscan: 5,
@@ -118,7 +103,7 @@ export default function HmrcResults({ search }: { search: string }) {
     );
   }
 
-  if (isLoading || !showCards) {
+  if (isLoading || !ready) {
     return (
       <>
         <SkeletonCards />

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -104,28 +104,37 @@ export function useSearchPill(
   }, [isStuck]);
 
   // Safety net: if the inline script set the attribute but we end up at the
-  // top of the page with nothing to restore (rare — e.g., the script fired
-  // during a transient scroll that was then reset), remove it after two
-  // animation frames. HmrcResults' scroll-restore rAF fires in the same
-  // window, so by the second frame scroll position reflects reality.
+  // top of the page with nothing to restore, drop it. Polls every frame for
+  // up to 1s rather than checking once after 2 frames — HmrcResults'
+  // scroll-restore is gated on the virtualizer's font/width readiness, which
+  // can take many frames on a SPA back-nav from a reloaded details page,
+  // leaving `hmrc-scroll-y` in sessionStorage past the original 2-frame
+  // window. Without polling, the attribute persists, the input stays hidden
+  // at scroll-y=0, and the user has to scroll down + back up to surface it.
+  // The poll exits early once the attribute is gone (cleared by another
+  // path) or the conditions are met.
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (!document.documentElement.hasAttribute('data-hide-search-input')) {
       return;
     }
     let cancelled = false;
-    const outer = requestAnimationFrame(() => {
+    const start = performance.now();
+    const tick = () => {
       if (cancelled) return;
-      requestAnimationFrame(() => {
-        if (cancelled) return;
-        if (window.scrollY === 0 && !sessionStorage.getItem('hmrc-scroll-y')) {
-          clearHideAttribute();
-        }
-      });
-    });
+      if (!document.documentElement.hasAttribute('data-hide-search-input')) {
+        return;
+      }
+      if (window.scrollY === 0 && !sessionStorage.getItem('hmrc-scroll-y')) {
+        clearHideAttribute();
+        return;
+      }
+      if (performance.now() - start > 1000) return;
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
     return () => {
       cancelled = true;
-      cancelAnimationFrame(outer);
     };
   }, []);
 

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -104,22 +104,25 @@ export function useSearchPill(
   }, [isStuck]);
 
   // Safety net: if the inline script set the attribute but we end up at the
-  // top of the page with nothing to restore, drop it. Polls every frame for
-  // up to 1s rather than checking once after 2 frames — HmrcResults'
-  // scroll-restore is gated on the virtualizer's font/width readiness, which
-  // can take many frames on a SPA back-nav from a reloaded details page,
-  // leaving `hmrc-scroll-y` in sessionStorage past the original 2-frame
-  // window. Without polling, the attribute persists, the input stays hidden
-  // at scroll-y=0, and the user has to scroll down + back up to surface it.
-  // The poll exits early once the attribute is gone (cleared by another
-  // path) or the conditions are met.
+  // top of the page with nothing to restore, drop it. Polls every animation
+  // frame and terminates only when one of three conditions is met:
+  //   1. The attribute has been removed by another path (e.g., `isStuck=true`
+  //      via the useLayoutEffect above).
+  //   2. `scrollY === 0` and `hmrc-scroll-y` has been consumed by HmrcResults.
+  //   3. The component unmounts (cancelled flag stops the next tick).
+  //
+  // A naive timeout cutoff isn't safe — HmrcResults' scroll-restore is gated
+  // on the virtualizer's font/width readiness, which can take an indefinite
+  // number of frames on slow loads. Anything shorter than "wait until the
+  // restore actually happens" leaves a race window where the attribute
+  // persists with no remaining clearer. rAF auto-pauses on background tabs,
+  // so an open-ended poll has no idle cost when the user isn't looking.
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (!document.documentElement.hasAttribute('data-hide-search-input')) {
       return;
     }
     let cancelled = false;
-    const start = performance.now();
     const tick = () => {
       if (cancelled) return;
       if (!document.documentElement.hasAttribute('data-hide-search-input')) {
@@ -129,7 +132,6 @@ export function useSearchPill(
         clearHideAttribute();
         return;
       }
-      if (performance.now() - start > 1000) return;
       requestAnimationFrame(tick);
     };
     requestAnimationFrame(tick);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import Header from '../components/Header';
 import { McpTools } from '../components/McpTools';
 import NavigationProgress from '../components/NavigationProgress';
 import RouteError from '../components/RouteError';
+import { BROWSER_INIT_SCRIPT } from '../scripts/browser-init';
 import { SEARCH_INIT_SCRIPT } from '../scripts/search-input-init';
 import { THEME_INIT_SCRIPT } from '../scripts/theme-init';
 import appCss from '../styles.css?url';
@@ -120,6 +121,8 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static search input init script, no user input */}
         <script dangerouslySetInnerHTML={{ __html: SEARCH_INIT_SCRIPT }} />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static browser detection script, no user input */}
+        <script dangerouslySetInnerHTML={{ __html: BROWSER_INIT_SCRIPT }} />
         <HeadContent />
       </head>
       <body className="font-sans antialiased wrap-anywhere selection:bg-[rgba(0,114,245,0.16)]">

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -121,127 +121,131 @@ function CompanyDetail() {
   return (
     <main className="page-wrap min-h-[50vh] px-4 py-16">
       <section className="mx-auto max-w-2xl">
-        <div className="rounded-lg bg-(--sponsor-card-bg) shadow-(--shadow-card) p-6">
-          <h1 className="text-xl font-semibold text-(--sea-ink)">
-            {titleCase(sponsor.organisationName)}
-          </h1>
-          {profile?.sicDescriptions && profile.sicDescriptions.length > 0 && (
-            <p className="mt-1 text-sm text-(--sea-ink-soft)">
-              {profile.sicDescriptions.map((sic) => sic.description).join(', ')}
-            </p>
-          )}
-          <dl className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <div>
-              <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                Location
-              </dt>
-              <dd className="mt-1 text-sm text-(--sea-ink)">
-                {[sponsor.townCity, sponsor.county]
-                  .filter(Boolean)
-                  .map(titleCase)
-                  .join(', ') || 'Not specified'}
-              </dd>
-            </div>
-            {profile?.company_status && (
+        <div className="page-flip-details">
+          <div className="rounded-lg bg-(--sponsor-card-bg) shadow-(--shadow-card) p-6">
+            <h1 className="text-xl font-semibold text-(--sea-ink)">
+              {titleCase(sponsor.organisationName)}
+            </h1>
+            {profile?.sicDescriptions && profile.sicDescriptions.length > 0 && (
+              <p className="mt-1 text-sm text-(--sea-ink-soft)">
+                {profile.sicDescriptions
+                  .map((sic) => sic.description)
+                  .join(', ')}
+              </p>
+            )}
+            <dl className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
               <div>
                 <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                  Status
+                  Location
                 </dt>
-                <dd className="mt-1">
-                  <StatusBadge status={profile.company_status} />
+                <dd className="mt-1 text-sm text-(--sea-ink)">
+                  {[sponsor.townCity, sponsor.county]
+                    .filter(Boolean)
+                    .map(titleCase)
+                    .join(', ') || 'Not specified'}
                 </dd>
               </div>
-            )}
-            <div>
-              <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                Visa Route
-              </dt>
-              <dd className="mt-1 text-sm text-(--sea-ink)">
-                {titleCase(sponsor.route)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                Rating
-              </dt>
-              <dd className="mt-1 text-sm text-(--sea-ink)">
-                {titleCase(sponsor.typeRating)}
-              </dd>
-            </div>
-          </dl>
-        </div>
-
-        {profile && (
-          <div className="glass mt-4 rounded-lg p-6">
-            <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-              {formatDate(profile.date_of_creation) && (
+              {profile?.company_status && (
                 <div>
                   <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                    Incorporated
+                    Status
                   </dt>
-                  <dd className="mt-1 text-sm text-(--sea-ink)">
-                    {formatDate(profile.date_of_creation)}
+                  <dd className="mt-1">
+                    <StatusBadge status={profile.company_status} />
                   </dd>
                 </div>
               )}
-
-              {profile.type && (
-                <div>
-                  <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                    Company Type
-                  </dt>
-                  <dd className="mt-1 text-sm text-(--sea-ink)">
-                    {titleCase(profile.type.replace(/-/g, ' '))}
-                  </dd>
-                </div>
-              )}
-
-              {profile.accounts?.last_accounts?.made_up_to && (
-                <div>
-                  <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                    Last Accounts Filed
-                  </dt>
-                  <dd className="mt-1 text-sm text-(--sea-ink)">
-                    {formatDate(profile.accounts.last_accounts.made_up_to)}
-                  </dd>
-                </div>
-              )}
-
-              {profile.company_number && (
-                <div>
-                  <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                    Registration No.
-                  </dt>
-                  <dd className="mt-1 text-sm text-(--sea-ink)">
-                    <span x-apple-data-detectors="false">
-                      {profile.company_number}
-                    </span>
-                  </dd>
-                </div>
-              )}
-
-              {formatAddress(profile.registered_office_address) && (
-                <div className="col-span-2 sm:col-span-4">
-                  <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
-                    Registered Address
-                  </dt>
-                  <dd className="mt-1 text-sm">
-                    <a
-                      href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(formatAddress(profile.registered_office_address))}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="no-underline inline-flex items-center gap-1.5 text-(--sea-ink-soft) hover:text-(--sea-ink)"
-                    >
-                      <MapPin size={14} className="shrink-0" />
-                      {formatAddress(profile.registered_office_address)}
-                      <ExternalLink size={12} className="shrink-0" />
-                    </a>
-                  </dd>
-                </div>
-              )}
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                  Visa Route
+                </dt>
+                <dd className="mt-1 text-sm text-(--sea-ink)">
+                  {titleCase(sponsor.route)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                  Rating
+                </dt>
+                <dd className="mt-1 text-sm text-(--sea-ink)">
+                  {titleCase(sponsor.typeRating)}
+                </dd>
+              </div>
             </dl>
           </div>
-        )}
+
+          {profile && (
+            <div className="glass mt-4 rounded-lg p-6">
+              <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                {formatDate(profile.date_of_creation) && (
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                      Incorporated
+                    </dt>
+                    <dd className="mt-1 text-sm text-(--sea-ink)">
+                      {formatDate(profile.date_of_creation)}
+                    </dd>
+                  </div>
+                )}
+
+                {profile.type && (
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                      Company Type
+                    </dt>
+                    <dd className="mt-1 text-sm text-(--sea-ink)">
+                      {titleCase(profile.type.replace(/-/g, ' '))}
+                    </dd>
+                  </div>
+                )}
+
+                {profile.accounts?.last_accounts?.made_up_to && (
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                      Last Accounts Filed
+                    </dt>
+                    <dd className="mt-1 text-sm text-(--sea-ink)">
+                      {formatDate(profile.accounts.last_accounts.made_up_to)}
+                    </dd>
+                  </div>
+                )}
+
+                {profile.company_number && (
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                      Registration No.
+                    </dt>
+                    <dd className="mt-1 text-sm text-(--sea-ink)">
+                      <span x-apple-data-detectors="false">
+                        {profile.company_number}
+                      </span>
+                    </dd>
+                  </div>
+                )}
+
+                {formatAddress(profile.registered_office_address) && (
+                  <div className="col-span-2 sm:col-span-4">
+                    <dt className="text-[10px] font-medium uppercase tracking-wider text-(--sea-ink-soft)">
+                      Registered Address
+                    </dt>
+                    <dd className="mt-1 text-sm">
+                      <a
+                        href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(formatAddress(profile.registered_office_address))}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="no-underline inline-flex items-center gap-1.5 text-(--sea-ink-soft) hover:text-(--sea-ink)"
+                      >
+                        <MapPin size={14} className="shrink-0" />
+                        {formatAddress(profile.registered_office_address)}
+                        <ExternalLink size={12} className="shrink-0" />
+                      </a>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          )}
+        </div>
 
         <Link
           to="/"

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -72,9 +72,9 @@ function Home() {
         <p className="island-kicker mb-3">
           Search UK skilled worker visa sponsors
         </p>
-        <div ref={sentinelRef} className="mt-6" />
+        <div ref={sentinelRef} className="pointer-events-none mt-6" />
         <div
-          className={`z-40 -mx-4 px-4 ${isStuck && pillClicked ? 'fixed left-0 right-0 top-[61px] sm:top-[77px] mx-auto max-w-2xl search-glow pb-4 pt-2' : 'sticky top-[69px] sm:top-[85px] pb-4'}`}
+          className={`pointer-events-none z-40 -mx-4 px-4 ${isStuck && pillClicked ? 'fixed left-0 right-0 top-[61px] sm:top-[77px] mx-auto max-w-2xl search-glow pb-4 pt-2' : 'sticky top-[69px] sm:top-[85px] pb-4'}`}
         >
           <SearchBar
             search={search}
@@ -99,9 +99,11 @@ function Home() {
           />
         </div>
 
-        <Suspense fallback={<SkeletonCards />}>
-          <HmrcResults search={search} />
-        </Suspense>
+        <div className="page-flip-listing">
+          <Suspense fallback={<SkeletonCards />}>
+            <HmrcResults search={search} />
+          </Suspense>
+        </div>
       </section>
     </main>
   );

--- a/apps/web/src/scripts/browser-init.ts
+++ b/apps/web/src/scripts/browser-init.ts
@@ -1,0 +1,24 @@
+/**
+ * Pre-hydration inline script that stamps `data-browser="<name>"` on
+ * `<html>` so CSS can target browser-specific fixes — e.g. dropping
+ * `object-fit: fill` on the active-card view-transition pseudos under
+ * Safari, where it causes cumulative GPU pressure across navigations.
+ * Set as a generic mechanism so future per-browser tweaks (Chrome,
+ * Firefox, Edge) can hang off the same attribute.
+ *
+ * Detection is order-sensitive because Chromium-based browsers also
+ * include "Chrome" / "Safari" tokens in their UA strings — Edge is
+ * checked first, then Firefox, then Chrome, then Safari as the final
+ * fallback for true WebKit.
+ */
+export const BROWSER_INIT_SCRIPT = `(() => {
+  try {
+    const ua = navigator.userAgent;
+    let browser = 'unknown';
+    if (/edg\\//i.test(ua)) browser = 'edge';
+    else if (/firefox/i.test(ua)) browser = 'firefox';
+    else if (/chrome/i.test(ua)) browser = 'chrome';
+    else if (/safari/i.test(ua)) browser = 'safari';
+    document.documentElement.setAttribute('data-browser', browser);
+  } catch (_e) {}
+})();`;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,5 +1,6 @@
 @import "./fonts.css";
 @import "tailwindcss";
+@import "./transitions.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -283,111 +284,7 @@ html[data-hide-search-input] .search-input-wrapper {
 }
 
 /*
- * Page transitions: outgoing page recedes (scale + slight slide + fade),
- * incoming page rises into place (scale + slide + fade). The combined
- * scale + translate gives a subtle "depth pass" feel without long travel
- * distances that can trigger motion sickness. Outgoing distance is small
- * (12%) and dampened with a blur tick so the eye doesn't track it.
+ * Page transitions live in `transitions.css` (imported at the top of
+ * this file). Keep view-transition keyframes, named-region rules, and
+ * browser-specific overrides there — not here.
  */
-@keyframes route-recede-left {
-  from {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-    filter: blur(0);
-  }
-  to {
-    transform: translate3d(-12%, 0, 0) scale(0.96);
-    opacity: 0;
-    filter: blur(4px);
-  }
-}
-
-@keyframes route-rise-from-right {
-  from {
-    transform: translate3d(8%, 0, 0) scale(0.985);
-    opacity: 0;
-    filter: blur(2px);
-    clip-path: inset(0 0 0 50%);
-  }
-  60% {
-    filter: blur(0);
-  }
-  to {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-    filter: blur(0);
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-@keyframes route-recede-right {
-  from {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-    filter: blur(0);
-  }
-  to {
-    transform: translate3d(12%, 0, 0) scale(0.96);
-    opacity: 0;
-    filter: blur(4px);
-  }
-}
-
-@keyframes route-rise-from-left {
-  from {
-    transform: translate3d(-8%, 0, 0) scale(0.985);
-    opacity: 0;
-    filter: blur(2px);
-    clip-path: inset(0 50% 0 0);
-  }
-  60% {
-    filter: blur(0);
-  }
-  to {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-    filter: blur(0);
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-::view-transition-group(root) {
-  animation-duration: 280ms;
-}
-
-::view-transition-old(root) {
-  animation-duration: 200ms;
-  animation-timing-function: cubic-bezier(0.4, 0, 1, 1);
-  animation-fill-mode: forwards;
-  mix-blend-mode: normal;
-  transform-origin: center center;
-}
-
-::view-transition-new(root) {
-  animation-duration: 280ms;
-  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-  animation-fill-mode: forwards;
-  mix-blend-mode: normal;
-  transform-origin: center center;
-}
-
-html:active-view-transition-type(forward)::view-transition-old(root) {
-  animation-name: route-recede-left;
-}
-html:active-view-transition-type(forward)::view-transition-new(root) {
-  animation-name: route-rise-from-right;
-}
-
-html:active-view-transition-type(back)::view-transition-old(root) {
-  animation-name: route-recede-right;
-}
-html:active-view-transition-type(back)::view-transition-new(root) {
-  animation-name: route-rise-from-left;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    animation: none;
-  }
-}

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -67,65 +67,27 @@
   }
 }
 
-/*
- * Listing wrapper fades in/out — only the surrounding cards animate via
- * this keyframe. The clicked card is carved out as `active-card` and gets
- * its own slide animation below.
- */
-@keyframes listing-fade-out {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes listing-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-/*
- * Each page assigns a distinct view-transition-name to its results wrapper.
- * Because each name only exists on one page, the browser never pairs them
- * as a single morphing snapshot — the listing wrapper has only an outgoing
- * snapshot, the details wrapper has only an incoming one. That avoids the
- * positional interpolation you'd get with a shared name when the two
- * wrappers sit at different y-offsets on each page.
- */
-.page-flip-listing {
-  view-transition-name: results-listing;
-}
-
 /* Shares the `active-card` name with the clicked card on the listing so
    the browser pairs them as a single shared element — the card morphs
-   into the details wrapper on forward. */
+   into the details wrapper on forward. The surrounding listing is
+   intentionally NOT named: a named region whose bbox extends above the
+   viewport (because the user scrolled) renders its snapshot in front of
+   `root` and visually covers the header. Keeping the listing in `root`
+   means the live header (in NEW root) sits in front for the entire
+   transition. */
 .page-flip-details {
   view-transition-name: active-card;
 }
 
 /*
- * On back-nav the named regions are dropped so the entire page (header
- * included) is captured into a single `root` snapshot. Without this, a
- * tall listing wrapper whose bbox extends above the viewport would carve
- * a hole out of root that covers the header — making the header
- * invisible during the slide and "pop back" when the live DOM takes over.
+ * On back-nav the active-card name is dropped so the entire page is
+ * captured into a single `root` snapshot and animates as one piece.
+ * (A shrink-back morph isn't practical here — the listing is virtualized
+ * and scroll-restored asynchronously, so the morph target isn't reliably
+ * in the DOM at NEW-snapshot capture time. See CLAUDE.md.)
  */
-html:active-view-transition-type(back) .page-flip-listing,
 html:active-view-transition-type(back) .page-flip-details {
   view-transition-name: none;
-}
-
-::view-transition-old(results-listing),
-::view-transition-new(results-listing) {
-  animation-fill-mode: both;
-  mix-blend-mode: normal;
-  transform-origin: center center;
 }
 
 /*
@@ -169,7 +131,6 @@ html:active-view-transition-type(back) .page-flip-details {
  * `!important` because the name is set as an inline style by HmrcCard
  * — that's the only way to beat inline-style specificity from CSS.
  */
-html[data-browser="safari"] .page-flip-listing,
 html[data-browser="safari"] .page-flip-details {
   view-transition-name: none;
 }
@@ -196,13 +157,6 @@ html[data-browser="safari"]:active-view-transition-type(
   )::view-transition-new(root) {
   animation: route-rise-from-right 280ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   transform-origin: center center;
-}
-
-/* Forward: surrounding listing fades out under the morphing card. */
-html:active-view-transition-type(forward)::view-transition-old(
-    results-listing
-  ) {
-  animation: listing-fade-out 180ms ease-out forwards;
 }
 
 ::view-transition-group(root),
@@ -243,8 +197,6 @@ html:active-view-transition-type(back)::view-transition-new(root) {
   ::view-transition-old(root),
   ::view-transition-new(root),
   ::view-transition-group(active-card),
-  ::view-transition-old(results-listing),
-  ::view-transition-new(results-listing),
   ::view-transition-old(active-card),
   ::view-transition-new(active-card) {
     animation: none;

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -239,6 +239,9 @@ html:active-view-transition-type(back)::view-transition-new(root) {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(root),
+  ::view-transition-old(root),
+  ::view-transition-new(root),
   ::view-transition-group(active-card),
   ::view-transition-old(results-listing),
   ::view-transition-new(results-listing),

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -1,0 +1,249 @@
+/*
+ * Page transitions: outgoing page recedes (scale + slight slide + fade),
+ * incoming page rises into place (scale + slide + fade). The combined
+ * scale + translate gives a subtle "depth pass" feel without long travel
+ * distances that can trigger motion sickness. Outgoing distance is small
+ * (12%) and dampened with a blur tick so the eye doesn't track it.
+ */
+@keyframes route-recede-left {
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  to {
+    transform: translate3d(-12%, 0, 0) scale(0.96);
+    opacity: 0;
+    filter: blur(4px);
+  }
+}
+
+@keyframes route-rise-from-right {
+  from {
+    transform: translate3d(8%, 0, 0) scale(0.985);
+    opacity: 0;
+    filter: blur(2px);
+    clip-path: inset(0 0 0 50%);
+  }
+  60% {
+    filter: blur(0);
+  }
+  to {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: blur(0);
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes route-recede-right {
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+  to {
+    transform: translate3d(12%, 0, 0) scale(0.96);
+    opacity: 0;
+    filter: blur(4px);
+  }
+}
+
+@keyframes route-rise-from-left {
+  from {
+    transform: translate3d(-8%, 0, 0) scale(0.985);
+    opacity: 0;
+    filter: blur(2px);
+    clip-path: inset(0 50% 0 0);
+  }
+  60% {
+    filter: blur(0);
+  }
+  to {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: blur(0);
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+/*
+ * Listing wrapper fades in/out — only the surrounding cards animate via
+ * this keyframe. The clicked card is carved out as `active-card` and gets
+ * its own slide animation below.
+ */
+@keyframes listing-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes listing-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/*
+ * Each page assigns a distinct view-transition-name to its results wrapper.
+ * Because each name only exists on one page, the browser never pairs them
+ * as a single morphing snapshot — the listing wrapper has only an outgoing
+ * snapshot, the details wrapper has only an incoming one. That avoids the
+ * positional interpolation you'd get with a shared name when the two
+ * wrappers sit at different y-offsets on each page.
+ */
+.page-flip-listing {
+  view-transition-name: results-listing;
+}
+
+/* Shares the `active-card` name with the clicked card on the listing so
+   the browser pairs them as a single shared element — the card morphs
+   into the details wrapper on forward. */
+.page-flip-details {
+  view-transition-name: active-card;
+}
+
+/*
+ * On back-nav the named regions are dropped so the entire page (header
+ * included) is captured into a single `root` snapshot. Without this, a
+ * tall listing wrapper whose bbox extends above the viewport would carve
+ * a hole out of root that covers the header — making the header
+ * invisible during the slide and "pop back" when the live DOM takes over.
+ */
+html:active-view-transition-type(back) .page-flip-listing,
+html:active-view-transition-type(back) .page-flip-details {
+  view-transition-name: none;
+}
+
+::view-transition-old(results-listing),
+::view-transition-new(results-listing) {
+  animation-fill-mode: both;
+  mix-blend-mode: normal;
+  transform-origin: center center;
+}
+
+/*
+ * Active card morph: the browser pairs the listing card with the details
+ * wrapper (both share `view-transition-name: active-card`) and animates
+ * the group's bbox from the small card to the full-size wrapper — which
+ * produces the magnify-in / shrink-back effect. We just tune the timing
+ * and let the default cross-fade between the two snapshots run.
+ */
+::view-transition-group(active-card) {
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+::view-transition-old(active-card),
+::view-transition-new(active-card) {
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+  mix-blend-mode: normal;
+  /* Force the snapshot to fill the morphing group bbox. Without this the
+     browser keeps the snapshot at its captured natural size and the
+     image-pair just clips a smaller window onto it as the group shrinks
+     — which reads as "the card disappears" rather than "the card shrinks".
+     `object-fit: fill` stretches the snapshot to match the group at every
+     frame, so the rendered content visibly scales with the morph. */
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+}
+
+/*
+ * Safari: skip the shared-element morph entirely and use the original
+ * page-level slide that was on main before the morph was added. Drop
+ * the named regions so the whole page is captured into a single `root`
+ * snapshot, then animate root with the same recede-left / rise-from-
+ * right pattern used on back. WebKit handles a single root pair
+ * cleanly without the cumulative GPU pressure that the active-card
+ * pairing was causing.
+ *
+ * The override on the listing card uses an attribute selector +
+ * `!important` because the name is set as an inline style by HmrcCard
+ * — that's the only way to beat inline-style specificity from CSS.
+ */
+html[data-browser="safari"] .page-flip-listing,
+html[data-browser="safari"] .page-flip-details {
+  view-transition-name: none;
+}
+html[data-browser="safari"] .page-flip-listing [style*="view-transition-name"] {
+  /* biome-ignore lint: needed to override the inline view-transition-name set by HmrcCard */
+  view-transition-name: none !important;
+}
+
+/* Forward root animation for Safari. Higher specificity than the shared
+   `forward root: animation: none` rule below, so it wins on Safari. */
+html[data-browser="safari"]:active-view-transition-type(
+    forward
+  )::view-transition-group(root) {
+  animation-duration: 280ms;
+}
+html[data-browser="safari"]:active-view-transition-type(
+    forward
+  )::view-transition-old(root) {
+  animation: route-recede-left 200ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  transform-origin: center center;
+}
+html[data-browser="safari"]:active-view-transition-type(
+    forward
+  )::view-transition-new(root) {
+  animation: route-rise-from-right 280ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  transform-origin: center center;
+}
+
+/* Forward: surrounding listing fades out under the morphing card. */
+html:active-view-transition-type(forward)::view-transition-old(
+    results-listing
+  ) {
+  animation: listing-fade-out 180ms ease-out forwards;
+}
+
+::view-transition-group(root),
+::view-transition-old(root),
+::view-transition-new(root) {
+  mix-blend-mode: normal;
+}
+
+/* Forward: root stays put — only the active-card group morphs and the
+   listing wrapper fades. */
+html:active-view-transition-type(forward)::view-transition-group(root),
+html:active-view-transition-type(forward)::view-transition-old(root),
+html:active-view-transition-type(forward)::view-transition-new(root) {
+  animation: none;
+}
+
+/*
+ * Back: page-level slide. With no named regions carved out on back, the
+ * whole page (header, footer, content) is captured into the `root`
+ * snapshot and animates as one piece — old recedes right, new rises in
+ * from the left. The header stays in its normal stacking position so
+ * it never gets covered by a tall listing snapshot mid-animation.
+ */
+html:active-view-transition-type(back)::view-transition-group(root) {
+  animation-duration: 380ms;
+}
+html:active-view-transition-type(back)::view-transition-old(root) {
+  animation: route-recede-right 280ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  transform-origin: center center;
+}
+html:active-view-transition-type(back)::view-transition-new(root) {
+  animation: route-rise-from-left 380ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  transform-origin: center center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(active-card),
+  ::view-transition-old(results-listing),
+  ::view-transition-new(results-listing),
+  ::view-transition-old(active-card),
+  ::view-transition-new(active-card) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Since Safari has known viewTransition performance issues we revert to the basic page transitions for this browser. However on Chrome we apply a card morphing animation to improve UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directional page transitions with reliable card→detail morph and preserved selected-card animation
  * Browser-detection script to enable targeted animation fallbacks and Safari-safe behavior
  * Active-card activation state persisted to restore scroll/selection during navigation

* **Refactor**
  * Transition styles consolidated into a dedicated transitions module

* **Bug Fixes**
  * More robust scroll restoration and search-input visibility timing

* **Documentation**
  * Added guide explaining where and how transition rules are applied
<!-- end of auto-generated comment: release notes by coderabbit.ai -->