### PR TITLE
experimental: migrate from react -> redact (thanks to Tanner Linsley and team)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/react-virtual": "^3.13.23",
-    "@tanstack/redact": "^0.0.10",
+    "@ss/redact": "workspace:*",
     "@tanstack/router-plugin": "^1.132.0",
     "@tanstack/start-server-core": "^1.167.18",
     "@vercel/analytics": "^2.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@mcp-b/global": "^2.2.0",
     "@ss/db": "workspace:*",
-    "virtual-text-layout": "0.2.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",
     "@tanstack/react-query": "^5.96.2",
@@ -40,6 +39,7 @@
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/react-virtual": "^3.13.23",
+    "@tanstack/redact": "^0.0.10",
     "@tanstack/router-plugin": "^1.132.0",
     "@tanstack/start-server-core": "^1.167.18",
     "@vercel/analytics": "^2.0.1",
@@ -55,6 +55,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.18",
+    "virtual-text-layout": "0.2.0",
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
@@ -65,14 +66,14 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^6.0.1",
     "drizzle-kit": "^0.31.10",
     "h3": "^2.0.1-rc.20",
     "jsdom": "^28.1.0",
     "playwright": "^1.59.1",
     "portless": "^0.10.1",
     "sharp": "^0.34.5",
-    "vite": "^7.3.1",
+    "vite": "^8.0.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
-import { redact } from '@tanstack/redact/vite';
+import { redact } from '@ss/redact/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import dotenv from 'dotenv';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,5 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
+import { redact } from '@tanstack/redact/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import dotenv from 'dotenv';
@@ -11,6 +12,7 @@ dotenv.config({ path: '../../.env.local' });
 
 const config = defineConfig({
   plugins: [
+    redact(),
     devtools(),
     tsconfigPaths({ projects: ['./tsconfig.json'] }),
     tailwindcss(),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,6 @@
+import { redact } from '@ss/redact/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
-import { redact } from '@ss/redact/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import dotenv from 'dotenv';

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "dependencies": {
         "@mcp-b/global": "^2.2.0",
         "@ss/db": "workspace:*",
+        "@ss/redact": "workspace:*",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-devtools": "latest",
         "@tanstack/react-query": "^5.96.2",
@@ -33,7 +34,6 @@
         "@tanstack/react-router-ssr-query": "latest",
         "@tanstack/react-start": "latest",
         "@tanstack/react-virtual": "^3.13.23",
-        "@tanstack/redact": "^0.0.10",
         "@tanstack/router-plugin": "^1.132.0",
         "@tanstack/start-server-core": "^1.167.18",
         "@vercel/analytics": "^2.0.1",
@@ -78,6 +78,20 @@
         "@neondatabase/serverless": "^1.0.2",
         "drizzle-orm": "^0.45.2",
       },
+    },
+    "packages/redact": {
+      "name": "@ss/redact",
+      "version": "0.0.0",
+      "devDependencies": {
+        "esbuild": "^0.28.0",
+        "typescript": "^5.7.2",
+      },
+      "peerDependencies": {
+        "vite": ">=5",
+      },
+      "optionalPeers": [
+        "vite",
+      ],
     },
   },
   "packages": {
@@ -179,57 +193,57 @@
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
@@ -419,6 +433,8 @@
 
     "@ss/db": ["@ss/db@workspace:packages/db"],
 
+    "@ss/redact": ["@ss/redact@workspace:packages/redact"],
+
     "@ss/web": ["@ss/web@workspace:apps/web"],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -496,8 +512,6 @@
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
-
-    "@tanstack/redact": ["@tanstack/redact@0.0.10", "", { "peerDependencies": { "vite": ">=5" }, "optionalPeers": ["vite"] }, "sha512-W7V1KXgLjB+zYbvTzvElYAygilYVYEKejWgePzQGlsDUp2l07JwUtMbhtguY7X/dSo/8lbOc5OkQpNYeKSxSPA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
@@ -751,7 +765,7 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1243,6 +1257,8 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -1330,6 +1346,58 @@
     "@vitest/mocker/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@vitest/mocker/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "drizzle-kit/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "drizzle-kit/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "drizzle-kit/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "drizzle-kit/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "drizzle-kit/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "drizzle-kit/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "drizzle-kit/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "drizzle-kit/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "drizzle-kit/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "drizzle-kit/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "drizzle-kit/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "drizzle-kit/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "drizzle-kit/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "drizzle-kit/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "drizzle-kit/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "drizzle-kit/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@tanstack/react-router-ssr-query": "latest",
         "@tanstack/react-start": "latest",
         "@tanstack/react-virtual": "^3.13.23",
+        "@tanstack/redact": "^0.0.10",
         "@tanstack/router-plugin": "^1.132.0",
         "@tanstack/start-server-core": "^1.167.18",
         "@vercel/analytics": "^2.0.1",
@@ -59,14 +60,14 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react": "^6.0.1",
         "drizzle-kit": "^0.31.10",
         "h3": "^2.0.1-rc.20",
         "jsdom": "^28.1.0",
         "playwright": "^1.59.1",
         "portless": "^0.10.1",
         "sharp": "^0.34.5",
-        "vite": "^7.3.1",
+        "vite": "^8.0.3",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.5",
       },
@@ -122,10 +123,6 @@
 
     "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
 
-    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
-
-    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
-
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
@@ -172,7 +169,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -310,7 +307,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.2", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw=="],
 
@@ -322,39 +319,39 @@
 
     "@oozcitak/util": ["@oozcitak/util@10.0.0", "", {}, "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+    "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.18", "", { "os": "freebsd", "cpu": "x64" }, "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm" }, "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "s390x" }, "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.18", "", { "os": "linux", "cpu": "x64" }, "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.18", "", { "os": "linux", "cpu": "x64" }, "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.18", "", { "os": "none", "cpu": "arm64" }, "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.18", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.18", "", { "os": "win32", "cpu": "x64" }, "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
 
@@ -482,45 +479,47 @@
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.99.0", "", { "dependencies": { "@tanstack/query-devtools": "5.99.0" }, "peerDependencies": { "@tanstack/react-query": "^5.99.0", "react": "^18 || ^19" } }, "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.23", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.15", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/react-router": "^1.168.15", "@tanstack/router-core": "^1.168.11", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA=="],
 
-    "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.166.11", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.167.1" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-i81a5avRWgTjSKH5VYttbQ/Y86Il8GIkdcrIlyYUys0Lt1zMCxkTGHH9lBN5ZmhBe3mzwQ+9jOlx9xSxj8Kx0w=="],
+    "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.166.12", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.168.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-yDUIoEh+PimAcWmk/2BE0EkI8TwLVeToNzoIuwahmTtBUR+ptZPWbtiPjudO8JZ0BhT3odHtuOn1eBOK0/4NAQ=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.167.44", "", { "dependencies": { "@tanstack/react-router": "1.168.23", "@tanstack/react-start-client": "1.166.40", "@tanstack/react-start-rsc": "0.0.23", "@tanstack/react-start-server": "1.166.41", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-plugin-core": "1.169.0", "@tanstack/start-server-core": "1.167.19", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"], "bin": { "intent": "bin/intent.js" } }, "sha512-xyGZHwjtn9m1b1E4pxccORX4tkL8BIMbomus/eDpOkfVbjWYvX4Q3rwprJK3qNxYg6YaVuWXa66yRpAT0h/2zA=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.167.65", "", { "dependencies": { "@tanstack/react-router": "1.169.2", "@tanstack/react-start-client": "1.166.48", "@tanstack/react-start-rsc": "0.0.44", "@tanstack/react-start-server": "1.166.52", "@tanstack/router-utils": "1.161.8", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-plugin-core": "1.169.20", "@tanstack/start-server-core": "1.167.30", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-vCGga3RECeR4VpSVuXIU/+zxak5f2qdpUXdZ2yrgcwwKoYPtatdJm6zjS0Py7UOecRqLqMtSeuOjowBJ1higWQ=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.40", "", { "dependencies": { "@tanstack/react-router": "1.168.23", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-ynjRe8YjaPfcQNEaQ3nE2/zIZNCdyVGew0pHK5lCorqEy3z/YuiKlj5ZXPmel7XGw0XoKsDIH2eXnUtTbIwpjg=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.48", "", { "dependencies": { "@tanstack/react-router": "1.169.2", "@tanstack/router-core": "1.169.2", "@tanstack/start-client-core": "1.168.2" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-6fqwCwe6v+Nvtdf6vg6gxs/0gCXyZEHF18EslNeG/kca2wnXYFuXRhqGJjJaEgMk3WF4IE9mUgFuBSAOY3P7nQ=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.0.23", "", { "dependencies": { "@tanstack/react-router": "1.168.23", "@tanstack/react-start-server": "1.166.41", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-plugin-core": "1.169.0", "@tanstack/start-server-core": "1.167.19", "@tanstack/start-storage-context": "1.166.29", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-bEDmSAZgHOEqsDxH9QdKlYnVnb6108J9Fy7R0KgHmiFoFtt6S43gKpUEqhCqJkzaMw+f3vemcNv7g23B8O5pnA=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.0.44", "", { "dependencies": { "@tanstack/react-router": "1.169.2", "@tanstack/react-start-server": "1.166.52", "@tanstack/router-core": "1.169.2", "@tanstack/router-utils": "1.161.8", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-plugin-core": "1.169.20", "@tanstack/start-server-core": "1.167.30", "@tanstack/start-storage-context": "1.166.35", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-5iYUWSBjTwJbV8bTLJHZ5dHm8c/79J6spxPlKsjt9/R0mQaQQjLVNMpv5CrOZ2vPTaZx1ALoGdSWP4WdPcuKRA=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.41", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.168.23", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-server-core": "1.167.19" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-Z0kyOeraz5nHE7DYh4brYetYoXvh3wjNNI3fJZ0+OzGODfNUgZtEQg/f1g1f1kj64irgWIuWTVPi3rOwiPSzYw=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.52", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.169.2", "@tanstack/router-core": "1.169.2", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-server-core": "1.167.30" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-46Gx+byIndYywUtyna5h3qatHipJkPFqo/miexfuYPgeVAI6ypQzsw7wxF194H6VAP43m2q+fdLPBXStufoOGw=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.15", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA=="],
+    "@tanstack/redact": ["@tanstack/redact@0.0.10", "", { "peerDependencies": { "vite": ">=5" }, "optionalPeers": ["vite"] }, "sha512-W7V1KXgLjB+zYbvTzvElYAygilYVYEKejWgePzQGlsDUp2l07JwUtMbhtguY7X/dSo/8lbOc5OkQpNYeKSxSPA=="],
+
+    "@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.33", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "magic-string": "^0.30.21", "prettier": "^3.5.0", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-MXP1WrEaZ13tlO5iJoXC+ZIFHNj5CtcvWuqlAZ3zXY70Musuq+mfUcKWMVdcIstnNqrZl5M2hfqLh5Zf5t4NVw=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.42", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.23", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.33", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.168.23", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-dqfCd8gsZThbVQ8bcYMO62/hW5GCkUoPLnnjOd3fCWoEi+Ei5oWa/GnlgHCpG7bdeGr/K8isnYUmI9Ysq5vLrg=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.35", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-generator": "1.166.42", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.169.2", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-UAScU5VAzLYVY4FML/Cbc5S5TucT4I8Ata05yozGOe4ZfepTKRffA5xWLtD2N+ov5svdv0KTX/kqlZnYPe28mA=="],
 
-    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.167.1", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-sJNRHa36lfuHw04akO9C6KU1P1Ncam2Azsk5XlgdQHMFgOtSlFAsuwqAHpyYSwu5Jyxj6P3PmyKYMIm4u8dI7Q=="],
+    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.168.0", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-5yBUAF1d9z2kOFKoz1spvpvkMSTmRnRXEwi+bGKfrXYmt7CfHu3Pk8KUFMln67uQoKQ9VTkcd5tLkjJVrZ2/AQ=="],
 
-    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.7", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng=="],
+    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.8", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-xyiLWEKjfBAVhauDSSjXxyf7s8elU6SM+V050sbkofvGmIIvkwPFtDsX7Gvwh14kBd6iCwAT+RiPvXTxAptY0Q=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.17", "", { "dependencies": { "@tanstack/router-core": "1.168.15", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.29", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-3ZnpQ0LPnhrm/GX+HT7XfRxTcqnmBE1KJd7LtaJNuN13NH0C4ZOWchKLPEed2/gluhgsT6UgWm+Ec0kEFtxSaw=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.168.2", "", { "dependencies": { "@tanstack/router-core": "1.169.2", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.35", "seroval": "^1.5.4" } }, "sha512-/bckv9k/yxY4VmSY2V2MeX7NBsS5uqGvdSPs5WIvW3Uv35DXPrdiumKXTNJeZRNRMtxrM+YfxQPjXLx3C7ykvg=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.161.6", "", {}, "sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.169.0", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.33", "@tanstack/router-plugin": "1.167.23", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-server-core": "1.167.19", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.0", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-53l4ijLfQ2ZdUVuVBCrKNeMVnubnO7xEr+d1YONzQ4/xxkfIakLC89HyDUV9xzIfvr52s60mfyWcwdMY1bM5+A=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.169.20", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.169.2", "@tanstack/router-generator": "1.166.42", "@tanstack/router-plugin": "1.167.35", "@tanstack/router-utils": "1.161.8", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-server-core": "1.167.30", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-MLSH5P3auFpnol1lMGQhUrpJH7+P5knzBXMnJjXG+nVOvmcYbY0JA+nQMl81kKiqfkEceAiaEdKhl8Zc5Ldolw=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.19", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-storage-context": "1.166.29", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-wzOdfzLsK91CnjoywnEjXSlVlaRVK99HJhyVijNU1TECBI2JEKvW9S6d14YfS4gD4fFH4V86tFYhkcLPe6nzWg=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.30", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.2", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-storage-context": "1.166.35", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-GC0PXzYYSEwfAOC2NxGXFUyYvfbSjVoqnIrzJsyInKd8xQxGEQaVdrebbyx9TV5cj7A5e7EJcWAsf3G3wRDQBw=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.29", "", { "dependencies": { "@tanstack/router-core": "1.168.15" } }, "sha512-KrJYudc1nbnTY43jdN+hQFMYkhz7+3T+hkgBoGnIP1OspSe6vGQaYGDB4EUXYnkLfyQp+iUuKubgS8hSKeJ0ng=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.35", "", { "dependencies": { "@tanstack/router-core": "1.169.2" } }, "sha512-ZKDkKiorJrKwfEHjatEwRHG7EP3raJPhh6CSl4CFmHW0naIvwaW5gQcxcT8IlHtoGDLYDAjBEcSr3MZyXgqmOA=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -547,14 +546,6 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
-
-    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
-
-    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
-
-    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
-
-    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
@@ -584,7 +575,7 @@
 
     "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -601,8 +592,6 @@
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -789,6 +778,8 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -1000,7 +991,7 @@
 
     "portless": ["portless@0.10.1", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-WSzw0bW5tKoK8TIrOr54T43jc0A35XR6RApGEhlbBOl8NgugfQTD3EGKwqE2jjEdcNtPG5WHH/dXzxgVIoY4hw=="],
 
-    "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
@@ -1032,15 +1023,13 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
-
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+    "rolldown": ["rolldown@1.0.0-rc.18", "", { "dependencies": { "@oxc-project/types": "=0.128.0", "@rolldown/pluginutils": "1.0.0-rc.18" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-x64": "1.0.0-rc.18", "@rolldown/binding-freebsd-x64": "1.0.0-rc.18", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
@@ -1058,9 +1047,9 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1156,7 +1145,7 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
-    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+    "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
     "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
@@ -1170,7 +1159,7 @@
 
     "virtual-text-layout": ["virtual-text-layout@0.2.0", "", { "dependencies": { "@chenglou/pretext": "^0.0.6" }, "peerDependencies": { "react": ">=18" } }, "sha512-ViRvVJg7gwRsubA2lcAFtOmoq4GCeigp4zDwLIhJjdTT49WF1STBSUOoXcmRkfBCoXFZBzTYp2yP7q+poLdSAw=="],
 
-    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
@@ -1222,6 +1211,8 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
@@ -1234,9 +1225,13 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
+
+    "@vitest/mocker/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -1252,15 +1247,21 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "nitro/rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "solid-js/seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
+
+    "solid-js/seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1272,9 +1273,11 @@
 
     "unstorage/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
-
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite-node/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -1321,6 +1324,46 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@vitest/mocker/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "@vitest/mocker/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@vitest/mocker/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "nitro/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "nitro/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "nitro/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "nitro/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "nitro/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "nitro/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "nitro/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1376,56 +1419,176 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
-    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "vite-node/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "vite-node/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "vite-node/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
-    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "vitest/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "vitest/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
-    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
-    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
 
-    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
 
-    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
 
-    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
 
-    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
 
-    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
 
-    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
 
-    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
 
-    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
 
-    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
 
-    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
 
-    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
 
-    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
 
-    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
 
-    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
 
-    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
 
-    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
 
-    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
 
-    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@vitest/mocker/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,9 @@
       "version": "0.0.0",
       "devDependencies": {
         "esbuild": "^0.28.0",
+        "jsdom": "^25.0.1",
         "typescript": "^5.7.2",
+        "vitest": "^2.1.8",
       },
       "peerDependencies": {
         "vite": ">=5",
@@ -99,7 +101,7 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.82.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ=="],
 
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.10", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww=="],
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.8.1", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.6" } }, "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ=="],
 
@@ -169,17 +171,17 @@
 
     "@chenglou/pretext": ["@chenglou/pretext@0.0.6", "", {}, "sha512-U10s4tFeyu3oVHfXuNWwZSKqHXefhaigpcBkGj60qQFRJ+yUoQ+ez3cGJelP7BWDAB58HCgjcTSmOcg+77afBQ=="],
 
-    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
-    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
 
-    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
 
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
 
-    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -591,19 +593,19 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
-    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 
-    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
 
-    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
 
-    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
 
-    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -626,6 +628,8 @@
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
@@ -671,6 +675,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
@@ -699,13 +705,13 @@
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
-    "cssstyle": ["cssstyle@6.2.0", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.28", "css-tree": "^3.1.0", "lru-cache": "^11.2.6" } }, "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig=="],
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "csv-parse": ["csv-parse@6.2.1", "", {}, "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="],
 
-    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
@@ -716,6 +722,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -765,6 +773,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -799,6 +809,8 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -831,13 +843,15 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "hookable": ["hookable@6.1.0", "", {}, "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw=="],
 
-    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
@@ -849,7 +863,7 @@
 
     "httpxy": ["httpxy@0.5.0", "", {}, "sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -881,7 +895,7 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "jsdom": ["jsdom@28.1.0", "", { "dependencies": { "@acemir/cssom": "^0.9.31", "@asamuzakjp/dom-selector": "^6.8.1", "@bramus/specificity": "^2.4.2", "@exodus/bytes": "^1.11.0", "cssstyle": "^6.0.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "undici": "^7.21.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug=="],
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -937,9 +951,9 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -957,6 +971,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -971,7 +987,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
 
@@ -983,7 +999,7 @@
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
-    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
@@ -1050,6 +1066,8 @@
     "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -1119,21 +1137,21 @@
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
-    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
 
-    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
-    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
@@ -1175,25 +1193,25 @@
 
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
-    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
-    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
-    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1217,6 +1235,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1226,6 +1246,10 @@
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@ss/web/jsdom": ["jsdom@28.1.0", "", { "dependencies": { "@acemir/cssom": "^0.9.31", "@asamuzakjp/dom-selector": "^6.8.1", "@bramus/specificity": "^2.4.2", "@exodus/bytes": "^1.11.0", "cssstyle": "^6.0.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "undici": "^7.21.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug=="],
+
+    "@ss/web/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -1239,41 +1263,49 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/react-start/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@tanstack/react-start-rsc/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@tanstack/router-utils/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
 
-    "@vitest/mocker/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "@tanstack/start-plugin-core/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "nitro/rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
-    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "solid-js/seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
 
@@ -1287,15 +1319,17 @@
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "unstorage/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vite-node/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
-    "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
-
-    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1341,11 +1375,45 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
-    "@vitest/mocker/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "@ss/web/jsdom/cssstyle": ["cssstyle@6.2.0", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.28", "css-tree": "^3.1.0", "lru-cache": "^11.2.6" } }, "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig=="],
 
-    "@vitest/mocker/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "@ss/web/jsdom/data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
-    "@vitest/mocker/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+    "@ss/web/jsdom/html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "@ss/web/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "@ss/web/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "@ss/web/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "@ss/web/jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "@ss/web/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "@ss/web/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@ss/web/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@ss/web/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@ss/web/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@ss/web/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@ss/web/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@ss/web/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@ss/web/vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@ss/web/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@ss/web/vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "@ss/web/vitest/vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -1399,6 +1467,8 @@
 
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
     "nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
@@ -1432,6 +1502,8 @@
     "nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
     "nitro/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1485,178 +1557,190 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "unstorage/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
-    "vite-node/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "vite-node/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vite-node/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
-
-    "vitest/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vitest/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.10", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "@ss/web/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "@ss/web/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "@ss/web/vitest/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "@ss/web/vitest/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "@ss/web/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "@vitest/mocker/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "@vitest/mocker/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@ss/web/vitest/vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "nitro/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
 
-    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
 
-    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
 
-    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
 
-    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
 
-    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
 
-    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
 
-    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
 
-    "vite-node/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
 
-    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
 
-    "vite-node/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
-    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
-    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
 
-    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
 
-    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
 
-    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
 
-    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
 
-    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
 
-    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
 
-    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
 
-    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
 
-    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
 
-    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
 
-    "vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
 
-    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
-    "vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color/@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
 
-    "vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color/@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
 
-    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color/@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
 
-    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color/@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
-    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+    "@ss/web/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
-    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@ss/web/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@ss/web/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@ss/web/jsdom/cssstyle/@asamuzakjp/css-color/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
   }
 }

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -72,7 +72,9 @@
     "./dist/dom/_all.js"
   ],
   "scripts": {
-    "build": "bun scripts/build.mjs"
+    "build": "bun scripts/build.mjs",
+    "test": "vitest run --config tests/vitest.config.ts",
+    "test:watch": "vitest --config tests/vitest.config.ts"
   },
   "peerDependencies": {
     "vite": ">=5"
@@ -84,6 +86,8 @@
   },
   "devDependencies": {
     "esbuild": "^0.28.0",
-    "typescript": "^5.7.2"
+    "jsdom": "^25.0.1",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@ss/redact",
+  "version": "0.0.0",
+  "description": "Vendored @tanstack/redact (React-API-compatible drop-in) — local fork carrying SVG-attribute aliasing pending upstream PR.",
+  "private": true,
+  "type": "module",
+  "main": "./dist/react/index.js",
+  "module": "./dist/react/index.js",
+  "types": "./dist/react/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/react/index.d.ts",
+      "default": "./dist/react/index.js"
+    },
+    "./jsx-runtime": {
+      "types": "./dist/react/jsx-runtime.d.ts",
+      "default": "./dist/react/jsx-runtime.js"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./dist/react/jsx-runtime.d.ts",
+      "default": "./dist/react/jsx-runtime.js"
+    },
+    "./compiler-runtime": {
+      "types": "./dist/react/compiler-runtime.d.ts",
+      "default": "./dist/react/compiler-runtime.js"
+    },
+    "./dom": {
+      "types": "./dist/dom/index.d.ts",
+      "default": "./dist/dom/index.js"
+    },
+    "./dom-client": {
+      "types": "./dist/dom/client.d.ts",
+      "default": "./dist/dom/client.js"
+    },
+    "./dom-test-utils": {
+      "types": "./dist/dom/test-utils.d.ts",
+      "default": "./dist/dom/test-utils.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "default": "./dist/server/index.js"
+    },
+    "./scheduler": {
+      "types": "./dist/scheduler/index.d.ts",
+      "default": "./dist/scheduler/index.js"
+    },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "default": "./dist/vite/index.js"
+    },
+    "./features/*": {
+      "types": "./dist/dom/features/*.d.ts",
+      "default": "./dist/dom/features/*.js"
+    },
+    "./_all": {
+      "types": "./dist/dom/_all.d.ts",
+      "default": "./dist/dom/_all.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": [
+    "./src/dom/features/**",
+    "./dist/dom/features/**",
+    "./src/dom/index.ts",
+    "./src/dom/client.ts",
+    "./src/dom/_all.ts",
+    "./dist/dom/index.js",
+    "./dist/dom/client.js",
+    "./dist/dom/_all.js"
+  ],
+  "scripts": {
+    "build": "bun scripts/build.mjs"
+  },
+  "peerDependencies": {
+    "vite": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/redact/scripts/build.mjs
+++ b/packages/redact/scripts/build.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Build @ss/redact to dist/.
+//
+// Each TS module under src/ is emitted as its own dist file with relative
+// imports preserved literally — that keeps a single runtime instance of
+// every module no matter which subpath the consumer imports first, and
+// preserves the import-graph boundaries the redact() Vite plugin needs at
+// consumer-build time to swap features/<name>/index.js → stub.js.
+import { build } from 'esbuild'
+import { execSync } from 'node:child_process'
+import {
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkgDir = resolve(__dirname, '..')
+const srcDir = resolve(pkgDir, 'src')
+const distDir = resolve(pkgDir, 'dist')
+
+function listTsFiles(dir) {
+  const out = []
+  for (const name of readdirSync(dir)) {
+    const full = resolve(dir, name)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      out.push(...listTsFiles(full))
+    } else if (full.endsWith('.ts') && !full.endsWith('.d.ts')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+// Each TS module emits its own dist file with all relative imports kept as
+// literal external imports in the output. Preserves boundaries the redact()
+// plugin needs to swap features/<name>/index.js → stub.js at consumer-
+// build time, and keeps single-instance state because each module is
+// emitted exactly once in dist/.
+const externalizeRelative = {
+  name: 'externalize-relative',
+  setup(b) {
+    b.onResolve({ filter: /^\.\.?\// }, (args) => {
+      if (args.kind === 'entry-point') return null
+      return { external: true, path: args.path }
+    })
+  },
+}
+
+async function buildPackage() {
+  rmSync(distDir, { recursive: true, force: true })
+  mkdirSync(distDir, { recursive: true })
+
+  const tsFiles = listTsFiles(srcDir)
+  console.log(`Building @ss/redact: ${tsFiles.length} entries...\n`)
+
+  for (const tsFile of tsFiles) {
+    const relPath = relative(srcDir, tsFile).replace(/\.ts$/, '')
+    // The vite plugin runs in Node — uses fs/path/url. Browser/SSR code
+    // never imports from vite/, so the node:* builtins it uses are safe
+    // to leave external in that one entry.
+    const isVite = relPath.startsWith('vite' + sep) || relPath === 'vite'
+    await build({
+      entryPoints: [{ in: tsFile, out: relPath }],
+      bundle: true,
+      format: 'esm',
+      platform: isVite ? 'node' : 'browser',
+      target: 'es2022',
+      outdir: distDir,
+      external: isVite ? ['vite', 'node:*'] : [],
+      sourcemap: true,
+      splitting: false,
+      plugins: [externalizeRelative],
+      logLevel: 'warning',
+    })
+  }
+
+  // Generate .d.ts files. tsc --emitDeclarationOnly.
+  const tsconfig = {
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+      strict: false,
+      skipLibCheck: true,
+      declaration: true,
+      emitDeclarationOnly: true,
+      outDir: './dist',
+      rootDir: './src',
+      jsx: 'react-jsx',
+      jsxImportSource: '@ss/redact',
+    },
+    include: ['./src/**/*'],
+  }
+  const tsconfigPath = resolve(pkgDir, 'tsconfig.build.json')
+  writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2))
+  try {
+    execSync(`bun x tsc -p ${tsconfigPath}`, { cwd: pkgDir, stdio: 'inherit' })
+  } catch {
+    // Non-fatal: declarations may be incomplete, but JS still builds.
+  } finally {
+    rmSync(tsconfigPath, { force: true })
+  }
+
+  console.log(`\n  ✓ @ss/redact`)
+}
+
+await buildPackage()
+console.log('\nDone.')

--- a/packages/redact/src/core/index.ts
+++ b/packages/redact/src/core/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './internal'

--- a/packages/redact/src/core/internal.ts
+++ b/packages/redact/src/core/internal.ts
@@ -1,0 +1,107 @@
+import type { ReactElement, ReactNode, Ref } from './types'
+
+export const enum FiberTag {
+  Host = 0,
+  Text = 1,
+  Function = 2,
+  Class = 3,
+  Fragment = 4,
+  Portal = 5,
+  Provider = 6,
+  Consumer = 7,
+  ForwardRef = 8,
+  Memo = 9,
+  Lazy = 10,
+  Suspense = 11,
+  Root = 12,
+}
+
+export const enum FiberFlag {
+  None = 0,
+  Placement = 1 << 0,
+  Update = 1 << 1,
+  Deletion = 1 << 2,
+  Ref = 1 << 3,
+  Effect = 1 << 4,
+  LayoutEffect = 1 << 5,
+  ContentReset = 1 << 6,
+  DidCapture = 1 << 7,
+}
+
+export interface Hook {
+  state: any
+  queue: any
+  deps: any
+  cleanup: any
+  next: Hook | null
+}
+
+export interface Effect {
+  tag: 'effect' | 'layout' | 'insertion'
+  create: () => any
+  destroy: (() => void) | void
+  deps: ReadonlyArray<unknown> | undefined
+}
+
+export interface Fiber {
+  tag: FiberTag
+  type: any
+  key: string | null
+  ref: Ref<any> | null
+  pendingProps: any
+  memoizedProps: any
+  memoizedState: any
+  stateNode: any
+  dom: Node | null
+  parent: Fiber | null
+  child: Fiber | null
+  sibling: Fiber | null
+  hooks: Hook | null
+  effects: Effect[] | null
+  layoutEffects: Effect[] | null
+  cleanups: Array<() => void> | null
+  flags: FiberFlag
+  dirty: boolean
+  unmounted: boolean
+  root: FiberRoot | null
+}
+
+export interface FiberRoot {
+  container: Element | DocumentFragment
+  current: Fiber
+  pending: Set<Fiber>
+  scheduled: boolean
+  onRecoverableError?: ((err: unknown) => void) | undefined
+  onCaughtError?: ((err: unknown) => void) | undefined
+  onUncaughtError?: ((err: unknown) => void) | undefined
+  identifierPrefix: string
+  hydrating: boolean
+}
+
+export function createFiber(tag: FiberTag, type: any, key: string | null): Fiber {
+  return {
+    tag,
+    type,
+    key,
+    ref: null,
+    pendingProps: null,
+    memoizedProps: null,
+    memoizedState: null,
+    stateNode: null,
+    dom: null,
+    parent: null,
+    child: null,
+    sibling: null,
+    hooks: null,
+    effects: null,
+    layoutEffects: null,
+    cleanups: null,
+    flags: FiberFlag.None,
+    dirty: false,
+    unmounted: false,
+    root: null,
+  }
+}
+
+export type ChildNode = ReactElement | string | number | boolean | null | undefined | ChildNode[]
+export type { ReactElement, ReactNode }

--- a/packages/redact/src/core/types.ts
+++ b/packages/redact/src/core/types.ts
@@ -1,0 +1,36 @@
+// React 19+ uses the transitional element symbol. When our shim's elements
+// are passed to react-dom (e.g. Start routing through real react-dom/server
+// somewhere), they must carry the symbol that React's isValidElement checks.
+export const REACT_ELEMENT_TYPE = Symbol.for('react.transitional.element')
+export const REACT_LEGACY_ELEMENT_TYPE = Symbol.for('react.element')
+export const REACT_FRAGMENT_TYPE = Symbol.for('react.fragment')
+
+export type Key = string | number | null | undefined
+
+export interface ReactElement<P = any, T = any> {
+  $$typeof: typeof REACT_ELEMENT_TYPE
+  type: T
+  key: string | null
+  ref: any
+  props: P
+}
+
+export type ReactNode =
+  | ReactElement
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Iterable<ReactNode>
+
+export type RefObject<T> = { current: T | null }
+export type RefCallback<T> = (instance: T | null) => void | (() => void)
+export type Ref<T> = RefObject<T> | RefCallback<T> | null
+
+export type Dispatch<A> = (value: A) => void
+export type SetStateAction<S> = S | ((prev: S) => S)
+
+export type EffectCallback = () => void | (() => void)
+export type DependencyList = ReadonlyArray<unknown>
+

--- a/packages/redact/src/dom/_all.ts
+++ b/packages/redact/src/dom/_all.ts
@@ -1,0 +1,54 @@
+// Unified entry exposing both top-level public API (createRoot, hydrateRoot,
+// createPortal, …) and the registration primitives that custom features and
+// custom bundler plugins need to hook into the reconciler. Reachable as
+// `@ss/redact/_all` via the package's subpath exports. Single-instance
+// state for things like the hydration CLAIMED WeakSet, scheduler queue,
+// dispatcher H slot, etc. is preserved because every public entry funnels
+// through this module.
+
+// Side-effect import: registers all opt-in features (renderers, type matchers,
+// element markers) with the reconciler. A vite plugin may alias individual
+// feature modules to ./features/<name>/stub to strip them from the bundle.
+import './features'
+
+// Top-level public API (mirrors the surface of /, /dom, /dom-client).
+export { flushSync, batchedUpdates as unstable_batchedUpdates } from './root'
+export { createRoot, hydrateRoot } from './root'
+export type { Root, RootOptions } from './root'
+export { createPortal } from './portal'
+export { act } from './test-utils'
+
+// Resource hints — stubs
+export function preconnect(_href: string, _opts?: any): void {}
+export function prefetchDNS(_href: string): void {}
+export function preload(_href: string, _opts?: any): void {}
+export function preinit(_href: string, _opts?: any): void {}
+export function preloadModule(_href: string, _opts?: any): void {}
+export function preinitModule(_href: string, _opts?: any): void {}
+
+export const version = '19.2.3'
+
+// Registration primitives — needed by custom features
+// (`registerRenderer`, `registerTypeMatcher`, `registerElementMarker`) and by
+// anything that wants to override a cross-cutting concern like Suspense's
+// `handleSuspended` or Context's `readContext` (`installCapability`). The
+// built-in features in `./features/*/{full,stub}.ts` use these via relative
+// imports; external authors reach them through this entry. Order-of-
+// registration matters: later calls overwrite earlier ones.
+export {
+  registerRenderer,
+  registerTypeMatcher,
+  registerElementMarker,
+  installCapability,
+  reconcileChildren,
+  childrenToArray,
+} from './reconcile'
+export type {
+  RenderFn,
+  TypeMatcher,
+  Capabilities,
+} from './reconcile'
+
+// Core types most custom features need.
+export { FiberTag } from '../core'
+export type { Fiber, FiberRoot, ReactNode, ReactElement } from '../core'

--- a/packages/redact/src/dom/client.ts
+++ b/packages/redact/src/dom/client.ts
@@ -1,0 +1,14 @@
+import './features'
+
+export { createRoot, hydrateRoot } from './root'
+export type { Root, RootOptions } from './root'
+
+// Default export — real React's `react-dom/client` is named-only too, but
+// bundlers synthesize a default from the CJS `module.exports` object.
+// Redact ships pure ESM, so without an explicit default, strict bundlers
+// (rolldown, modern Vite) reject `import ReactDOM from 'react-dom/client'`.
+import { createRoot, hydrateRoot } from './root'
+export default {
+  createRoot,
+  hydrateRoot,
+}

--- a/packages/redact/src/dom/dispatcher.ts
+++ b/packages/redact/src/dom/dispatcher.ts
@@ -62,8 +62,14 @@ export function makeDispatcher() {
 
 function makeDispatcherImpl() {
   return {
-    useState<S>(initial: S | (() => S)) {
-      return this.useReducer<S, S | ((p: S) => S)>(
+    useState<S>(initial: S | (() => S)): [S, (action: S | ((p: S) => S)) => void] {
+      // `this` inside an object-literal method has no static type, so TS
+      // refuses generic type arguments on `this.useReducer<S, A>(...)`
+      // (TS2347 — generics on an untyped call). The dispatcher is self-
+      // referencing by design; instead of restructuring the literal or
+      // forging a `this` type, drop the call-site type arguments and
+      // express the same contract via the return-type annotation above.
+      return (this as any).useReducer(
         basicReducer as any,
         typeof initial === 'function' ? (initial as () => S)() : initial,
       )

--- a/packages/redact/src/dom/dispatcher.ts
+++ b/packages/redact/src/dom/dispatcher.ts
@@ -1,0 +1,328 @@
+import type { Hook, Fiber, FiberRoot, Effect } from '../core'
+import { ReactSharedInternals, REACT_CONTEXT_TYPE } from '../react'
+import { scheduleUpdate, enqueueEffect, readContext } from './reconcile'
+
+function getCurrentFiber(): Fiber {
+  const f = ReactSharedInternals.currentFiber
+  if (!f) throw new Error('Hook called outside a function component render.')
+  return f
+}
+
+function nextHook(): Hook {
+  const fiber = getCurrentFiber()
+  const idx = ReactSharedInternals.hookIndex++
+
+  let prev = ReactSharedInternals.currentHook
+
+  if (idx === 0) {
+    if (fiber.hooks) {
+      ReactSharedInternals.currentHook = fiber.hooks
+      return fiber.hooks
+    }
+    const h: Hook = { state: undefined, queue: undefined, deps: undefined, cleanup: undefined, next: null }
+    fiber.hooks = h
+    ReactSharedInternals.currentHook = h
+    return h
+  }
+
+  if (prev && prev.next) {
+    ReactSharedInternals.currentHook = prev.next
+    return prev.next
+  }
+
+  const h: Hook = { state: undefined, queue: undefined, deps: undefined, cleanup: undefined, next: null }
+  if (prev) prev.next = h
+  else fiber.hooks = h
+  ReactSharedInternals.currentHook = h
+  return h
+}
+
+function depsEqual(
+  a: ReadonlyArray<unknown> | undefined,
+  b: ReadonlyArray<unknown> | undefined,
+): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return false
+  }
+  return true
+}
+
+// Singleton — every method reads render context via ReactSharedInternals,
+// and per-hook closures live on the hook itself, so nothing is render-local
+// to capture. Allocating a fresh wrapper + 17 method closures per function-
+// component render was pure GC pressure.
+const DISPATCHER = makeDispatcherImpl()
+
+export function makeDispatcher() {
+  return DISPATCHER
+}
+
+function makeDispatcherImpl() {
+  return {
+    useState<S>(initial: S | (() => S)) {
+      return this.useReducer<S, S | ((p: S) => S)>(
+        basicReducer as any,
+        typeof initial === 'function' ? (initial as () => S)() : initial,
+      )
+    },
+
+    useReducer<S, A>(reducer: (s: S, a: A) => S, initialArg: any, init?: (a: any) => S) {
+      const hook = nextHook()
+      const fiber = getCurrentFiber()
+      if (hook.queue === undefined) {
+        hook.state = init ? init(initialArg) : initialArg
+        const queue: any = { reducer }
+        const dispatch = (action: A) => {
+          const currentState = hook.state as S
+          const next = queue.reducer(currentState, action)
+          if (!Object.is(next, currentState)) {
+            hook.state = next
+            scheduleUpdate(fiber)
+          }
+        }
+        queue.dispatch = dispatch
+        hook.queue = queue
+      } else {
+        hook.queue.reducer = reducer
+      }
+      return [hook.state, hook.queue.dispatch] as [S, (a: A) => void]
+    },
+
+    useEffect(create: () => any, deps?: ReadonlyArray<unknown>) {
+      const hook = nextHook()
+      const fiber = getCurrentFiber()
+      const prevDeps = hook.deps
+      if (prevDeps !== undefined && depsEqual(prevDeps, deps)) return
+      hook.deps = deps
+      const effect: Effect = {
+        tag: 'effect',
+        create: () => {
+          // Run the prior cleanup INSIDE the effect run, not during the
+          // dispatch/render phase. If render A → B → C all happen back-to-
+          // back before the passive microtask drains, dispatch-time cleanup
+          // only fires once (between A→B) and effects B + C both run fresh,
+          // leaving two side-effects (e.g. two plot SVGs) in the DOM. Doing
+          // it here, at effect-run time, means every new create first tears
+          // down whatever cleanup is currently live on the hook.
+          if (hook.cleanup) {
+            try { hook.cleanup() } catch {}
+            // The prior cleanup was also pushed onto fiber.cleanups; remove
+            // it so unmount doesn't double-call it.
+            if (fiber.cleanups) {
+              const i = fiber.cleanups.indexOf(hook.cleanup)
+              if (i >= 0) fiber.cleanups.splice(i, 1)
+            }
+            hook.cleanup = null
+          }
+          const c = create()
+          hook.cleanup = typeof c === 'function' ? c : null
+          return hook.cleanup
+        },
+        destroy: undefined,
+        deps,
+      }
+      enqueueEffect(fiber, effect)
+    },
+
+    useLayoutEffect(create: () => any, deps?: ReadonlyArray<unknown>) {
+      const hook = nextHook()
+      const fiber = getCurrentFiber()
+      const prevDeps = hook.deps
+      if (prevDeps !== undefined && depsEqual(prevDeps, deps)) return
+      hook.deps = deps
+      const effect: Effect = {
+        tag: 'layout',
+        create: () => {
+          // Mirror useEffect: tear down the prior cleanup at run time so
+          // coalesced renders don't leak side-effects.
+          if (hook.cleanup) {
+            try { hook.cleanup() } catch {}
+            if (fiber.cleanups) {
+              const i = fiber.cleanups.indexOf(hook.cleanup)
+              if (i >= 0) fiber.cleanups.splice(i, 1)
+            }
+            hook.cleanup = null
+          }
+          const c = create()
+          hook.cleanup = typeof c === 'function' ? c : null
+          return hook.cleanup
+        },
+        destroy: undefined,
+        deps,
+      }
+      enqueueEffect(fiber, effect)
+    },
+
+    useInsertionEffect(create: () => any, deps?: ReadonlyArray<unknown>) {
+      return this.useLayoutEffect(create, deps)
+    },
+
+    useRef<T>(initial: T) {
+      const hook = nextHook()
+      if (hook.state === undefined) hook.state = { current: initial }
+      return hook.state as { current: T }
+    },
+
+    useMemo<T>(factory: () => T, deps?: ReadonlyArray<unknown>) {
+      const hook = nextHook()
+      if (hook.deps !== undefined && depsEqual(hook.deps, deps)) {
+        return hook.state as T
+      }
+      const value = factory()
+      hook.state = value
+      hook.deps = deps
+      return value
+    },
+
+    useCallback<T extends Function>(fn: T, deps?: ReadonlyArray<unknown>): T {
+      return this.useMemo(() => fn, deps) as T
+    },
+
+    useContext<T>(ctx: any): T {
+      const fiber = getCurrentFiber()
+      return readContext(fiber, ctx)
+    },
+
+    useImperativeHandle<T>(ref: any, factory: () => T, deps?: ReadonlyArray<unknown>) {
+      const hook = nextHook()
+      if (hook.deps !== undefined && depsEqual(hook.deps, deps)) return
+      hook.deps = deps
+      const value = factory()
+      if (ref) {
+        if (typeof ref === 'function') ref(value)
+        else ref.current = value
+      }
+    },
+
+    useDebugValue<T>(_value: T, _formatter?: (v: T) => any): void {
+      // noop
+    },
+
+    useId(): string {
+      const hook = nextHook()
+      if (hook.state === undefined) {
+        const fiber = getCurrentFiber()
+        const root = findRootFromFiber(fiber)
+        hook.state = (root?.identifierPrefix ?? ':r') + (idCounter++).toString(36)
+      }
+      return hook.state as string
+    },
+
+    useTransition(): [boolean, (fn: () => void) => void] {
+      return [false, (fn: () => void) => fn()]
+    },
+
+    useDeferredValue<T>(v: T): T {
+      return v
+    },
+
+    useSyncExternalStore<T>(
+      subscribe: (cb: () => void) => () => void,
+      getSnapshot: () => T,
+      getServerSnapshot?: () => T,
+    ): T {
+      const fiber = getCurrentFiber()
+      const hook = nextHook()
+
+      // During hydration, use the server snapshot (if provided) so the tree
+      // matches the SSR output. Components like TanStack Router's ClientOnly
+      // rely on this: they render `false` on server, `true` on client — and
+      // if we return `true` during hydration, client and server diverge and
+      // the tree mounts fresh next to the SSR fallback DOM.
+      const root = fiber.root ?? findRootFromFiber(fiber)
+      const isHydrating = Boolean(root?.hydrating)
+      const value =
+        isHydrating && getServerSnapshot ? getServerSnapshot() : getSnapshot()
+      hook.state = value
+
+      if (hook.cleanup == null) {
+        const forceUpdate = () => {
+          let next: T
+          try {
+            next = getSnapshot()
+          } catch {
+            scheduleUpdate(fiber)
+            return
+          }
+          if (!Object.is(hook.state, next)) {
+            hook.state = next
+            scheduleUpdate(fiber)
+          }
+        }
+        const unsubscribe = subscribe(forceUpdate)
+        hook.cleanup = unsubscribe
+        // Register with fiber so unmountFiber runs it. Without this, the store
+        // keeps holding forceUpdate and every store update schedules an already-
+        // unmounted fiber — its rerender walks stale .parent pointers and mounts
+        // zombie DOM into the old parent.
+        if (typeof unsubscribe === 'function') {
+          fiber.cleanups ||= []
+          fiber.cleanups.push(unsubscribe)
+        }
+
+        // If we served the server snapshot, run a post-hydration check so
+        // components like `useHydrated()` flip from false → true after the
+        // initial render commits. Queued late so hydration finishes first.
+        if (isHydrating && getServerSnapshot) {
+          queueMicrotask(() => queueMicrotask(forceUpdate))
+        }
+      }
+      return value
+    },
+
+    use<T>(resource: any): T {
+      if (resource == null) throw new Error('use() received null or undefined')
+      if (resource.$$typeof === REACT_CONTEXT_TYPE) {
+        return readContext(getCurrentFiber(), resource)
+      }
+      if (typeof resource.then === 'function') {
+        const thenable = resource
+        switch (thenable.status) {
+          case 'fulfilled':
+            return thenable.value
+          case 'rejected':
+            throw thenable.reason
+          default: {
+            if (thenable.status === undefined) {
+              thenable.status = 'pending'
+              thenable.then(
+                (v: any) => {
+                  if (thenable.status === 'pending') {
+                    thenable.status = 'fulfilled'
+                    thenable.value = v
+                  }
+                },
+                (e: any) => {
+                  if (thenable.status === 'pending') {
+                    thenable.status = 'rejected'
+                    thenable.reason = e
+                  }
+                },
+              )
+            }
+            throw thenable
+          }
+        }
+      }
+      throw new Error('use() expected a Promise or Context')
+    },
+  }
+}
+
+function basicReducer<S>(state: S, action: S | ((p: S) => S)): S {
+  return typeof action === 'function' ? (action as (p: S) => S)(state) : action
+}
+
+let idCounter = 0
+
+function findRootFromFiber(fiber: Fiber): FiberRoot | null {
+  let f: Fiber | null = fiber
+  while (f) {
+    if (f.root) return f.root
+    f = f.parent
+  }
+  return null
+}

--- a/packages/redact/src/dom/dom.ts
+++ b/packages/redact/src/dom/dom.ts
@@ -1,0 +1,409 @@
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+const BOOLEAN_ATTRS = new Set([
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+])
+
+const IDL_ATTRS = new Set([
+  'value',
+  'checked',
+  'selected',
+  'disabled',
+  'multiple',
+  'muted',
+  'readonly',
+  'contentEditable',
+  'spellcheck',
+  'draggable',
+])
+
+// SVG attribute names: JSX/React convention is camelCase, but most SVG
+// presentation attributes are kebab-case in the DOM (`stroke-width`,
+// `clip-path`, …). A subset of SVG attributes IS spec'd as camelCase
+// (`viewBox`, `preserveAspectRatio`, `gradientTransform`, …) and must be
+// passed through unchanged. A static rename map is therefore safer than
+// a generic camelCase→kebab transformation. Names not present here pass
+// through verbatim, which is correct for both case-preserving SVG attrs
+// and any HTML attribute that lands on a foreign-content node.
+const SVG_ATTR_RENAME: Record<string, string> = {
+  // stroke
+  strokeDasharray: 'stroke-dasharray',
+  strokeDashoffset: 'stroke-dashoffset',
+  strokeLinecap: 'stroke-linecap',
+  strokeLinejoin: 'stroke-linejoin',
+  strokeMiterlimit: 'stroke-miterlimit',
+  strokeOpacity: 'stroke-opacity',
+  strokeWidth: 'stroke-width',
+  // fill
+  fillOpacity: 'fill-opacity',
+  fillRule: 'fill-rule',
+  // clip / mask
+  clipPath: 'clip-path',
+  clipRule: 'clip-rule',
+  // color / lighting
+  colorInterpolation: 'color-interpolation',
+  colorInterpolationFilters: 'color-interpolation-filters',
+  colorProfile: 'color-profile',
+  colorRendering: 'color-rendering',
+  floodColor: 'flood-color',
+  floodOpacity: 'flood-opacity',
+  lightingColor: 'lighting-color',
+  stopColor: 'stop-color',
+  stopOpacity: 'stop-opacity',
+  // font (SVG presentation form)
+  fontFamily: 'font-family',
+  fontSize: 'font-size',
+  fontSizeAdjust: 'font-size-adjust',
+  fontStretch: 'font-stretch',
+  fontStyle: 'font-style',
+  fontVariant: 'font-variant',
+  fontWeight: 'font-weight',
+  // text
+  textAnchor: 'text-anchor',
+  textDecoration: 'text-decoration',
+  textRendering: 'text-rendering',
+  alignmentBaseline: 'alignment-baseline',
+  baselineShift: 'baseline-shift',
+  dominantBaseline: 'dominant-baseline',
+  letterSpacing: 'letter-spacing',
+  wordSpacing: 'word-spacing',
+  writingMode: 'writing-mode',
+  // markers
+  markerEnd: 'marker-end',
+  markerMid: 'marker-mid',
+  markerStart: 'marker-start',
+  // rendering hints
+  pointerEvents: 'pointer-events',
+  shapeRendering: 'shape-rendering',
+  imageRendering: 'image-rendering',
+  vectorEffect: 'vector-effect',
+  paintOrder: 'paint-order',
+  // misc presentation
+  enableBackground: 'enable-background',
+  glyphOrientationHorizontal: 'glyph-orientation-horizontal',
+  glyphOrientationVertical: 'glyph-orientation-vertical',
+  unicodeBidi: 'unicode-bidi',
+  // xlink:* — deprecated in SVG2 but still in use; setAttribute accepts the
+  // colon form without the namespace, which is enough for browser parsing.
+  xlinkActuate: 'xlink:actuate',
+  xlinkArcrole: 'xlink:arcrole',
+  xlinkHref: 'xlink:href',
+  xlinkRole: 'xlink:role',
+  xlinkShow: 'xlink:show',
+  xlinkTitle: 'xlink:title',
+  xlinkType: 'xlink:type',
+  // xml:* and xmlns:xlink
+  xmlBase: 'xml:base',
+  xmlLang: 'xml:lang',
+  xmlSpace: 'xml:space',
+  xmlnsXlink: 'xmlns:xlink',
+}
+
+export function createHostNode(type: string, isSvg: boolean): Element {
+  if (isSvg || type === 'svg') {
+    return document.createElementNS(SVG_NS, type)
+  }
+  return document.createElement(type)
+}
+
+export function isSvgElement(el: Element): boolean {
+  return (el as any).ownerSVGElement !== undefined || el.tagName === 'svg'
+}
+
+export function setProp(
+  el: Element,
+  name: string,
+  next: any,
+  prev: any,
+  isSvg: boolean,
+): void {
+  if (name === 'children' || name === 'key' || name === 'ref') return
+
+  // defaultValue / defaultChecked are IDL-property-only — they seed the
+  // initial value/checked of a form control on first mount and must NOT be
+  // emitted as HTML attributes (which would leak as `defaultValue="..."`).
+  // Setting `el.defaultValue` on a fresh control also sets the initial
+  // `el.value`, which is what consumers expect. Skip on hydrated DOM so we
+  // don't clobber a live user-typed value.
+  if (name === 'defaultValue' || name === 'defaultChecked') {
+    if (prev === undefined && next != null) {
+      try {
+        ;(el as any)[name] = next
+      } catch {}
+    }
+    return
+  }
+
+  if (name === 'className') {
+    if (isSvg) {
+      if (next == null) el.removeAttribute('class')
+      else el.setAttribute('class', '' + next)
+    } else {
+      ;(el as HTMLElement).className = next == null ? '' : '' + next
+    }
+    return
+  }
+
+  if (name === 'class') {
+    if (next == null) el.removeAttribute('class')
+    else el.setAttribute('class', '' + next)
+    return
+  }
+
+  if (name === 'style') {
+    setStyle(el as HTMLElement, next, prev)
+    return
+  }
+
+  if (name === 'dangerouslySetInnerHTML') {
+    const nextHtml = next?.__html ?? ''
+    const prevHtml = prev?.__html ?? ''
+    if (nextHtml !== prevHtml) (el as HTMLElement).innerHTML = nextHtml
+    return
+  }
+
+  if (name[0] === 'o' && name[1] === 'n') {
+    setEventHandler(el, name, next, prev)
+    return
+  }
+
+  if (name === 'htmlFor') {
+    if (next == null) el.removeAttribute('for')
+    else el.setAttribute('for', '' + next)
+    return
+  }
+
+  if (!isSvg && IDL_ATTRS.has(name) && name in el) {
+    try {
+      ;(el as any)[name] = next == null ? '' : next
+      return
+    } catch {}
+  }
+
+  if (BOOLEAN_ATTRS.has(name.toLowerCase())) {
+    if (next) el.setAttribute(name, '')
+    else el.removeAttribute(name)
+    return
+  }
+
+  // aria-* and data-* attributes stringify booleans to `"true"`/`"false"`
+  // rather than using the HTML boolean-attribute presence/absence semantics.
+  // This matches React and the ARIA spec (aria-hidden="false" is meaningful).
+  if (name.length > 5 && (name.charCodeAt(0) === 97 /* a */ || name.charCodeAt(0) === 100 /* d */)) {
+    if (name.startsWith('aria-') || name.startsWith('data-')) {
+      if (next == null) {
+        el.removeAttribute(name)
+      } else {
+        el.setAttribute(name, '' + next)
+      }
+      return
+    }
+  }
+
+  // SVG attribute name aliasing — `strokeWidth` → `stroke-width`,
+  // `clipPath` → `clip-path`, etc. Without this, the browser sees a
+  // camelCase attribute it doesn't recognize and silently ignores it,
+  // making strokes default to 1px and clip references no-op (the user-
+  // visible symptom is "an SVG that renders just its bounding rect").
+  // Applied regardless of element namespace to match React's behavior
+  // and to keep client/SSR output identical so hydration doesn't mismatch
+  // when a known SVG-prop name appears on a non-SVG element.
+  const aliased = SVG_ATTR_RENAME[name]
+  if (aliased) name = aliased
+
+  if (next == null || next === false) {
+    el.removeAttribute(name)
+  } else if (next === true) {
+    el.setAttribute(name, '')
+  } else {
+    el.setAttribute(name, '' + next)
+  }
+}
+
+function setStyle(el: HTMLElement, next: any, prev: any): void {
+  const style = el.style
+  if (typeof next === 'string') {
+    style.cssText = next
+    return
+  }
+  if (typeof prev === 'string') style.cssText = ''
+  if (prev && typeof prev === 'object') {
+    for (const k in prev) {
+      if (!next || !(k in next)) setStyleProperty(style, k, '')
+    }
+  }
+  if (next && typeof next === 'object') {
+    for (const k in next) {
+      if (!prev || prev[k] !== next[k]) setStyleProperty(style, k, next[k])
+    }
+  }
+}
+
+function setStyleProperty(style: CSSStyleDeclaration, key: string, value: any): void {
+  if (key[0] === '-') {
+    style.setProperty(key, value == null ? '' : '' + value)
+  } else if (value == null || value === '') {
+    ;(style as any)[key] = ''
+  } else if (typeof value === 'number' && !UNITLESS_STYLE.has(key)) {
+    ;(style as any)[key] = value + 'px'
+  } else {
+    ;(style as any)[key] = '' + value
+  }
+}
+
+const UNITLESS_STYLE = new Set([
+  'animationIterationCount',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexPositive',
+  'flexShrink',
+  'flexNegative',
+  'flexOrder',
+  'gridArea',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowSpan',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnSpan',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+  'fillOpacity',
+  'floodOpacity',
+  'stopOpacity',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
+])
+
+export interface SyntheticEvent extends Event {
+  nativeEvent: Event
+  isDefaultPrevented(): boolean
+  isPropagationStopped(): boolean
+  persist(): void
+  currentTarget: EventTarget & Element
+}
+
+function setEventHandler(el: Element, name: string, next: any, prev: any): void {
+  // Only function handlers are accepted. Reject strings/objects/etc — the
+  // legacy `onclick="..."` HTML attribute (string handler) is a known XSS
+  // vector if a parent spreads untrusted props onto a host element. React
+  // also ignores non-function handlers.
+  if (next != null && typeof next !== 'function') next = null
+
+  const capture = name.endsWith('Capture')
+  const reactEventName = name.slice(2, capture ? -7 : undefined)
+  const eventName = domEventFor(reactEventName, el)
+
+  // Key by the React prop name (not DOM event name) so `onChange` and
+  // `onInput` on the same text input — which both dispatch from the native
+  // `input` event — can coexist without clobbering each other's handlers.
+  const handlers = ((el as any).__handlers ||= Object.create(null))
+  const key = name
+
+  const existing = handlers[key]
+
+  if (existing && !next) {
+    el.removeEventListener(existing.event, existing.listener, existing.capture)
+    handlers[key] = null
+    return
+  }
+
+  if (!existing && next) {
+    const entry = {
+      current: next as Function,
+      listener: null as any,
+      event: eventName,
+      capture,
+    }
+    entry.listener = (e: Event) => {
+      // React hands handlers a SyntheticEvent that carries `.nativeEvent`.
+      // Many libraries check `event.nativeEvent.isComposing` (react-instantsearch)
+      // or `event.nativeEvent.shiftKey` (UI kits) — without the alias they throw
+      // on `undefined.foo`. Aliasing the native event to itself is the cheapest
+      // way to satisfy the shape without building a full synthetic layer.
+      if ((e as any).nativeEvent === undefined) (e as any).nativeEvent = e
+      entry.current(e)
+    }
+    handlers[key] = entry
+    el.addEventListener(eventName, entry.listener, capture)
+    return
+  }
+
+  if (existing) {
+    // Re-bind if the effective DOM event changed (e.g. <input> whose `type`
+    // flipped from "text" to "checkbox" — onChange should now follow `change`
+    // instead of `input`). This is rare but keeps semantics correct.
+    if (existing.event !== eventName || existing.capture !== capture) {
+      el.removeEventListener(existing.event, existing.listener, existing.capture)
+      existing.event = eventName
+      existing.capture = capture
+      el.addEventListener(eventName, existing.listener, capture)
+    }
+    existing.current = next
+  }
+}
+
+function domEventFor(reactEventName: string, el: Element): string {
+  const lower = reactEventName.toLowerCase()
+  // React's `onChange` on text-like <input> and <textarea> maps to the
+  // native `input` event so handlers fire on every keystroke. On checkbox,
+  // radio, file inputs, and <select>, React's `onChange` maps to the
+  // native `change` event (which fires on click / option select).
+  if (lower === 'change') {
+    const tag = el.tagName
+    if (tag === 'TEXTAREA') return 'input'
+    if (tag === 'INPUT') {
+      const type = ((el as HTMLInputElement).type || 'text').toLowerCase()
+      if (type !== 'checkbox' && type !== 'radio' && type !== 'file') {
+        return 'input'
+      }
+    }
+  }
+  if (lower === 'doubleclick') return 'dblclick'
+  return lower
+}

--- a/packages/redact/src/dom/event-replay.ts
+++ b/packages/redact/src/dom/event-replay.ts
@@ -1,0 +1,55 @@
+/**
+ * Drain the `window.$RE_q` event buffer that the inline runtime populated
+ * before the main bundle was parsed. For each buffered event, re-dispatch a
+ * synthesized event at the original target so handlers attached during
+ * hydration see it.
+ *
+ * Lossy by design: only the event type and target are preserved. Modifier
+ * keys, pointer positions, etc. are zeroed. This is acceptable because the
+ * replay window is a fraction of a second between shell render and full
+ * hydration of a streaming page; users who need pixel-accurate replay won't
+ * lose much beyond that.
+ */
+export function drainReplayQueue(): void {
+  const g = globalThis as any
+  const q = g.$RE_q as Array<[string, EventTarget, number]> | undefined
+  if (!q) return
+
+  // Stop capturing before replaying so we don't re-capture what we dispatch.
+  if (typeof g.$RE_stop === 'function') {
+    try {
+      g.$RE_stop()
+    } catch {}
+  }
+
+  const events = q.splice(0)
+  for (const [type, target] of events) {
+    try {
+      const ev = createEvent(type)
+      target.dispatchEvent(ev)
+    } catch {}
+  }
+}
+
+function createEvent(type: string): Event {
+  switch (type) {
+    case 'click':
+    case 'dblclick':
+    case 'mousedown':
+    case 'mouseup':
+    case 'contextmenu':
+      return new MouseEvent(type, { bubbles: true, cancelable: true })
+    case 'keydown':
+    case 'keyup':
+    case 'keypress':
+      return new KeyboardEvent(type, { bubbles: true, cancelable: true })
+    case 'input':
+      return new InputEvent(type, { bubbles: true, cancelable: true })
+    case 'submit':
+    case 'change':
+    case 'focus':
+    case 'blur':
+    default:
+      return new Event(type, { bubbles: true, cancelable: true })
+  }
+}

--- a/packages/redact/src/dom/features/class/full.ts
+++ b/packages/redact/src/dom/features/class/full.ts
@@ -1,0 +1,104 @@
+import { FiberTag, type Fiber, type ReactNode } from '../../../core'
+import {
+  registerRenderer,
+  reconcileChildren,
+  childrenToArray,
+  scheduleUpdate,
+  scheduleLifecycle,
+  isThenable,
+  handleSuspended,
+  handleErrorInRender,
+} from '../../reconcile'
+
+function renderClass(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const Ctor = fiber.type as any
+  let instance = fiber.stateNode
+  const props = fiber.pendingProps ?? {}
+  const isNew = !instance
+
+  // Class contextType: read the current value of the subscribed context so
+  // `this.context` reflects the nearest Provider. Evaluated every render.
+  const ctxValue = Ctor.contextType ? Ctor.contextType._currentValue : undefined
+
+  if (isNew) {
+    instance = new Ctor(props, ctxValue)
+    instance.props = props
+    instance.context = ctxValue
+    instance._fiber = fiber
+    instance._enqueueUpdate = (updater: any, cb?: () => void) => {
+      const next = typeof updater === 'function' ? updater(instance.state, instance.props) : updater
+      if (next != null) instance.state = { ...instance.state, ...next }
+      if (cb) {
+        fiber.cleanups ||= []
+        fiber.cleanups.push(cb)
+      }
+      scheduleUpdate(fiber)
+    }
+    instance._forceUpdate = (cb?: () => void) => {
+      if (cb) {
+        fiber.cleanups ||= []
+        fiber.cleanups.push(cb)
+      }
+      scheduleUpdate(fiber)
+    }
+    fiber.stateNode = instance
+    if (Ctor.getDerivedStateFromProps) {
+      const d = Ctor.getDerivedStateFromProps(props, instance.state)
+      if (d) instance.state = { ...instance.state, ...d }
+    }
+  } else {
+    const prevProps = instance.props
+    const prevState = instance.state
+    // Refresh context on every render — Providers higher up may have changed.
+    instance.context = ctxValue
+    if (Ctor.getDerivedStateFromProps) {
+      const d = Ctor.getDerivedStateFromProps(props, instance.state)
+      if (d) instance.state = { ...instance.state, ...d }
+    }
+    if (instance.shouldComponentUpdate) {
+      if (!instance.shouldComponentUpdate(props, instance.state, instance.context)) {
+        instance.props = props
+        fiber.memoizedProps = props
+        // Still need to render children with previous output
+        if (fiber.memoizedState?.rendered) {
+          reconcileChildren(fiber, childrenToArray(fiber.memoizedState.rendered), domParent, anchor)
+        }
+        return
+      }
+    }
+    instance.props = props
+    // New snapshot must win over any stale one from a previous render —
+    // otherwise componentDidUpdate keeps seeing the original props and can
+    // ping-pong setState forever.
+    fiber.memoizedState = { ...(fiber.memoizedState ?? {}), prevProps, prevState }
+  }
+
+  let rendered: ReactNode
+  try {
+    rendered = instance.render()
+  } catch (e: any) {
+    if (isThenable(e)) {
+      handleSuspended(fiber, e)
+      rendered = null
+    } else {
+      handleErrorInRender(fiber, e)
+      return
+    }
+  }
+  fiber.memoizedState = { ...(fiber.memoizedState ?? {}), rendered }
+
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = props
+
+  // Schedule lifecycle
+  if (isNew) {
+    if (instance.componentDidMount) {
+      scheduleLifecycle(fiber, () => instance.componentDidMount())
+    }
+  } else if (instance.componentDidUpdate) {
+    const { prevProps, prevState } = fiber.memoizedState ?? {}
+    scheduleLifecycle(fiber, () => instance.componentDidUpdate(prevProps, prevState))
+  }
+}
+
+registerRenderer(FiberTag.Class, renderClass)

--- a/packages/redact/src/dom/features/class/index.ts
+++ b/packages/redact/src/dom/features/class/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/class/stub.ts
+++ b/packages/redact/src/dom/features/class/stub.ts
@@ -1,0 +1,65 @@
+import { FiberTag, type Fiber, type ReactNode } from '../../../core'
+import {
+  registerRenderer,
+  reconcileChildren,
+  childrenToArray,
+  scheduleUpdate,
+  isThenable,
+  handleSuspended,
+  handleErrorInRender,
+} from '../../reconcile'
+
+// Stub: Class feature disabled. Class components still render — they're
+// detected by `type.prototype.isReactComponent` in the reconciler regardless —
+// but ONLY the core contract is honored: constructor, `render()`, and
+// `setState` triggering a re-render. Dropped from this stub:
+//   - `contextType` (this.context is always undefined)
+//   - `getDerivedStateFromProps`
+//   - `shouldComponentUpdate`
+//   - `componentDidMount` / `componentDidUpdate` / `componentWillUnmount`
+//   - `getDerivedStateFromError` / `componentDidCatch` (error boundaries)
+// Apps that actually need these should keep the feature on. Apps that just
+// have a handful of legacy class components that do `render() + setState`
+// still work, and save ~400 B min / ~200 B gz.
+function renderClassStub(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const Ctor = fiber.type as any
+  let instance = fiber.stateNode
+  const props = fiber.pendingProps ?? {}
+
+  if (!instance) {
+    instance = new Ctor(props, undefined)
+    instance.props = props
+    instance._fiber = fiber
+    instance._enqueueUpdate = (updater: any, cb?: () => void) => {
+      const next = typeof updater === 'function' ? updater(instance.state, instance.props) : updater
+      if (next != null) instance.state = { ...instance.state, ...next }
+      if (cb) {
+        fiber.cleanups ||= []
+        fiber.cleanups.push(cb)
+      }
+      scheduleUpdate(fiber)
+    }
+    instance._forceUpdate = instance._enqueueUpdate
+    fiber.stateNode = instance
+  } else {
+    instance.props = props
+  }
+
+  let rendered: ReactNode
+  try {
+    rendered = instance.render()
+  } catch (e: any) {
+    if (isThenable(e)) {
+      handleSuspended(fiber, e)
+      rendered = null
+    } else {
+      handleErrorInRender(fiber, e)
+      return
+    }
+  }
+
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = props
+}
+
+registerRenderer(FiberTag.Class, renderClassStub)

--- a/packages/redact/src/dom/features/context/full.ts
+++ b/packages/redact/src/dom/features/context/full.ts
@@ -1,0 +1,57 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_PROVIDER_TYPE, REACT_CONSUMER_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  installCapability,
+  reconcileChildren,
+  childrenToArray,
+} from '../../reconcile'
+
+function realReadContext(fiber: Fiber, ctx: any): any {
+  let p: Fiber | null = fiber.parent
+  while (p) {
+    if (p.tag === FiberTag.Provider && (p.type as any)._context === ctx) {
+      return (p.pendingProps ?? p.memoizedProps)?.value
+    }
+    p = p.parent
+  }
+  return ctx._currentValue
+}
+
+function renderProvider(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const ctx = (fiber.type as any)._context
+  const props = fiber.pendingProps ?? {}
+  const prevValue = ctx._currentValue
+  ctx._currentValue = props.value
+  try {
+    reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
+  } finally {
+    ctx._currentValue = prevValue
+  }
+  // Also store the value on the fiber so descendants rendering later (via updates)
+  // can read through by walking up.
+  fiber.memoizedState = props.value
+  fiber.memoizedProps = props
+}
+
+function renderConsumer(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const ctx = (fiber.type as any)._context
+  const props = fiber.pendingProps ?? {}
+  const children = props.children
+  const value = realReadContext(fiber, ctx)
+  const rendered = typeof children === 'function' ? children(value) : null
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = props
+}
+
+registerTypeMatcher((_type, marker) =>
+  marker === REACT_PROVIDER_TYPE
+    ? FiberTag.Provider
+    : marker === REACT_CONSUMER_TYPE
+      ? FiberTag.Consumer
+      : null,
+)
+registerRenderer(FiberTag.Provider, renderProvider)
+registerRenderer(FiberTag.Consumer, renderConsumer)
+installCapability('readContext', realReadContext)

--- a/packages/redact/src/dom/features/context/index.ts
+++ b/packages/redact/src/dom/features/context/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/context/stub.ts
+++ b/packages/redact/src/dom/features/context/stub.ts
@@ -1,0 +1,32 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_PROVIDER_TYPE, REACT_CONSUMER_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  reconcileChildren,
+  childrenToArray,
+} from '../../reconcile'
+
+// Stub: Context feature disabled. Provider elements render as Fragments
+// (value is never propagated — descendants see only the Context's default).
+// Consumer elements still invoke their function-children with the default
+// value, so `<Ctx.Consumer>{v => ...}</Ctx.Consumer>` patterns keep working.
+// The default `readContext` capability returns `ctx._currentValue` without
+// walking, which matches the no-Provider-fibers-in-tree reality.
+function renderConsumerStub(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const ctx = (fiber.type as any)._context
+  const props = fiber.pendingProps ?? {}
+  const value = ctx._currentValue
+  const rendered = typeof props.children === 'function' ? props.children(value) : null
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = props
+}
+
+registerTypeMatcher((_type, marker) =>
+  marker === REACT_PROVIDER_TYPE
+    ? FiberTag.Fragment
+    : marker === REACT_CONSUMER_TYPE
+      ? FiberTag.Consumer
+      : null,
+)
+registerRenderer(FiberTag.Consumer, renderConsumerStub)

--- a/packages/redact/src/dom/features/forward-ref/full.ts
+++ b/packages/redact/src/dom/features/forward-ref/full.ts
@@ -1,0 +1,54 @@
+import { FiberTag, type Fiber, type ReactNode } from '../../../core'
+import { ReactSharedInternals, REACT_FORWARD_REF_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  reconcileChildren,
+  childrenToArray,
+  isThenable,
+  handleSuspended,
+  handleErrorInRender,
+} from '../../reconcile'
+import { makeDispatcher } from '../../dispatcher'
+
+function renderForwardRef(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const props = fiber.pendingProps ?? {}
+  const render = (fiber.type as any).render
+  const ref = fiber.ref ?? (props.ref ?? null)
+
+  const prevDispatcher = ReactSharedInternals.H
+  const prevFiber = ReactSharedInternals.currentFiber
+  const prevHook = ReactSharedInternals.currentHook
+  const prevIndex = ReactSharedInternals.hookIndex
+  ReactSharedInternals.H = makeDispatcher()
+  ReactSharedInternals.currentFiber = fiber
+  ReactSharedInternals.currentHook = null
+  ReactSharedInternals.hookIndex = 0
+
+  let rendered: ReactNode
+  try {
+    const { ref: _omit, ...rest } = props
+    rendered = render(rest, ref)
+  } catch (e: any) {
+    if (isThenable(e)) {
+      handleSuspended(fiber, e)
+      rendered = null
+    } else {
+      handleErrorInRender(fiber, e)
+      return
+    }
+  } finally {
+    ReactSharedInternals.H = prevDispatcher
+    ReactSharedInternals.currentFiber = prevFiber
+    ReactSharedInternals.currentHook = prevHook
+    ReactSharedInternals.hookIndex = prevIndex
+  }
+
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = props
+}
+
+registerTypeMatcher((_type, marker) =>
+  marker === REACT_FORWARD_REF_TYPE ? FiberTag.ForwardRef : null,
+)
+registerRenderer(FiberTag.ForwardRef, renderForwardRef)

--- a/packages/redact/src/dom/features/forward-ref/index.ts
+++ b/packages/redact/src/dom/features/forward-ref/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/forward-ref/stub.ts
+++ b/packages/redact/src/dom/features/forward-ref/stub.ts
@@ -1,0 +1,28 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_FORWARD_REF_TYPE } from '../../../react'
+import { registerRenderer, registerTypeMatcher, renderFiber } from '../../reconcile'
+
+// Stub: ForwardRef feature disabled. `forwardRef(fn)` elements still render,
+// but the ref prop is NOT forwarded — the component is called as a plain
+// function with just props. React 19+ supports refs as normal props on
+// function components, so most apps can drop forwardRef entirely; this stub
+// preserves JSX compatibility while stripping the dispatcher save/restore
+// machinery.
+function renderForwardRefStub(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const render = (fiber.type as any).render
+  const savedTag = fiber.tag
+  const savedType = fiber.type
+  fiber.type = render
+  fiber.tag = FiberTag.Function
+  try {
+    renderFiber(fiber, domParent, anchor)
+  } finally {
+    fiber.tag = savedTag
+    fiber.type = savedType
+  }
+}
+
+registerTypeMatcher((_type, marker) =>
+  marker === REACT_FORWARD_REF_TYPE ? FiberTag.ForwardRef : null,
+)
+registerRenderer(FiberTag.ForwardRef, renderForwardRefStub)

--- a/packages/redact/src/dom/features/hydration/full.ts
+++ b/packages/redact/src/dom/features/hydration/full.ts
@@ -1,0 +1,345 @@
+import { FiberTag, type Fiber, type FiberRoot } from '../../../core'
+import { setProp } from '../../dom'
+import { findRoot } from '../../reconcile'
+
+// Re-export from event-replay so all hydration concerns live behind one
+// feature boundary — the plugin's stub swap strips drainReplayQueue too.
+export { drainReplayQueue } from '../../event-replay'
+
+const GUARD_WINDOW_MS = 3000
+
+/**
+ * Preserve the user's scroll position across hydration. If the user scrolled
+ * between SSR paint and hydrate (common in dev where JS takes seconds to
+ * load), libraries that wire scroll-restoration into a `useLayoutEffect`
+ * near the root (e.g. TanStack Router) will run during our synchronous
+ * hydrate and call `window.scrollTo(savedFromLastVisit)` — overwriting the
+ * user's fresh scroll. We install a short-lived wrapper around scrollTo that
+ * suppresses programmatic calls when a user-initiated scroll happened
+ * recently. Only runs in the hydration feature — the stub skips it.
+ */
+export function installHydrationScrollGuard(): void {
+  if (typeof window === 'undefined') return
+  const w = window as any
+  if (w.__tdomScrollGuardInstalled) return
+  w.__tdomScrollGuardInstalled = true
+  const guardStartedAt = performance.now()
+  let lastUserScrollAt = 0
+  let programmatic = 0
+  w.__tdomScrollLog = []
+  window.addEventListener(
+    'scroll',
+    () => {
+      if (programmatic === 0) {
+        lastUserScrollAt = performance.now()
+        w.__tdomScrollLog.push({ t: Math.round(lastUserScrollAt), ev: 'user-scroll', y: window.scrollY })
+      }
+    },
+    { capture: true, passive: true },
+  )
+  const origScrollTo = window.scrollTo.bind(window)
+  window.scrollTo = function (this: any, ...args: any[]) {
+    const now = performance.now()
+    const inGuardWindow = now - guardStartedAt < GUARD_WINDOW_MS
+    const userScrolledRecently = lastUserScrollAt > 0 && now - lastUserScrollAt < 1500
+    if (inGuardWindow && userScrolledRecently) {
+      w.__tdomScrollLog.push({
+        t: Math.round(now),
+        ev: 'suppressed',
+        args: JSON.stringify(args).slice(0, 80),
+        tSinceHydrate: Math.round(now - guardStartedAt),
+        tSinceUserScroll: Math.round(now - lastUserScrollAt),
+      })
+      return
+    }
+    w.__tdomScrollLog.push({
+      t: Math.round(now),
+      ev: 'allowed',
+      args: JSON.stringify(args).slice(0, 80),
+      tSinceHydrate: Math.round(now - guardStartedAt),
+      inGuard: inGuardWindow,
+      userScrolled: userScrolledRecently,
+    })
+    programmatic++
+    try {
+      return (origScrollTo as any).apply(this, args)
+    } finally {
+      queueMicrotask(() => {
+        programmatic = Math.max(0, programmatic - 1)
+      })
+    }
+  }
+}
+
+/**
+ * Hydration cursor: walks existing DOM children in document order so we can
+ * adopt them during fiber tree construction. One cursor per host parent.
+ *
+ * `endBefore` scopes the cursor to a subrange — used by rehydrateBoundary()
+ * so we only adopt DOM up to the closing `/$` marker for that boundary.
+ */
+export class HydrationCursor {
+  next: ChildNode | null
+  parent: Node
+  endBefore: ChildNode | null
+  constructor(parent: Node, start: ChildNode | null = null, endBefore: ChildNode | null = null) {
+    this.parent = parent
+    this.next = start ?? parent.firstChild
+    this.endBefore = endBefore
+  }
+  takeHostNode(): ChildNode | null {
+    while (this.next && this.next !== this.endBefore) {
+      const n = this.next
+      // Skip anything that isn't an element (1) or text (3):
+      // comments (8), doctype (10), processing instructions (7), cdata (4).
+      if (n.nodeType !== 1 && n.nodeType !== 3) {
+        this.next = n.nextSibling
+        continue
+      }
+      this.next = n.nextSibling
+      return n
+    }
+    return null
+  }
+  /**
+   * Position-insensitive lookup for head/html adoption. Scans forward past
+   * non-matching nodes without removing them, matching by tag AND the key
+   * attributes that identify head elements uniquely (rel/href for links,
+   * name/property for meta, src for script). Non-matching nodes stay in
+   * place so the SSR'd stylesheet/script order is preserved.
+   */
+  takeMatchingHeadElement(tag: string, props: Record<string, any>): ChildNode | null {
+    const target = tag.toLowerCase()
+    const keyAttrs = HEAD_KEY_ATTRS[target] ?? []
+    let scan = this.parent.firstChild
+    while (scan) {
+      if (
+        scan.nodeType === 1 &&
+        (scan as Element).tagName.toLowerCase() === target &&
+        headAttrsMatch(scan as Element, props, keyAttrs)
+      ) {
+        CLAIMED.add(scan)
+        return scan
+      }
+      scan = scan.nextSibling
+    }
+    return null
+  }
+  remaining(): ChildNode[] {
+    const out: ChildNode[] = []
+    let n = this.next
+    while (n && n !== this.endBefore) {
+      out.push(n)
+      n = n.nextSibling
+    }
+    return out
+  }
+}
+
+const hydrationCursors = new WeakMap<Fiber, HydrationCursor>()
+
+// Head elements that we match against server DOM by attribute signature.
+const HEAD_KEY_ATTRS: Record<string, ReadonlyArray<string>> = {
+  link: ['rel', 'href', 'sizes', 'type'],
+  meta: ['name', 'property', 'charset', 'http-equiv'],
+  script: ['src', 'type'],
+  style: [],
+  title: [],
+}
+
+// DOM elements already claimed by some fiber during this hydration pass.
+const CLAIMED = new WeakSet<Node>()
+
+function headAttrsMatch(
+  el: Element,
+  props: Record<string, any>,
+  keys: ReadonlyArray<string>,
+): boolean {
+  if (CLAIMED.has(el)) return false
+  if (keys.length === 0) return true
+  for (const k of keys) {
+    const propVal = props[k] ?? (k === 'http-equiv' ? props.httpEquiv : undefined)
+    const elVal = el.getAttribute(k)
+    // If neither defines it, skip this key; if one defines it, they must match.
+    if (propVal == null && elVal == null) continue
+    if (propVal == null || elVal == null) continue // tolerate missing on either side
+    if (String(propVal) !== elVal) return false
+  }
+  // At least one matching signal must be present.
+  return keys.some((k) => props[k] != null || el.hasAttribute(k))
+}
+
+export function beginHydration(root: FiberRoot): void {
+  root.hydrating = true
+  hydrationCursors.set(root.current, new HydrationCursor(root.container))
+}
+
+export function endHydration(root: FiberRoot): void {
+  root.hydrating = false
+  hydrationCursors.delete(root.current)
+}
+
+/**
+ * Inspect the current cursor position for a streaming-suspense boundary
+ * marker emitted by the server. Returns info + advances the cursor past the
+ * marker pair (start comment + fallback/real content + end comment).
+ */
+export interface BoundaryInfo {
+  kind: 'pending' | 'resolved'
+  id: number
+  startMark: Comment
+  endMark: Comment
+}
+
+export function tryConsumeBoundary(parent: Fiber): BoundaryInfo | null {
+  const cursor = hydrationCursors.get(findHostParent(parent))
+  if (!cursor) return null
+  const peek = cursor.next
+  if (!peek || peek.nodeType !== 8) return null
+  const data = (peek as Comment).data
+  const m = /^(\$\??)(\d+)$/.exec(data)
+  if (!m) return null
+  const kind = m[1] === '$?' ? 'pending' : 'resolved'
+  const id = Number(m[2])
+  const startMark = peek as Comment
+  // Advance past the start comment
+  cursor.next = startMark.nextSibling
+  // Locate end comment: closest <!--/$-->
+  let endMark: Comment | null = null
+  let scan = startMark.nextSibling
+  while (scan) {
+    if (scan.nodeType === 8 && (scan as Comment).data === '/$') {
+      endMark = scan as Comment
+      break
+    }
+    scan = scan.nextSibling
+  }
+  if (!endMark) return null
+  return { kind, id, startMark, endMark }
+}
+
+export function advanceCursorPast(parent: Fiber, node: Node): void {
+  const cursor = hydrationCursors.get(findHostParent(parent))
+  if (!cursor) return
+  cursor.next = node.nextSibling
+}
+
+export function getHydrationCursor(hostFiber: Fiber): HydrationCursor | undefined {
+  return hydrationCursors.get(hostFiber)
+}
+
+export function setHydrationCursor(hostFiber: Fiber, cursor: HydrationCursor): void {
+  hydrationCursors.set(hostFiber, cursor)
+}
+
+export function clearHydrationCursor(hostFiber: Fiber): void {
+  hydrationCursors.delete(hostFiber)
+}
+
+/**
+ * Try to adopt a DOM node for this host fiber. Returns true if adopted.
+ * Attaches existing attrs/children via separate hydrate pass.
+ */
+export function adoptHostDom(fiber: Fiber, parent: Fiber): boolean {
+  const hostParent = findHostParent(parent)
+  const cursor = hydrationCursors.get(hostParent)
+  if (!cursor) return false
+
+  const tag = (fiber.type as string).toLowerCase()
+  const parentEl = cursor.parent as Element
+  const parentTag =
+    parentEl.nodeType === 1 ? (parentEl as Element).tagName.toLowerCase() : ''
+  const isHeadish = parentTag === 'head' || parentTag === 'html'
+
+  let candidate: ChildNode | null
+  if (isHeadish) {
+    // Head/html children are position-insensitive — server may emit them in
+    // a different order than the React tree (React 19 head hoisting, etc.).
+    // Scan forward without removing non-matching nodes; match on attribute
+    // signature so we don't adopt the wrong <link> and clobber its props.
+    candidate = cursor.takeMatchingHeadElement(tag, fiber.pendingProps ?? {})
+  } else {
+    candidate = cursor.takeHostNode()
+  }
+
+  if (!candidate) {
+    // Client expected a host here but the cursor is exhausted — server gave
+    // fewer children than the client tree. Report the structural gap (React
+    // fires `onRecoverableError` for this exact case) and let the reconciler
+    // mount a fresh DOM for this fiber below.
+    // Exception: <head> children are position-insensitive; a missing match
+    // there means "server didn't hoist this one yet", which we silently mount.
+    if (!isHeadish) onMismatch(fiber, null)
+    return false
+  }
+
+  if (candidate.nodeType !== 1 || (candidate as Element).tagName.toLowerCase() !== tag) {
+    // mismatch — log and re-render fresh from this point
+    onMismatch(fiber, candidate)
+    return false
+  }
+  fiber.dom = candidate
+  // Apply props (attach events, sync IDL props). Don't re-set existing attrs.
+  const props = fiber.pendingProps ?? {}
+  const isSvg =
+    tag === 'svg' ||
+    ((candidate as Element).namespaceURI === 'http://www.w3.org/2000/svg' &&
+      tag !== 'foreignobject')
+  for (const k in props) {
+    if (k === 'children') continue
+    if (k[0] === 'o' && k[1] === 'n' && typeof props[k] === 'function') {
+      setProp(candidate as Element, k, props[k], undefined, isSvg)
+    }
+    // Non-event props: trust the server HTML, skip
+  }
+  // Set up child cursor for this host's children
+  hydrationCursors.set(fiber, new HydrationCursor(candidate))
+  return true
+}
+
+export function adoptTextDom(fiber: Fiber, parent: Fiber, text: string): boolean {
+  const cursor = hydrationCursors.get(findHostParent(parent))
+  if (!cursor) return false
+  const candidate = cursor.takeHostNode()
+  if (!candidate) return false
+  if (candidate.nodeType === 3) {
+    if ((candidate as Text).data !== text) {
+      ;(candidate as Text).data = text
+    }
+    fiber.dom = candidate
+    return true
+  }
+  onMismatch(fiber, candidate)
+  return false
+}
+
+export function findHostParent(fiber: Fiber): Fiber {
+  let f: Fiber | null = fiber
+  while (f) {
+    // A fiber explicitly holding a cursor acts as a boundary for hydration
+    // (e.g. Suspense with a scoped cursor during fallback/boundary hydration).
+    if (hydrationCursors.has(f)) return f
+    if (f.tag === FiberTag.Host || f.tag === FiberTag.Root || f.tag === FiberTag.Portal) {
+      return f
+    }
+    f = f.parent
+  }
+  throw new Error('No host parent found')
+}
+
+function onMismatch(fiber: Fiber, actualNode: ChildNode | null): void {
+  // For v1: log and exit hydration for this subtree. The normal reconciler
+  // will create a fresh DOM node below.
+  const root = findRoot(fiber)
+  if (root?.onRecoverableError) {
+    root.onRecoverableError(
+      new Error(
+        `Hydration mismatch: expected <${(fiber.type as string) ?? 'text'}> but found ${
+          actualNode ? (actualNode.nodeType === 1 ? (actualNode as Element).tagName : 'text') : 'nothing'
+        }.`,
+      ),
+    )
+  }
+  // Remove stale DOM if still there
+  if (actualNode && actualNode.parentNode) actualNode.parentNode.removeChild(actualNode)
+}

--- a/packages/redact/src/dom/features/hydration/index.ts
+++ b/packages/redact/src/dom/features/hydration/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/hydration/stub.ts
+++ b/packages/redact/src/dom/features/hydration/stub.ts
@@ -1,0 +1,72 @@
+import type { Fiber, FiberRoot } from '../../../core'
+
+// Stub: Hydration feature disabled. Every adoption attempt returns "no match",
+// all cursor operations no-op, and `beginHydration` throws so `hydrateRoot`
+// fails loudly — apps that opt out of hydration should use `createRoot`.
+// The SSR walk-the-DOM machinery, streaming-boundary coordination, head
+// element matching, and the WeakMap of cursors per fiber are all stripped.
+
+export class HydrationCursor {
+  next: ChildNode | null = null
+  parent: Node
+  endBefore: ChildNode | null = null
+  constructor(parent?: Node, _s?: ChildNode | null, _e?: ChildNode | null) {
+    this.parent = parent as Node
+  }
+  takeHostNode(): ChildNode | null {
+    return null
+  }
+  takeMatchingHeadElement(): ChildNode | null {
+    return null
+  }
+  remaining(): ChildNode[] {
+    return []
+  }
+}
+
+export interface BoundaryInfo {
+  kind: 'pending' | 'resolved'
+  id: number
+  startMark: Comment
+  endMark: Comment
+}
+
+export function beginHydration(_root: FiberRoot): void {
+  throw new Error(
+    '`hydrateRoot` requires the `hydration` feature. ' +
+      'Enable it via @ss/redact/vite `features.hydration = true`, ' +
+      'or use `createRoot` for a SPA (no SSR hydration).',
+  )
+}
+
+export function endHydration(_root: FiberRoot): void {}
+
+export function tryConsumeBoundary(_parent: Fiber): BoundaryInfo | null {
+  return null
+}
+
+export function advanceCursorPast(_parent: Fiber, _node: Node): void {}
+
+export function getHydrationCursor(_hostFiber: Fiber): HydrationCursor | undefined {
+  return undefined
+}
+
+export function setHydrationCursor(_hostFiber: Fiber, _cursor: HydrationCursor): void {}
+
+export function clearHydrationCursor(_hostFiber: Fiber): void {}
+
+export function adoptHostDom(_fiber: Fiber, _parent: Fiber): boolean {
+  return false
+}
+
+export function adoptTextDom(_fiber: Fiber, _parent: Fiber, _text: string): boolean {
+  return false
+}
+
+export function findHostParent(fiber: Fiber): Fiber {
+  return fiber
+}
+
+export function installHydrationScrollGuard(): void {}
+
+export function drainReplayQueue(): void {}

--- a/packages/redact/src/dom/features/index.ts
+++ b/packages/redact/src/dom/features/index.ts
@@ -1,0 +1,11 @@
+// Feature wiring. Each import is a side-effect import that triggers the
+// feature module's self-registration with the reconciler (renderer, type
+// matcher, element marker). A vite plugin can swap any entry to './stub'
+// to disable that feature in the emitted bundle.
+import './portal'
+import './context'
+import './suspense'
+import './memo'
+import './forward-ref'
+import './lazy'
+import './class'

--- a/packages/redact/src/dom/features/lazy/full.ts
+++ b/packages/redact/src/dom/features/lazy/full.ts
@@ -1,0 +1,98 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_LAZY_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  renderFiber,
+  scheduleUpdate,
+  isThenable,
+  handleSuspended,
+  getCurrentRoot,
+} from '../../reconcile'
+import {
+  getHydrationCursor,
+  setHydrationCursor,
+  findHostParent as findHydrationHost,
+} from '../hydration'
+
+function renderLazy(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const { _payload, _init } = fiber.type as any
+  let resolved: any
+  try {
+    resolved = _init(_payload)
+  } catch (thenable: any) {
+    if (isThenable(thenable)) {
+      // During initial hydration, a lazy component inside an SSR-resolved
+      // Suspense boundary needs special handling: the SSR DOM for its
+      // resolved content is already in the page and our cursor is pointing
+      // at it. A normal `handleSuspended` would schedule the lazy's later
+      // re-render WITHOUT the hydration cursor — so when it eventually
+      // resolves, we'd create a fresh DOM copy next to the SSR one (visible
+      // as duplicate logos / buttons / sections inside the Suspense). Mirror
+      // the pattern in renderFunction: preserve the in-scope cursor on this
+      // fiber and flag it for deferred re-hydration, so rerenderFiber
+      // restores `root.hydrating = true` and the resolved render adopts the
+      // existing DOM instead of mounting a duplicate.
+      const root = getCurrentRoot()
+      if (root?.hydrating) {
+        const hostParent = findHydrationHost(fiber)
+        const inheritedCursor = getHydrationCursor(hostParent)
+        if (inheritedCursor) {
+          setHydrationCursor(fiber, inheritedCursor)
+        }
+        fiber.memoizedState = {
+          ...(fiber.memoizedState ?? {}),
+          _pendingHydration: true,
+        }
+        // Mark the nearest ancestor Suspense as "awaiting hydration-resume"
+        // so a post-hydration re-render of that Suspense doesn't accidentally
+        // flip into suspended+pending and mount a fallback atop the SSR
+        // content. Match-by-tag-name works whether Suspense is the full
+        // feature or stubbed to Fragment (the walk just never finds one).
+        let sus: Fiber | null = fiber.parent
+        while (sus && sus.tag !== FiberTag.Suspense) sus = sus.parent
+        if (sus && sus.memoizedState) {
+          ;(sus.memoizedState as any)._awaitingLazyHydration = true
+        }
+        thenable.then(
+          () => {
+            if (sus && sus.memoizedState) {
+              ;(sus.memoizedState as any)._awaitingLazyHydration = false
+            }
+            scheduleUpdate(fiber)
+          },
+          () => {
+            if (sus && sus.memoizedState) {
+              ;(sus.memoizedState as any)._awaitingLazyHydration = false
+            }
+            scheduleUpdate(fiber)
+          },
+        )
+        return
+      }
+      handleSuspended(fiber, thenable)
+      // reconcileChildren would be called here if we were rendering children,
+      // but Lazy delegates and has no children of its own.
+      return
+    }
+    throw thenable
+  }
+  const savedTag = fiber.tag
+  const savedType = fiber.type
+  fiber.type = resolved
+  fiber.tag =
+    typeof resolved === 'function'
+      ? resolved.prototype?.isReactComponent
+        ? FiberTag.Class
+        : FiberTag.Function
+      : FiberTag.Fragment
+  try {
+    renderFiber(fiber, domParent, anchor)
+  } finally {
+    fiber.tag = savedTag
+    fiber.type = savedType
+  }
+}
+
+registerTypeMatcher((_type, marker) => (marker === REACT_LAZY_TYPE ? FiberTag.Lazy : null))
+registerRenderer(FiberTag.Lazy, renderLazy)

--- a/packages/redact/src/dom/features/lazy/index.ts
+++ b/packages/redact/src/dom/features/lazy/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/lazy/stub.ts
+++ b/packages/redact/src/dom/features/lazy/stub.ts
@@ -1,0 +1,45 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_LAZY_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  renderFiber,
+  isThenable,
+  handleSuspended,
+} from '../../reconcile'
+
+// Stub: Lazy feature disabled. Lazy elements still resolve — sync if the
+// payload is ready, otherwise the thrown thenable goes through the default
+// `handleSuspended` capability (retry-on-settle). What's stripped: the
+// hydration-deferred-reveal pathway and the Suspense-awaiting coordination.
+function renderLazyStub(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const { _payload, _init } = fiber.type as any
+  let resolved: any
+  try {
+    resolved = _init(_payload)
+  } catch (thrown: any) {
+    if (isThenable(thrown)) {
+      handleSuspended(fiber, thrown)
+      return
+    }
+    throw thrown
+  }
+  const savedTag = fiber.tag
+  const savedType = fiber.type
+  fiber.type = resolved
+  fiber.tag =
+    typeof resolved === 'function'
+      ? resolved.prototype?.isReactComponent
+        ? FiberTag.Class
+        : FiberTag.Function
+      : FiberTag.Fragment
+  try {
+    renderFiber(fiber, domParent, anchor)
+  } finally {
+    fiber.tag = savedTag
+    fiber.type = savedType
+  }
+}
+
+registerTypeMatcher((_type, marker) => (marker === REACT_LAZY_TYPE ? FiberTag.Lazy : null))
+registerRenderer(FiberTag.Lazy, renderLazyStub)

--- a/packages/redact/src/dom/features/memo/full.ts
+++ b/packages/redact/src/dom/features/memo/full.ts
@@ -1,0 +1,74 @@
+import { FiberTag, type Fiber } from '../../../core'
+import {
+  REACT_FORWARD_REF_TYPE,
+  REACT_MEMO_TYPE,
+  REACT_LAZY_TYPE,
+} from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  renderFiber,
+  getForceRerenderingFiber,
+} from '../../reconcile'
+
+function shallowEqual(a: any, b: any): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    if (a[k] !== b[k]) return false
+  }
+  return true
+}
+
+function renderMemo(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const { type, compare } = fiber.type as any
+  const props = fiber.pendingProps ?? {}
+  const prev = fiber.memoizedProps
+
+  // Memo's prop-equality gate guards PARENT-triggered rerenders. If this
+  // render is a STATE-triggered rerender of this exact fiber (hook update,
+  // useSyncExternalStore notification), props haven't changed by definition —
+  // bailing would swallow the state change and the subscriber never re-runs.
+  // rerenderFiber tags the fiber so we skip the gate here.
+  const bypassMemo = fiber === getForceRerenderingFiber()
+  const eq = !bypassMemo && prev && (compare ? compare(prev, props) : shallowEqual(prev, props))
+  if (eq) {
+    // Re-render children with previous output (already in tree)
+    return
+  }
+
+  // Determine the delegated tag based on the memoized type. `React.memo` can
+  // wrap plain functions, class components, OR other special types like
+  // `forwardRef`. Without the marker-based branch we'd mistreat
+  // `memo(forwardRef(...))` as a Fragment and render nothing.
+  let innerTag: FiberTag
+  if (typeof type === 'function') {
+    innerTag = type.prototype?.isReactComponent ? FiberTag.Class : FiberTag.Function
+  } else if (type && typeof type === 'object') {
+    const m = (type as any).$$typeof
+    if (m === REACT_FORWARD_REF_TYPE) innerTag = FiberTag.ForwardRef
+    else if (m === REACT_MEMO_TYPE) innerTag = FiberTag.Memo
+    else if (m === REACT_LAZY_TYPE) innerTag = FiberTag.Lazy
+    else innerTag = FiberTag.Fragment
+  } else {
+    innerTag = FiberTag.Fragment
+  }
+
+  // Swap tag and type for this render pass; this is a "delegating" render
+  const savedTag = fiber.tag
+  const savedType = fiber.type
+  fiber.tag = innerTag
+  fiber.type = type
+  try {
+    renderFiber(fiber, domParent, anchor)
+  } finally {
+    fiber.tag = savedTag
+    fiber.type = savedType
+  }
+}
+
+registerTypeMatcher((_type, marker) => (marker === REACT_MEMO_TYPE ? FiberTag.Memo : null))
+registerRenderer(FiberTag.Memo, renderMemo)

--- a/packages/redact/src/dom/features/memo/index.ts
+++ b/packages/redact/src/dom/features/memo/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/memo/stub.ts
+++ b/packages/redact/src/dom/features/memo/stub.ts
@@ -1,0 +1,42 @@
+import { FiberTag, type Fiber } from '../../../core'
+import {
+  REACT_FORWARD_REF_TYPE,
+  REACT_MEMO_TYPE,
+  REACT_LAZY_TYPE,
+} from '../../../react'
+import { registerRenderer, registerTypeMatcher, renderFiber } from '../../reconcile'
+
+// Stub: Memo feature disabled. `memo(Component)` still works — the element
+// renders — but without the prop-equality gate, so every parent rerender
+// passes through to the inner component. `shallowEqual` and the
+// forceRerenderingFiber read are stripped.
+function renderMemoStub(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const { type } = fiber.type as any
+
+  let innerTag: FiberTag
+  if (typeof type === 'function') {
+    innerTag = type.prototype?.isReactComponent ? FiberTag.Class : FiberTag.Function
+  } else if (type && typeof type === 'object') {
+    const m = (type as any).$$typeof
+    if (m === REACT_FORWARD_REF_TYPE) innerTag = FiberTag.ForwardRef
+    else if (m === REACT_MEMO_TYPE) innerTag = FiberTag.Memo
+    else if (m === REACT_LAZY_TYPE) innerTag = FiberTag.Lazy
+    else innerTag = FiberTag.Fragment
+  } else {
+    innerTag = FiberTag.Fragment
+  }
+
+  const savedTag = fiber.tag
+  const savedType = fiber.type
+  fiber.tag = innerTag
+  fiber.type = type
+  try {
+    renderFiber(fiber, domParent, anchor)
+  } finally {
+    fiber.tag = savedTag
+    fiber.type = savedType
+  }
+}
+
+registerTypeMatcher((_type, marker) => (marker === REACT_MEMO_TYPE ? FiberTag.Memo : null))
+registerRenderer(FiberTag.Memo, renderMemoStub)

--- a/packages/redact/src/dom/features/portal/full.ts
+++ b/packages/redact/src/dom/features/portal/full.ts
@@ -1,0 +1,22 @@
+import { FiberTag, type Fiber, type ReactNode } from '../../../core'
+import { REACT_PORTAL_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  registerElementMarker,
+  reconcileChildren,
+  childrenToArray,
+} from '../../reconcile'
+
+function renderPortal(fiber: Fiber, _domParent: Node, _anchor: Node | null): void {
+  const { children, container } = fiber.pendingProps as {
+    children: ReactNode
+    container: Element
+  }
+  reconcileChildren(fiber, childrenToArray(children), container, null)
+  fiber.memoizedProps = fiber.pendingProps
+}
+
+registerElementMarker(REACT_PORTAL_TYPE)
+registerTypeMatcher((type) => (type === REACT_PORTAL_TYPE ? FiberTag.Portal : null))
+registerRenderer(FiberTag.Portal, renderPortal)

--- a/packages/redact/src/dom/features/portal/index.ts
+++ b/packages/redact/src/dom/features/portal/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/portal/stub.ts
+++ b/packages/redact/src/dom/features/portal/stub.ts
@@ -1,0 +1,11 @@
+import { FiberTag } from '../../../core'
+import { REACT_PORTAL_TYPE } from '../../../react'
+import { registerTypeMatcher, registerElementMarker } from '../../reconcile'
+
+// Stub: Portal feature disabled. Portal elements still flow through JSX
+// (otherwise they'd be silently dropped by child normalization), but render
+// in place as a Fragment — the `container` prop is ignored. No Portal
+// renderer is registered, so the `renderPortal` function and its deps don't
+// ship in builds that select this stub.
+registerElementMarker(REACT_PORTAL_TYPE)
+registerTypeMatcher((type) => (type === REACT_PORTAL_TYPE ? FiberTag.Fragment : null))

--- a/packages/redact/src/dom/features/suspense/full.ts
+++ b/packages/redact/src/dom/features/suspense/full.ts
@@ -1,0 +1,191 @@
+import { FiberTag, type Fiber } from '../../../core'
+import { REACT_SUSPENSE_TYPE } from '../../../react'
+import {
+  registerRenderer,
+  registerTypeMatcher,
+  installCapability,
+  reconcileChildren,
+  childrenToArray,
+  scheduleUpdate,
+  unmountAllChildren,
+  findRoot,
+  runEffects,
+  getCurrentRoot,
+  withCurrentRoot,
+} from '../../reconcile'
+import {
+  HydrationCursor,
+  setHydrationCursor,
+  clearHydrationCursor,
+  advanceCursorPast,
+  tryConsumeBoundary,
+} from '../hydration'
+
+const suspendHandlerStack: Array<(t: Promise<any>) => void> = []
+
+function realHandleSuspended(fiber: Fiber, thenable: Promise<any>): void {
+  const handler = suspendHandlerStack[suspendHandlerStack.length - 1]
+  if (handler) {
+    handler(thenable)
+    return
+  }
+  // Fallback: schedule re-render when promise settles
+  thenable.then(
+    () => scheduleUpdate(fiber),
+    () => scheduleUpdate(fiber),
+  )
+}
+
+function renderSuspense(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const props = fiber.pendingProps ?? {}
+  const state = (fiber.memoizedState ??= { suspended: false, pending: null as Promise<any> | null })
+
+  // Streaming hydration: if the next DOM node is a server-emitted boundary
+  // marker, route through the boundary-aware hydration path.
+  const root = getCurrentRoot()
+  if (root?.hydrating && fiber.parent && !state.hydrated) {
+    const boundary = tryConsumeBoundary(fiber.parent)
+    if (boundary) {
+      hydrateSuspenseBoundary(fiber, props, boundary, domParent, anchor)
+      state.hydrated = true
+      return
+    }
+  }
+
+  // A descendant Lazy deferred its hydration (see renderLazy's hydrating
+  // branch). Its SSR-rendered content is still in the DOM and cursor-bound
+  // via the Lazy fiber — we just haven't swapped it into a fiber subtree
+  // yet. Until the Lazy's resume fires, skip our own tryChildren pass so
+  // an unrelated re-render can't accidentally flip us into the suspended
+  // path and mount a duplicate fallback on top of the SSR content.
+  if ((state as any)._awaitingLazyHydration) {
+    fiber.memoizedProps = props
+    return
+  }
+
+  const tryChildren = () => {
+    reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
+  }
+
+  if (state.suspended && state.pending) {
+    // Render fallback while waiting; pending promise will reschedule
+    reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+    fiber.memoizedProps = props
+    return
+  }
+
+  // Attempt children — suspension is handled by the pushed handler below
+  const savedHandler = suspendHandlerStack[suspendHandlerStack.length - 1]
+  suspendHandlerStack.push((thenable) => {
+    state.suspended = true
+    state.pending = thenable
+    thenable.then(
+      () => {
+        state.suspended = false
+        state.pending = null
+        scheduleUpdate(fiber)
+      },
+      () => {
+        state.suspended = false
+        state.pending = null
+        scheduleUpdate(fiber)
+      },
+    )
+  })
+  try {
+    tryChildren()
+  } finally {
+    suspendHandlerStack.pop()
+    void savedHandler
+  }
+
+  if (state.suspended) {
+    // Replace children with fallback
+    unmountAllChildren(fiber, domParent)
+    reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+  }
+  fiber.memoizedProps = props
+}
+
+function hydrateSuspenseBoundary(
+  fiber: Fiber,
+  props: any,
+  boundary: { kind: 'pending' | 'resolved'; id: number; startMark: Comment; endMark: Comment },
+  domParent: Node,
+  anchor: Node | null,
+): void {
+  const { kind, id, startMark, endMark } = boundary
+  // Record the boundary shape so we can re-hydrate on reveal.
+  fiber.memoizedState = {
+    suspended: false,
+    pending: null,
+    hydrated: true,
+    boundaryId: id,
+    startMark,
+    endMark,
+    realChildren: props.children,
+  }
+
+  if (kind === 'resolved') {
+    // Real DOM is inline between startMark and endMark. Hydrate into it.
+    const cursor = new HydrationCursor(startMark.parentNode!, startMark.nextSibling, endMark)
+    setHydrationCursor(fiber, cursor)
+    reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
+    clearHydrationCursor(fiber)
+    advanceCursorPast(fiber.parent!, endMark)
+    fiber.memoizedProps = props
+    return
+  }
+
+  // Pending: fallback DOM lives inside <div id="B:ID">. Hydrate the fallback
+  // React subtree against that div's children.
+  const bDiv = (document as Document).getElementById(`B:${id}`)
+  if (bDiv) {
+    const cursor = new HydrationCursor(bDiv)
+    setHydrationCursor(fiber, cursor)
+    reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+    clearHydrationCursor(fiber)
+  } else {
+    // Couldn't find fallback container — render fresh (non-adopting)
+    reconcileChildren(fiber, childrenToArray(props.fallback), domParent, anchor)
+  }
+  advanceCursorPast(fiber.parent!, endMark)
+
+  // Register for server-streamed reveal (HTML chunks + $RC calls).
+  const win = globalThis as any
+  if (typeof win.$RH === 'function') {
+    win.$RH(id, () => rehydrateBoundary(fiber))
+  }
+  // If the inline runtime isn't present, nothing external will mark us dirty.
+
+  fiber.memoizedProps = props
+}
+
+function rehydrateBoundary(fiber: Fiber): void {
+  const state = fiber.memoizedState
+  if (!state || !state.startMark || !state.endMark) return
+
+  const root = findRoot(fiber)
+  if (!root) return
+  const parent = state.startMark.parentNode as Node
+  if (!parent) return
+
+  // Unmount existing fallback subtree. Its DOM has already been removed by $RC
+  // (or at least its container); unmounting here cleans up fibers + effects.
+  withCurrentRoot(root, () => {
+    unmountAllChildren(fiber, parent)
+
+    // Re-hydrate with real children against the now-real DOM range.
+    root.hydrating = true
+    const cursor = new HydrationCursor(parent, state.startMark.nextSibling, state.endMark)
+    setHydrationCursor(fiber, cursor)
+    reconcileChildren(fiber, childrenToArray(state.realChildren), parent, null)
+    clearHydrationCursor(fiber)
+    root.hydrating = false
+    runEffects(root)
+  })
+}
+
+registerTypeMatcher((type) => (type === REACT_SUSPENSE_TYPE ? FiberTag.Suspense : null))
+registerRenderer(FiberTag.Suspense, renderSuspense)
+installCapability('handleSuspended', realHandleSuspended)

--- a/packages/redact/src/dom/features/suspense/index.ts
+++ b/packages/redact/src/dom/features/suspense/index.ts
@@ -1,0 +1,1 @@
+export * from './full'

--- a/packages/redact/src/dom/features/suspense/stub.ts
+++ b/packages/redact/src/dom/features/suspense/stub.ts
@@ -1,0 +1,12 @@
+import { FiberTag } from '../../../core'
+import { REACT_SUSPENSE_TYPE } from '../../../react'
+import { registerTypeMatcher } from '../../reconcile'
+
+// Stub: Suspense feature disabled. `<Suspense>` elements render as Fragments
+// — children mount inline and `fallback` is ignored. Thrown thenables in
+// descendants fall through to the default `handleSuspended` capability
+// (in reconcile.ts), which schedules a re-render when the promise settles.
+// Eventual consistency still works; there's just no fallback UI during the
+// pending window. Boundary-handler stack, streaming hydration integration,
+// and fallback-swap logic are all stripped.
+registerTypeMatcher((type) => (type === REACT_SUSPENSE_TYPE ? FiberTag.Fragment : null))

--- a/packages/redact/src/dom/index.ts
+++ b/packages/redact/src/dom/index.ts
@@ -1,0 +1,33 @@
+// Side-effect import: registers opt-in features (Portal, etc.) with the
+// reconciler. A vite plugin may alias individual feature modules to their
+// stub variants to strip them from the bundle.
+import './features'
+
+export { flushSync, batchedUpdates as unstable_batchedUpdates } from './root'
+export { createPortal } from './portal'
+
+// Resource hints — stubs
+export function preconnect(_href: string, _opts?: any): void {}
+export function prefetchDNS(_href: string): void {}
+export function preload(_href: string, _opts?: any): void {}
+export function preinit(_href: string, _opts?: any): void {}
+export function preloadModule(_href: string, _opts?: any): void {}
+export function preinitModule(_href: string, _opts?: any): void {}
+
+export const version = '19.2.3'
+
+// Required by React's default export consumers
+import { flushSync, batchedUpdates } from './root'
+import { createPortal } from './portal'
+export default {
+  flushSync,
+  unstable_batchedUpdates: batchedUpdates,
+  createPortal,
+  preconnect,
+  prefetchDNS,
+  preload,
+  preinit,
+  preloadModule,
+  preinitModule,
+  version: '19.2.3',
+}

--- a/packages/redact/src/dom/portal.ts
+++ b/packages/redact/src/dom/portal.ts
@@ -1,0 +1,16 @@
+import type { ReactNode, ReactElement } from '../core'
+import { REACT_PORTAL_TYPE } from '../react'
+
+export function createPortal(
+  children: ReactNode,
+  container: Element,
+  key: string | null = null,
+): ReactElement {
+  return {
+    $$typeof: REACT_PORTAL_TYPE as any,
+    type: REACT_PORTAL_TYPE as any,
+    key: key == null ? null : '' + key,
+    ref: null,
+    props: { children, container },
+  }
+}

--- a/packages/redact/src/dom/reconcile.ts
+++ b/packages/redact/src/dom/reconcile.ts
@@ -1,0 +1,1263 @@
+import {
+  FiberTag,
+  FiberFlag,
+  createFiber,
+  REACT_ELEMENT_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
+  REACT_FRAGMENT_TYPE,
+  type Fiber,
+  type FiberRoot,
+  type ReactElement,
+  type ReactNode,
+  type Hook,
+  type Effect,
+} from '../core'
+import {
+  ReactSharedInternals,
+  REACT_LAZY_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_PROFILER_TYPE,
+} from '../react'
+import { createHostNode, setProp } from './dom'
+import { makeDispatcher } from './dispatcher'
+import {
+  adoptHostDom,
+  adoptTextDom,
+  tryConsumeBoundary,
+  advanceCursorPast,
+  setHydrationCursor,
+  getHydrationCursor,
+  clearHydrationCursor,
+  HydrationCursor,
+  findHostParent as findHydrationHost,
+} from './features/hydration'
+
+// ---------------------------------------------------------------------------
+// Render scheduling
+// ---------------------------------------------------------------------------
+
+let currentRoot: FiberRoot | null = null
+let flushing = false
+let isBatching = false
+const pendingRoots = new Set<FiberRoot>()
+
+// Set by rerenderFiber to identify the exact memo-tagged fiber whose INTERNAL
+// state (hook update, useSyncExternalStore notification) triggered this render
+// pass. renderMemo checks this to bypass its prop-equality gate for that fiber.
+// Without the bypass, a memo bail would swallow state changes: React's memo is
+// only a parent-triggered gate — state-driven rerenders must always run the
+// inner function. Router-adjacent components (Outlet, Match, MatchInner) are
+// all memo-wrapped and subscribe to stores; missing this bypass breaks nav
+// content updates even though the URL changes.
+let forceRerenderingFiber: Fiber | null = null
+
+export function scheduleUpdate(fiber: Fiber): void {
+  // Drop updates scheduled on already-unmounted fibers. Subscribers (router,
+  // query, any external store) can fire after unmount if their cleanup was
+  // missed, and letting those reach rerenderFiber mounts zombie DOM into the
+  // old .parent's DOM (which stays reachable via the stale pointer).
+  if (fiber.unmounted) return
+  const root = findRoot(fiber)
+  if (!root) return
+  root.pending.add(fiber)
+  fiber.dirty = true
+  pendingRoots.add(root)
+  if (isBatching) return
+  if (!root.scheduled) {
+    root.scheduled = true
+    queueMicrotask(flushPending)
+  }
+}
+
+export function flushSyncWork(fn: () => void): void {
+  const wasBatching = isBatching
+  isBatching = true
+  try {
+    fn()
+  } finally {
+    isBatching = wasBatching
+  }
+  flushPending()
+}
+
+export function batchedUpdates<T>(fn: () => T): T {
+  const wasBatching = isBatching
+  isBatching = true
+  try {
+    return fn()
+  } finally {
+    isBatching = wasBatching
+    if (!wasBatching) flushPending()
+  }
+}
+
+function flushPending(): void {
+  if (flushing) return
+  flushing = true
+  try {
+    let guard = 0
+    while (pendingRoots.size > 0) {
+      if (++guard > 50) {
+        throw new Error('flushPending exceeded 50 iterations — suspected infinite update loop.')
+      }
+      const roots = [...pendingRoots]
+      pendingRoots.clear()
+      for (const root of roots) {
+        root.scheduled = false
+        // Render each pending fiber from shallowest first so an ancestor's
+        // cascade reaches descendants before we try to render them directly.
+        // Descendants rendered via cascade still have `dirty=true` (only
+        // rerenderFiber clears it); when we later reach them in this loop,
+        // rerenderFiber's own `if (!dirty) return` is our short-circuit. We
+        // previously filtered descendants of dirty ancestors here, but that
+        // loses updates whenever an ancestor's render doesn't actually reach
+        // the descendant — e.g. React.memo bailing on equal props. Keep all
+        // dirty fibers and let rerenderFiber de-dupe via its dirty check.
+        const pending = [...root.pending]
+        root.pending.clear()
+        pending.sort((a, b) => fiberDepth(a) - fiberDepth(b))
+        for (const fiber of pending) {
+          rerenderFiber(fiber, root)
+        }
+        runEffects(root)
+      }
+    }
+  } finally {
+    flushing = false
+  }
+}
+
+function fiberDepth(fiber: Fiber): number {
+  let d = 0
+  let p: Fiber | null = fiber.parent
+  while (p) {
+    d++
+    p = p.parent
+  }
+  return d
+}
+
+export function findRoot(fiber: Fiber): FiberRoot | null {
+  let f: Fiber | null = fiber
+  while (f) {
+    if (f.root) return f.root
+    f = f.parent
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Entry points (called by createRoot)
+// ---------------------------------------------------------------------------
+
+export function renderRoot(root: FiberRoot, children: ReactNode): void {
+  const rootFiber = root.current
+  rootFiber.pendingProps = { children }
+  currentRoot = root
+  try {
+    reconcileChildren(rootFiber, childrenToArray(children), root.container as Node, null)
+    rootFiber.memoizedProps = rootFiber.pendingProps
+    rootFiber.dirty = false
+  } finally {
+    currentRoot = null
+  }
+  runEffects(root)
+}
+
+function rerenderFiber(fiber: Fiber, root: FiberRoot): void {
+  if (!fiber.dirty) return
+  // Skip fibers that were unmounted between scheduling and flush. Without this,
+  // the flush loop re-enters a zombie fiber whose .parent is still set; its
+  // render mounts fresh DOM into the old parent's still-attached DOM (since
+  // unmountFiber only clears fiber.child, not fiber.parent). Visible as route
+  // content from a previous location staying on screen after nav, because a
+  // pending rerender on the old route's LibraryLandingPage (unmounted during
+  // Outlet's shallow-first render) still fires from root.pending.
+  if (fiber.unmounted) return
+  // Clear BEFORE rendering so a scheduleUpdate() triggered mid-render (e.g.
+  // error boundary catching a descendant throw) marks us dirty for the next
+  // flush iteration instead of being wiped out when render() completes.
+  fiber.dirty = false
+  currentRoot = root
+  // If this rerender is resuming a hydration that was deferred by a suspension,
+  // re-activate hydration mode for its duration so descendants adopt DOM
+  // instead of re-creating it.
+  const resumeHydration =
+    fiber.memoizedState && (fiber.memoizedState as any)._pendingHydration === true
+  const prevHydrating = root.hydrating
+  if (resumeHydration) {
+    delete (fiber.memoizedState as any)._pendingHydration
+    root.hydrating = true
+  }
+  const prevForcing = forceRerenderingFiber
+  forceRerenderingFiber = fiber
+  try {
+    renderFiber(fiber, getHostParent(fiber), getAnchor(fiber))
+  } finally {
+    forceRerenderingFiber = prevForcing
+    if (resumeHydration) {
+      root.hydrating = prevHydrating
+      // Deferred hydration completed — detach the preserved cursor so future
+      // updates (post-hydration state changes) don't try to adopt stale DOM.
+      clearHydrationCursor(fiber)
+    }
+    currentRoot = null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Element → children normalization
+// ---------------------------------------------------------------------------
+
+// Text children pass through as raw strings — no wrapper. The previous
+// `{_text: string}` shape allocated tens of thousands of objects per
+// stable-list re-render and dominated minor-GC pressure. `typeof === 'string'`
+// is also robust to RSC renderable proxies (which have `has` traps that
+// would fool a `'_text' in child` predicate but can't fool `typeof`).
+type NormalizedChild = ReactElement | string | null
+
+function isTextChild(child: Exclude<NormalizedChild, null>): child is string {
+  return typeof child === 'string'
+}
+
+export function childrenToArray(children: ReactNode): NormalizedChild[] {
+  const out: NormalizedChild[] = []
+  pushChildren(children, out)
+  return out
+}
+
+function pushChildren(node: ReactNode, out: NormalizedChild[]): void {
+  if (node == null || typeof node === 'boolean') return
+  if (typeof node === 'string') {
+    // Empty strings render no text node (matches React + the `<!-- -->`
+    // separator elision on the SSR side so server/client agree).
+    if (node === '') return
+    out.push(node)
+    return
+  }
+  if (typeof node === 'number') {
+    out.push('' + node)
+    return
+  }
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) pushChildren(node[i], out)
+    return
+  }
+  if (isIterable(node)) {
+    for (const item of node as Iterable<ReactNode>) pushChildren(item, out)
+    return
+  }
+  if (typeof node === 'object') {
+    const t = (node as any).$$typeof
+    if (ACCEPTED_ELEMENT_MARKERS.has(t)) {
+      out.push(node as ReactElement)
+      return
+    }
+    // Raw React.lazy as a child. RSC Flight encodes 'use client' components
+    // (CodeBlock, CodeExplorer, etc.) as bare Lazy objects in the tree, not
+    // wrapped in REACT_ELEMENT_TYPE. Dropping them made code snippets
+    // disappear from docs pages. The RSC decoder pre-awaits payloads via
+    // `awaitLazyElements`, so by render time the status is 'fulfilled' and
+    // `_init()` returns the resolved element synchronously.
+    if (t === REACT_LAZY_TYPE) {
+      const lazy = node as any
+      const resolved = lazy._init(lazy._payload)
+      pushChildren(resolved, out)
+      return
+    }
+  }
+}
+
+function isIterable(obj: any): boolean {
+  return obj != null && typeof obj !== 'string' && typeof obj[Symbol.iterator] === 'function'
+}
+
+function getKeyOf(child: NormalizedChild, index: number): string {
+  if (!child) return 'n' + index
+  if (isTextChild(child)) return '$t' + index
+  if (child.key != null) return 'k' + child.key
+  return 'i' + index
+}
+
+function sameType(fiber: Fiber, child: NormalizedChild): boolean {
+  if (!child) return false
+  if (isTextChild(child)) return fiber.tag === FiberTag.Text
+  return fiber.type === child.type && sameKey(fiber.key, child.key)
+}
+
+function sameKey(a: string | null, b: string | null | undefined): boolean {
+  return (a ?? null) === (b ?? null)
+}
+
+// ---------------------------------------------------------------------------
+// Fiber creation
+// ---------------------------------------------------------------------------
+
+function fiberFromChild(child: NormalizedChild, parent: Fiber): Fiber {
+  if (!child) return createFiber(FiberTag.Fragment, null, null)
+  if (isTextChild(child)) {
+    const f = createFiber(FiberTag.Text, null, null)
+    f.pendingProps = child
+    f.parent = parent
+    return f
+  }
+  const type = child.type
+  let tag: FiberTag = FiberTag.Host
+  const marker = type && (type as any).$$typeof
+  if (typeof type === 'string') tag = FiberTag.Host
+  else if (type === REACT_FRAGMENT_TYPE) tag = FiberTag.Fragment
+  else if (type === REACT_STRICT_MODE_TYPE || type === REACT_PROFILER_TYPE) tag = FiberTag.Fragment
+  else {
+    // Feature-registered type matchers (Portal, future extractions). Features
+    // that carry the symbol as element.type directly (rather than wrapping in
+    // REACT_ELEMENT_TYPE) match here by type identity.
+    let matched: FiberTag | null = null
+    for (const m of TYPE_MATCHERS) {
+      matched = m(type, marker)
+      if (matched !== null) break
+    }
+    if (matched !== null) tag = matched
+    else if (typeof type === 'function') {
+      tag = type.prototype && type.prototype.isReactComponent ? FiberTag.Class : FiberTag.Function
+    }
+  }
+  const f = createFiber(tag, type, child.key ?? null)
+  f.ref = (child as any).ref ?? null
+  f.pendingProps = child.props
+  f.parent = parent
+  return f
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile a parent fiber's child list against new normalized children.
+ * Mutates parent.child and the sibling chain.
+ * Mounts new host DOM into `domParent` before `anchor` (or appends if anchor === null).
+ */
+export function reconcileChildren(
+  parent: Fiber,
+  newChildren: NormalizedChild[],
+  domParent: Node,
+  anchor: Node | null,
+): void {
+  // Fast path: unkeyed positional steady-state. Walk the existing sibling
+  // chain and newChildren in lockstep, validating AND committing in one pass.
+  // On any divergence we fall back to the slow path, which rebuilds the
+  // sibling chain anyway — partial pendingProps writes are idempotent.
+  // Skips the Map / Set / existing-array allocation entirely.
+  if (!currentRoot?.hydrating) {
+    let f: Fiber | null = parent.child
+    let ok = true
+    for (let i = 0; i < newChildren.length; i++) {
+      const child = newChildren[i]
+      if (child == null || !f || f.key != null) { ok = false; break }
+      if (typeof child === 'string') {
+        if (f.tag !== FiberTag.Text) { ok = false; break }
+        f.pendingProps = child
+      } else {
+        if ((child as ReactElement).key != null) { ok = false; break }
+        if (f.type !== (child as ReactElement).type) { ok = false; break }
+        f.pendingProps = (child as ReactElement).props
+        f.ref = (child as any).ref ?? null
+      }
+      f = f.sibling
+    }
+    if (ok && f === null) {
+      // Pass 2: render forward with per-child anchors. Identical to the slow
+      // path's pass 2.
+      for (let r: Fiber | null = parent.child; r; r = r.sibling) {
+        let a = anchor
+        for (let s: Fiber | null = r.sibling; s; s = s.sibling) {
+          const d = firstDomNode(s)
+          if (d && d.parentNode === domParent) { a = d; break }
+        }
+        renderFiber(r, domParent, a)
+      }
+      return
+    }
+  }
+
+  const existing = collectChildren(parent)
+  const keyed = new Map<string, Fiber>()
+  for (const f of existing) {
+    if (f.key != null) keyed.set('k' + f.key, f)
+  }
+
+  let prevNewFiber: Fiber | null = null
+  const claimed = new Set<Fiber>()
+  let structurallyChanged = false
+  // Budget-guided positional matching. We walk `existing` (unkeyed only) with a
+  // single cursor `existingIdx` and, on a type mismatch, choose insert vs delete
+  // based on the remaining length delta (`budget`):
+  //   budget > 0: more new than old remain → treat slot as an INSERTION: keep
+  //               the old cursor and create a fresh fiber for new[i].
+  //   budget < 0: more old than new remain → treat slot as a DELETION: advance
+  //               the old cursor past the mismatched fiber (it'll be unmounted
+  //               in the unclaimed pass) and retry.
+  //   budget == 0: equal remaining → treat as REPLACE by preferring delete
+  //               until budget flips positive or we hit a match.
+  // This avoids greedy forward scans that steal a later same-type fiber for a
+  // newly inserted leading sibling (e.g. smallMenu flipping null → <div>
+  // stealing the content <div>'s fiber and tearing down the drawer fragment).
+  let existingIdx = 0
+  let unkeyedOld = 0
+  for (const f of existing) if (f.key == null) unkeyedOld++
+  let unkeyedNew = 0
+  for (const c of newChildren) if (c != null) unkeyedNew++
+  let budget = unkeyedNew - unkeyedOld
+
+  // Pass 1 (this loop): match against existing fibers and build the sibling
+  // chain. Pass 2 (after the loop) renders each fiber with the correct
+  // per-child anchor — the firstDomNode of its next still-mounted sibling,
+  // or the parent's own anchor for the rightmost. Without per-child anchors
+  // a child whose render output type changes from no-DOM (Portal, null) to
+  // an in-flow host gets appended to the end of domParent (every child
+  // would otherwise share the parent's anchor) and never moves before its
+  // later siblings. Hit by the t3code Sidebar swap from a portal-rendering
+  // <Sheet> to a <div data-slot=sidebar> when isMobile flips during a
+  // Provider re-render.
+  for (let i = 0; i < newChildren.length; i++) {
+    const child = newChildren[i]
+    if (child == null) continue
+
+    let match: Fiber | null = null
+
+    // key-based match
+    if (child && typeof child === 'object' && !isTextChild(child) && (child as ReactElement).key != null) {
+      const k = 'k' + (child as ReactElement).key
+      const m = keyed.get(k)
+      if (m && m.type === (child as ReactElement).type) {
+        match = m
+        keyed.delete(k)
+      }
+    }
+
+    if (!match) {
+      while (existingIdx < existing.length) {
+        const cand = existing[existingIdx]!
+        if (claimed.has(cand) || cand.key != null) {
+          existingIdx++
+          continue
+        }
+        if (sameType(cand, child)) {
+          match = cand
+          existingIdx++
+          break
+        }
+        // Type mismatch at the cursor. Resolve via budget.
+        if (budget > 0) {
+          // Insertion: leave cand in place, create new for child.
+          break
+        }
+        // Deletion (or replace-as-delete-first): advance past cand. It remains
+        // unclaimed and will be unmounted at the end.
+        existingIdx++
+        budget++
+      }
+    }
+
+    // Detect reorder: matched fiber is not at its original position
+    if (match && existing[i] !== match) structurallyChanged = true
+
+    let fiber: Fiber
+    if (match) {
+      claimed.add(match)
+      fiber = match
+      if (isTextChild(child!)) {
+        fiber.pendingProps = child
+      } else {
+        fiber.type = (child as ReactElement).type
+        fiber.pendingProps = (child as ReactElement).props
+        fiber.ref = (child as any).ref ?? null
+      }
+    } else {
+      fiber = fiberFromChild(child, parent)
+      structurallyChanged = true
+      if (budget > 0) budget--
+    }
+
+    fiber.parent = parent
+    fiber.sibling = null
+    if (prevNewFiber) prevNewFiber.sibling = fiber
+    else parent.child = fiber
+    prevNewFiber = fiber
+  }
+
+  // Pass 2: walk the sibling chain we just built and render each fiber
+  // forward with the correct per-child anchor. During hydration the cursor
+  // walks DOM forward and each renderFiber adopts the next existing node,
+  // so per-child anchors are moot — fall back to the parent's anchor.
+  const hydrating = !!currentRoot?.hydrating
+  for (let f: Fiber | null = parent.child; f; f = f.sibling) {
+    let a = anchor
+    if (!hydrating) {
+      // Find the firstDomNode of the next still-mounted sibling, if any.
+      for (let s: Fiber | null = f.sibling; s; s = s.sibling) {
+        const d = firstDomNode(s)
+        if (d && d.parentNode === domParent) { a = d; break }
+      }
+    }
+    renderFiber(f, domParent, a)
+  }
+
+  if (!prevNewFiber) parent.child = null
+  else prevNewFiber.sibling = null
+
+  // Head content is additive — server may inject metadata/stylesheets (Vite
+  // dev styles, Sentry, analytics) that aren't in the React tree. Unmounting
+  // them on every reconcile thrashes styles and causes flash of unstyled
+  // content. Keep existing head children that weren't matched this pass.
+  const parentIsHeadHost =
+    parent.tag === FiberTag.Host &&
+    typeof parent.type === 'string' &&
+    (parent.type as string).toLowerCase() === 'head'
+
+  if (!parentIsHeadHost) {
+    // Unmount unclaimed
+    for (const f of existing) {
+      if (!claimed.has(f)) {
+        unmountFiber(f, domParent)
+        structurallyChanged = true
+      }
+    }
+    // Leftover keyed
+    for (const f of keyed.values()) {
+      if (!claimed.has(f)) {
+        unmountFiber(f, domParent)
+        structurallyChanged = true
+      }
+    }
+  }
+
+  // During hydration, DOM is already in document order from the cursor-driven
+  // adoption walk. Running placeChildrenInOrder here would reappend nodes to
+  // the end of domParent when the true anchor (often an end marker comment)
+  // isn't reflected in `anchor`. Skip it in hydration mode.
+  //
+  // For <head>, skip always — HeadContent re-renders routinely (route match
+  // changes, providers updating), and reordering every <link>/<style>/<meta>
+  // on each re-render causes stylesheet flash and re-download. Head element
+  // ordering is semantically fluid; the browser doesn't care about exact
+  // order within <head>.
+  const parentIsHead =
+    (domParent as Element).nodeType === 1 &&
+    (domParent as Element).tagName.toLowerCase() === 'head'
+  if (structurallyChanged && !currentRoot?.hydrating && !parentIsHead) {
+    placeChildrenInOrder(parent, domParent, anchor)
+  }
+}
+
+function placeChildrenInOrder(parent: Fiber, domParent: Node, anchor: Node | null): void {
+  const doms: Node[] = []
+  let c = parent.child
+  while (c) {
+    collectHostDoms(c, doms)
+    c = c.sibling
+  }
+
+  // Pre-check: if our fiber-owned DOM is already in document order within
+  // domParent AND the trailing anchor matches, no reorder is needed. This is
+  // the common case on stable re-renders, and avoids detaching/re-attaching
+  // subtrees (which cancels CSS animations and triggers layout).
+  if (doms.length > 0) {
+    let current: Node | null = doms[0]!
+    let inOrder = current.parentNode === domParent
+    for (let i = 1; inOrder && i < doms.length; i++) {
+      current = current!.nextSibling
+      // Skip foreign nodes (SSR-injected scripts, dev-styles) between owned
+      // fiber DOMs — they should stay where they are.
+      while (current && !doms.includes(current as Node)) {
+        current = current.nextSibling
+      }
+      if (current !== doms[i]) inOrder = false
+    }
+    // Also verify the LAST dom's next sibling lines up with `anchor`. A
+    // single-dom collection (or correctly-internally-ordered doms) can sit
+    // at the WRONG absolute position in domParent and still pass the
+    // relative-order check above. This happens when a fiber's render output
+    // changes from no-DOM (e.g. a Portal-using <Sheet>, or null) to an
+    // in-flow host element: the new host is appended to the end of
+    // domParent (because the parent reconcileChildren loop hands every
+    // child the same anchor — typically null), and without this trailing
+    // check it would never get moved before its later siblings.
+    if (inOrder) {
+      let last: Node | null = doms[doms.length - 1]!.nextSibling
+      while (last && !doms.includes(last as Node) && last !== anchor) {
+        last = last.nextSibling
+      }
+      if (last !== anchor) inOrder = false
+    }
+    if (inOrder) return
+  }
+
+  // Reverse-iterate, anchoring each node before the one that should follow it.
+  // This works because by the time we're placing doms[i], doms[i+1] is already
+  // in its final slot. Forward iteration is buggy: insertBefore(doms[i],
+  // doms[i+1]) pulls doms[i] forward past any nodes that SHOULD move behind
+  // it, leaving those nodes mis-anchored (app-starter Analyze/Lucky swap, npm
+  // stats library dropdown reorder — both reported by users).
+  //
+  // Concrete example: start=[A, R, L], target=[A, L, R]. Forward pass gives
+  // [L, A, R] (wrong). Reverse pass moves R to end, then L and A are already
+  // correct — 1 move, matches target.
+  //
+  // Skip nodes already in their target position so CSS transitions on stable
+  // siblings aren't cancelled (e.g. drawer slide animation).
+  for (let i = doms.length - 1; i >= 0; i--) {
+    const d = doms[i]!
+    const targetNext: Node | null = i + 1 < doms.length ? doms[i + 1]! : anchor
+    if (d.parentNode !== domParent || d.nextSibling !== targetNext) {
+      domParent.insertBefore(d, targetNext)
+    }
+  }
+}
+
+function collectHostDoms(fiber: Fiber, out: Node[]): void {
+  if (fiber.tag === FiberTag.Host || fiber.tag === FiberTag.Text) {
+    if (fiber.dom) out.push(fiber.dom)
+    return
+  }
+  if (fiber.tag === FiberTag.Portal) return
+  let c = fiber.child
+  while (c) {
+    collectHostDoms(c, out)
+    c = c.sibling
+  }
+}
+
+function collectChildren(parent: Fiber): Fiber[] {
+  const out: Fiber[] = []
+  let c = parent.child
+  while (c) {
+    out.push(c)
+    c = c.sibling
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Rendering per fiber tag
+// ---------------------------------------------------------------------------
+
+export type RenderFn = (fiber: Fiber, domParent: Node, anchor: Node | null) => void
+export type TypeMatcher = (type: any, marker: any) => FiberTag | null
+
+// Mutable renderer registry indexed by FiberTag. Feature modules install their
+// renderer via registerRenderer(); unregistered features render as no-ops. The
+// initial registrations below rely on function-declaration hoisting — every
+// render* function is declared with `function` later in this file.
+const RENDERERS: Array<RenderFn | undefined> = new Array(13)
+
+// Element-marker allowlist for child normalization (pushChildren). Core-always
+// markers are seeded here; features add their own via registerElementMarker.
+const ACCEPTED_ELEMENT_MARKERS = new Set<symbol>([
+  REACT_ELEMENT_TYPE as symbol,
+  REACT_LEGACY_ELEMENT_TYPE as symbol,
+])
+
+// Type-to-tag matchers tried in registration order from fiberFromChild's
+// fallback branch. Features register here for element types that aren't
+// marker-based (e.g. Portal, where element.type IS the symbol).
+const TYPE_MATCHERS: TypeMatcher[] = []
+
+export function registerRenderer(tag: FiberTag, fn: RenderFn): void {
+  RENDERERS[tag] = fn
+}
+
+export function registerTypeMatcher(m: TypeMatcher): void {
+  TYPE_MATCHERS.push(m)
+}
+
+export function registerElementMarker(sym: symbol): void {
+  ACCEPTED_ELEMENT_MARKERS.add(sym)
+}
+
+// Accessor + scoped setter for the module-level `currentRoot`. Feature modules
+// need these to participate in the render loop (e.g. Suspense re-hydration
+// must temporarily set the root while rebuilding a boundary subtree).
+export function getCurrentRoot(): FiberRoot | null {
+  return currentRoot
+}
+
+export function withCurrentRoot<T>(root: FiberRoot | null, fn: () => T): T {
+  const prev = currentRoot
+  currentRoot = root
+  try {
+    return fn()
+  } finally {
+    currentRoot = prev
+  }
+}
+
+// The memo feature uses this to bypass its prop-equality gate on state-driven
+// rerenders of the memoized fiber itself (hook update / subscribed store),
+// where props haven't changed by definition.
+export function getForceRerenderingFiber(): Fiber | null {
+  return forceRerenderingFiber
+}
+
+registerRenderer(FiberTag.Text, renderText)
+registerRenderer(FiberTag.Host, renderHost)
+registerRenderer(FiberTag.Function, renderFunction)
+registerRenderer(FiberTag.Fragment, renderFragment)
+
+export function renderFiber(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const fn = RENDERERS[fiber.tag]
+  if (fn) fn(fiber, domParent, anchor)
+}
+
+function renderText(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const text = fiber.pendingProps as string
+  // Identity-unchanged fast path: skip the native Text.data write entirely.
+  if (fiber.dom && fiber.memoizedProps === text) return
+  if (!fiber.dom) {
+    const hydrated = currentRoot?.hydrating ? adoptTextDom(fiber, fiber.parent!, text) : false
+    if (!hydrated) {
+      fiber.dom = document.createTextNode(text)
+      insertInto(domParent, fiber.dom, anchor)
+    }
+  } else {
+    // Past the fast path, and adoptTextDom already realigned `.data` on
+    // hydration — `.data !== text` here is guaranteed, so write directly.
+    ;(fiber.dom as Text).data = text
+  }
+  fiber.memoizedProps = text
+  // dirty cleared at rerender start; leaving true lets mid-render schedule persist
+}
+
+function renderHost(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const props = fiber.pendingProps ?? {}
+  const prev = fiber.memoizedProps ?? {}
+  const type = fiber.type as string
+  const isSvg = type === 'svg' || (domParent as Element).namespaceURI === 'http://www.w3.org/2000/svg'
+
+  // <select value> must be applied AFTER children mount — setting `.value`
+  // on a `<select>` with no matching `<option>` yet resets it to empty. Same
+  // for `defaultValue` on first mount. Stash and replay.
+  const isSelect = type === 'select'
+  const deferredSelectValue =
+    isSelect && (props.value !== undefined || props.defaultValue !== undefined)
+      ? props.value !== undefined ? props.value : props.defaultValue
+      : undefined
+
+  if (!fiber.dom) {
+    const hydrated = currentRoot?.hydrating ? adoptHostDom(fiber, fiber.parent!) : false
+    if (!hydrated) {
+      fiber.dom = createHostNode(type, isSvg)
+      // Two passes so form-control attributes (notably <input type>) are in
+      // place before event handlers attach. setEventHandler reads the
+      // element's runtime state to decide the DOM event name (e.g. onChange
+      // → `input` vs `change`); binding before `type` is applied would
+      // attach to the wrong event for checkbox/radio/file inputs.
+      for (const k in props) {
+        if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+        if (isEventProp(k)) continue
+        setProp(fiber.dom as Element, k, props[k], undefined, isSvg)
+      }
+      for (const k in props) {
+        if (!isEventProp(k)) continue
+        setProp(fiber.dom as Element, k, props[k], undefined, isSvg)
+      }
+      insertInto(domParent, fiber.dom, anchor)
+    }
+    attachRef(fiber, fiber.dom)
+  } else if (prev !== props) {
+    const el = fiber.dom as Element
+    // Single-pass diff. Defer changed event props into a small array so the
+    // `type-before-events` invariant the mount path needs (setEventHandler
+    // reads `el.type` to resolve onChange→input vs change) still holds when
+    // a render flips both `type` and an event handler in the same pass.
+    // The vast majority of host updates have no events at all (e.g. data-*
+    // attributes flipping on a stable list), so the deferred array stays
+    // null and we collapse to one for-in over `props`.
+    let deferredEvents: string[] | null = null
+    for (const k in props) {
+      if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+      if (isEventProp(k)) {
+        if (prev[k] !== props[k]) {
+          deferredEvents ||= []
+          deferredEvents.push(k)
+        }
+        continue
+      }
+      if (prev[k] !== props[k]) setProp(el, k, props[k], prev[k], isSvg)
+    }
+    // Removals — keys present in prev but not in props.
+    for (const k in prev) {
+      if (!(k in props)) setProp(el, k, undefined, prev[k], isSvg)
+    }
+    if (deferredEvents) {
+      for (let i = 0; i < deferredEvents.length; i++) {
+        const k = deferredEvents[i]!
+        setProp(el, k, props[k], prev[k], isSvg)
+      }
+    }
+    syncRefIfChanged(fiber, fiber.dom)
+  }
+
+  // Children go into this DOM node
+  reconcileChildren(fiber, childrenToArray(props.children), fiber.dom!, null)
+
+  // During hydration, if after reconciling all client-expected children we
+  // still have server DOM left in the cursor for this host, that's a
+  // structural mismatch (server produced more than client wants). Report.
+  // <head>/<html> are position-insensitive — leftover here is normal
+  // (Vite dev-style injections, SSR-only scripts, etc.).
+  if (currentRoot?.hydrating) {
+    const parentTag = (fiber.type as string).toLowerCase()
+    if (parentTag !== 'head' && parentTag !== 'html') {
+      const cursor = getHydrationCursor(fiber)
+      if (cursor) {
+        const leftover = cursor.remaining().filter(
+          (n) => n.nodeType === 1 || n.nodeType === 3,
+        )
+        if (leftover.length > 0 && currentRoot.onRecoverableError) {
+          currentRoot.onRecoverableError(
+            new Error(
+              `Hydration mismatch: server rendered ${leftover.length} extra ` +
+                `${leftover.length === 1 ? 'node' : 'nodes'} inside <${parentTag}> ` +
+                `that the client tree did not.`,
+            ),
+          )
+          for (const n of leftover) n.parentNode?.removeChild(n)
+        }
+      }
+    }
+  }
+
+  // Apply <select> value after options are mounted.
+  if (isSelect && deferredSelectValue !== undefined) {
+    const select = fiber.dom as HTMLSelectElement
+    if (Array.isArray(deferredSelectValue)) {
+      const asStrings = deferredSelectValue.map((v) => '' + v)
+      for (const opt of Array.from(select.options)) {
+        opt.selected = asStrings.includes(opt.value)
+      }
+    } else {
+      select.value = '' + deferredSelectValue
+    }
+  }
+
+  fiber.memoizedProps = props
+  // dirty cleared at rerender start; leaving true lets mid-render schedule persist
+}
+
+function renderFunction(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const prevDispatcher = ReactSharedInternals.H
+  const prevFiber = ReactSharedInternals.currentFiber
+  const prevHook = ReactSharedInternals.currentHook
+  const prevIndex = ReactSharedInternals.hookIndex
+
+  ReactSharedInternals.H = makeDispatcher()
+  ReactSharedInternals.currentFiber = fiber
+  ReactSharedInternals.currentHook = null
+  ReactSharedInternals.hookIndex = 0
+
+  let rendered: ReactNode
+  let deferredForHydration = false
+  try {
+    rendered = (fiber.type as Function)(fiber.pendingProps ?? {})
+  } catch (e: any) {
+    if (isThenable(e)) {
+      if (currentRoot?.hydrating) {
+        // Suspension during initial hydration. Leave the existing DOM alone
+        // and preserve the in-scope hydration cursor on THIS fiber so it
+        // survives the synchronous endHydration() that fires when the initial
+        // hydrateRoot() call returns. When the promise settles, the fiber
+        // re-renders (see rerenderFiber) with hydration re-activated and its
+        // descendants adopt DOM instead of creating new nodes.
+        const hostParent = findHydrationHost(fiber)
+        const inheritedCursor = getHydrationCursor(hostParent)
+        if (inheritedCursor) {
+          setHydrationCursor(fiber, inheritedCursor)
+        }
+        fiber.memoizedState = {
+          ...(fiber.memoizedState ?? {}),
+          _pendingHydration: true,
+        }
+        // Mirror renderLazy's guard: mark the nearest Suspense ancestor as
+        // awaiting hydration-resume, so any re-render of that Suspense (e.g.
+        // rehydrateBoundary fired by $RC, or an unrelated state update from a
+        // sibling) doesn't re-enter `tryChildren`, re-throw, and flip Suspense
+        // into its suspended+pending path — which would unmount our deferred
+        // subtree and remount a fallback on top of the SSR content. By
+        // pinning the Suspense to a "hydration-suspended" no-op until our
+        // resume fires, the deferred re-render owns the adoption pass.
+        let sus: Fiber | null = fiber.parent
+        while (sus && sus.tag !== FiberTag.Suspense) sus = sus.parent
+        if (sus && sus.memoizedState) {
+          ;(sus.memoizedState as any)._awaitingLazyHydration = true
+        }
+        const clearAwait = () => {
+          if (sus && sus.memoizedState) {
+            ;(sus.memoizedState as any)._awaitingLazyHydration = false
+          }
+          scheduleUpdate(fiber)
+        }
+        e.then(clearAwait, clearAwait)
+        deferredForHydration = true
+      } else {
+        CAPABILITIES.handleSuspended(fiber, e)
+        rendered = null
+      }
+    } else {
+      handleErrorInRender(fiber, e)
+      return
+    }
+  } finally {
+    ReactSharedInternals.H = prevDispatcher
+    ReactSharedInternals.currentFiber = prevFiber
+    ReactSharedInternals.currentHook = prevHook
+    ReactSharedInternals.hookIndex = prevIndex
+  }
+
+  if (deferredForHydration) return
+
+  reconcileChildren(fiber, childrenToArray(rendered), domParent, anchor)
+  fiber.memoizedProps = fiber.pendingProps
+  // dirty cleared at rerender start; leaving true lets mid-render schedule persist
+}
+
+function hasAncestorHydrationCursor(_fiber: Fiber): boolean {
+  // Reserved for future per-Suspense-boundary hydration deferral. For now the
+  // top-level hydration path is all we need to special-case.
+  return false
+}
+
+function renderFragment(fiber: Fiber, domParent: Node, anchor: Node | null): void {
+  const props = fiber.pendingProps ?? {}
+  reconcileChildren(fiber, childrenToArray(props.children), domParent, anchor)
+  fiber.memoizedProps = props
+  // dirty cleared at rerender start; leaving true lets mid-render schedule persist
+}
+
+// ---------------------------------------------------------------------------
+// Error handling + default Suspense capability
+// ---------------------------------------------------------------------------
+
+// Default handler when the Suspense feature isn't installed: just schedule
+// a re-render when the thrown thenable settles. No boundary walk, no
+// fallback swap — children render empty during the pending window.
+function defaultHandleSuspended(fiber: Fiber, thenable: Promise<any>): void {
+  thenable.then(
+    () => scheduleUpdate(fiber),
+    () => scheduleUpdate(fiber),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Capability hooks — cross-cutting behaviors that features override.
+// Defaults here preserve today's behavior so the indirection is transparent
+// when all features are loaded. A feature's full-module can install its own
+// implementation via installCapability(); stubs leave the default in place,
+// where the default may intentionally degrade (e.g. a no-Context build's
+// readContext never walks the tree because no Provider fibers exist).
+// ---------------------------------------------------------------------------
+
+export interface Capabilities {
+  handleSuspended: (fiber: Fiber, thenable: Promise<any>) => void
+  readContext: (fiber: Fiber, ctx: any) => any
+}
+
+const CAPABILITIES: Capabilities = {
+  handleSuspended: defaultHandleSuspended,
+  readContext: defaultReadContext,
+}
+
+export function installCapability<K extends keyof Capabilities>(
+  name: K,
+  fn: Capabilities[K],
+): void {
+  CAPABILITIES[name] = fn
+}
+
+// Wrapper for features that catch thrown thenables inside their render
+// functions. Delegates to the installed Suspense capability.
+export function handleSuspended(fiber: Fiber, thenable: Promise<any>): void {
+  CAPABILITIES.handleSuspended(fiber, thenable)
+}
+
+export function handleErrorInRender(fiber: Fiber, err: any): void {
+  // Bubble to nearest class boundary with getDerivedStateFromError / componentDidCatch
+  let f: Fiber | null = fiber.parent
+  while (f) {
+    if (f.tag === FiberTag.Class) {
+      const Ctor = f.type as any
+      const instance = f.stateNode
+      if (Ctor.getDerivedStateFromError) {
+        const update = Ctor.getDerivedStateFromError(err)
+        instance.state = { ...instance.state, ...update }
+      }
+      if (instance.componentDidCatch) {
+        try {
+          instance.componentDidCatch(err, { componentStack: '' })
+        } catch {}
+      }
+      scheduleUpdate(f)
+      return
+    }
+    f = f.parent
+  }
+  // No boundary — report to root
+  if (currentRoot?.onUncaughtError) currentRoot.onUncaughtError(err)
+  else throw err
+}
+
+export function isThenable(x: any): x is Promise<any> {
+  return x != null && typeof x.then === 'function'
+}
+
+// ---------------------------------------------------------------------------
+// Unmount
+// ---------------------------------------------------------------------------
+
+function unmountFiber(fiber: Fiber, domParent: Node): void {
+  fiber.unmounted = true
+  // Recurse first
+  let c = fiber.child
+  while (c) {
+    const next = c.sibling
+    unmountFiber(c, fiber.tag === FiberTag.Host ? fiber.dom! : domParent)
+    c = next
+  }
+  fiber.child = null
+
+  // Run cleanups (effects + layout effects)
+  if (fiber.cleanups) {
+    for (const cleanup of fiber.cleanups) {
+      try {
+        cleanup()
+      } catch (e) {
+        if (currentRoot?.onRecoverableError) currentRoot.onRecoverableError(e)
+      }
+    }
+    fiber.cleanups = null
+  }
+
+  if (fiber.tag === FiberTag.Class && fiber.stateNode?.componentWillUnmount) {
+    try {
+      fiber.stateNode.componentWillUnmount()
+    } catch (e) {
+      if (currentRoot?.onRecoverableError) currentRoot.onRecoverableError(e)
+    }
+    fiber.stateNode._fiber = null
+    fiber.stateNode._enqueueUpdate = null
+    fiber.stateNode._forceUpdate = null
+  }
+
+  // Detach ref
+  if (fiber.ref) detachRef(fiber.ref)
+
+  // Remove DOM if host
+  if (fiber.tag === FiberTag.Host && fiber.dom && fiber.dom.parentNode) {
+    fiber.dom.parentNode.removeChild(fiber.dom)
+  } else if (fiber.tag === FiberTag.Text && fiber.dom && fiber.dom.parentNode) {
+    fiber.dom.parentNode.removeChild(fiber.dom)
+  }
+}
+
+export function unmountAllChildren(parent: Fiber, domParent: Node): void {
+  let c = parent.child
+  while (c) {
+    const next = c.sibling
+    unmountFiber(c, domParent)
+    c = next
+  }
+  parent.child = null
+}
+
+// ---------------------------------------------------------------------------
+// DOM navigation helpers
+// ---------------------------------------------------------------------------
+
+function insertInto(parent: Node, node: Node, anchor: Node | null): void {
+  // Anchor may have been removed or moved since it was computed (mutations
+  // from unmount, boundary reveal, user code, HMR). If it's no longer a child
+  // of `parent`, fall back to append — trying to insertBefore a non-child
+  // throws NotFoundError and dev-loops the reconciler.
+  if (anchor && anchor.parentNode === parent) {
+    parent.insertBefore(node, anchor)
+  } else {
+    parent.appendChild(node)
+  }
+}
+
+function getHostParent(fiber: Fiber): Node {
+  let p = fiber.parent
+  while (p) {
+    if (p.tag === FiberTag.Host) return p.dom!
+    if (p.tag === FiberTag.Root)
+      return (p.stateNode as Node) || (p.dom as Node) || (p.root?.container as Node)
+    if (p.tag === FiberTag.Portal) {
+      // Portal renders its children into the `container` prop, not into any
+      // DOM element the portal fiber "owns". Read the container from the
+      // portal's own props so a rerenderFiber triggered on a descendant
+      // (e.g. a Floating-UI-positioned popper in a Radix Portal) finds its
+      // host parent — otherwise getHostParent returns undefined and the
+      // next renderHost crashes reading `.namespaceURI` on undefined.
+      const props = (p.pendingProps ?? p.memoizedProps) as { container?: Element } | null
+      return (props?.container as Node) || (p.stateNode as Node) || (p.dom as Node) || (p.root?.container as Node)
+    }
+    p = p.parent
+  }
+  throw new Error('No host parent found.')
+}
+
+function getAnchor(fiber: Fiber): Node | null {
+  // Return the first DOM node that comes after this fiber within the host parent
+  let f: Fiber | null = fiber.sibling
+  while (f) {
+    const d = firstDomNode(f)
+    if (d) return d
+    f = f.sibling
+  }
+  // Ascend
+  let p = fiber.parent
+  while (p && p.tag !== FiberTag.Host && p.tag !== FiberTag.Root && p.tag !== FiberTag.Portal) {
+    if (p.sibling) {
+      const d = firstDomNode(p.sibling)
+      if (d) return d
+    }
+    p = p.parent
+  }
+  return null
+}
+
+function firstDomNode(fiber: Fiber): Node | null {
+  if (fiber.tag === FiberTag.Host || fiber.tag === FiberTag.Text) return fiber.dom
+  let c = fiber.child
+  while (c) {
+    const d = firstDomNode(c)
+    if (d) return d
+    c = c.sibling
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Context read — exported for dispatcher.ts (useContext, use()). Delegates to
+// the installed capability so the Context feature can override with a walking
+// implementation that finds the nearest Provider fiber. When the feature is
+// stubbed, the default here returns ctx._currentValue — correct because no
+// Provider fibers exist in the tree (Provider element → Fragment via the
+// stub's type matcher).
+// ---------------------------------------------------------------------------
+
+export function readContext(fiber: Fiber, ctx: any): any {
+  return CAPABILITIES.readContext(fiber, ctx)
+}
+
+function defaultReadContext(_fiber: Fiber, ctx: any): any {
+  return ctx._currentValue
+}
+
+// ---------------------------------------------------------------------------
+// Refs
+// ---------------------------------------------------------------------------
+
+function attachRef(fiber: Fiber, value: any): void {
+  const ref = fiber.ref ?? (fiber.pendingProps?.ref ?? null)
+  if (!ref) return
+  if (typeof ref === 'function') {
+    // Match React's commit-phase semantics: callback refs run after render
+    // (during the layout/commit phase), not during render. Calling them
+    // synchronously here breaks libraries that assert no event handlers run
+    // during render (e.g. base-ui's useStableCallback trampoline).
+    scheduleLifecycle(fiber, () => {
+      const cleanup = ref(value)
+      fiber.cleanups ||= []
+      fiber.cleanups.push(typeof cleanup === 'function' ? cleanup : () => ref(null))
+    })
+  } else {
+    ref.current = value
+  }
+}
+
+function syncRefIfChanged(fiber: Fiber, value: any): void {
+  const ref = fiber.ref ?? (fiber.pendingProps?.ref ?? null)
+  if (!ref) return
+  if (typeof ref === 'object' && ref.current !== value) ref.current = value
+}
+
+function detachRef(ref: any): void {
+  // Function refs are handled via fiber.cleanups (queued in attachRef during
+  // the commit phase): the cleanup either invokes the user-returned cleanup
+  // fn or calls ref(null). Calling ref(null) here would double-fire it.
+  if (ref && typeof ref === 'object') {
+    ref.current = null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Effects
+// ---------------------------------------------------------------------------
+
+const pendingEffects: Array<{ fiber: Fiber; effect: Effect }> = []
+const pendingLayoutEffects: Array<{ fiber: Fiber; effect: Effect }> = []
+const pendingLifecycles: Array<{ fiber: Fiber; fn: () => void }> = []
+
+export function enqueueEffect(fiber: Fiber, effect: Effect): void {
+  if (effect.tag === 'layout' || effect.tag === 'insertion') {
+    pendingLayoutEffects.push({ fiber, effect })
+  } else {
+    pendingEffects.push({ fiber, effect })
+  }
+}
+
+export function scheduleLifecycle(fiber: Fiber, fn: () => void): void {
+  pendingLifecycles.push({ fiber, fn })
+}
+
+export function runEffects(root: FiberRoot): void {
+  // Layout effects synchronously
+  while (pendingLayoutEffects.length) {
+    const { fiber, effect } = pendingLayoutEffects.shift()!
+    runEffect(fiber, effect, root)
+  }
+  // Then lifecycles
+  while (pendingLifecycles.length) {
+    const { fn } = pendingLifecycles.shift()!
+    try {
+      fn()
+    } catch (e) {
+      if (root.onCaughtError) root.onCaughtError(e)
+    }
+  }
+  // Passive effects on microtask
+  if (pendingEffects.length) {
+    const batch = pendingEffects.splice(0)
+    queueMicrotask(() => {
+      for (const { fiber, effect } of batch) runEffect(fiber, effect, root)
+    })
+  }
+}
+
+function runEffect(fiber: Fiber, effect: Effect, root: FiberRoot): void {
+  try {
+    const cleanup = effect.create()
+    effect.destroy = typeof cleanup === 'function' ? cleanup : undefined
+    if (effect.destroy) {
+      fiber.cleanups ||= []
+      fiber.cleanups.push(effect.destroy)
+    }
+  } catch (e) {
+    if (root.onCaughtError) root.onCaughtError(e)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function isEventProp(name: string): boolean {
+  return (
+    name.length > 2 &&
+    name.charCodeAt(0) === 111 /* o */ &&
+    name.charCodeAt(1) === 110 /* n */ &&
+    name.charCodeAt(2) >= 65 /* 'A'-ish: any uppercase start (onClick, onChange, …) */
+  )
+}
+

--- a/packages/redact/src/dom/root.ts
+++ b/packages/redact/src/dom/root.ts
@@ -1,0 +1,117 @@
+import { FiberTag, createFiber, type FiberRoot, type ReactNode } from '../core'
+import { renderRoot, flushSyncWork, batchedUpdates } from './reconcile'
+import {
+  beginHydration,
+  endHydration,
+  drainReplayQueue,
+  installHydrationScrollGuard,
+} from './features/hydration'
+
+export interface RootOptions {
+  identifierPrefix?: string
+  onRecoverableError?: (error: unknown) => void
+  onCaughtError?: (error: unknown) => void
+  onUncaughtError?: (error: unknown) => void
+}
+
+export interface Root {
+  render(children: ReactNode): void
+  unmount(): void
+}
+
+export function createRoot(container: Element | DocumentFragment, options: RootOptions = {}): Root {
+  const rootFiber = createFiber(FiberTag.Root, null, null)
+  rootFiber.dom = container
+  const root: FiberRoot = {
+    container,
+    current: rootFiber,
+    pending: new Set(),
+    scheduled: false,
+    onRecoverableError: options.onRecoverableError,
+    onCaughtError: options.onCaughtError,
+    onUncaughtError: options.onUncaughtError,
+    identifierPrefix: options.identifierPrefix ?? ':r',
+    hydrating: false,
+  }
+  rootFiber.root = root
+  rootFiber.stateNode = container
+
+  let firstRender = true
+  return {
+    render(children) {
+      if (firstRender) {
+        firstRender = false
+        // Match real React's `clearContainer` semantics: blow away any pre-render
+        // markup (server-rendered placeholder, splash shells, etc.) on the
+        // initial commit so it doesn't stack with the React tree.
+        if ((container as Node).nodeType === 1 /* ELEMENT_NODE */) {
+          ;(container as Element).textContent = ''
+        }
+      }
+      flushSyncWork(() => {
+        renderRoot(root, children)
+      })
+    },
+    unmount() {
+      flushSyncWork(() => {
+        renderRoot(root, null)
+      })
+    },
+  }
+}
+
+export function hydrateRoot(
+  container: Element | Document,
+  initialChildren: ReactNode,
+  options: RootOptions = {},
+): Root {
+  // `container` may be the Document when the React tree renders <html>...</html>
+  // (e.g. TanStack Start's default client entry). In that case we adopt
+  // documentElement as a CHILD of the root, not as the root itself — otherwise
+  // we'd try to render <html> inside <html>.
+  const target = container as any as Element | Document
+  const rootFiber = createFiber(FiberTag.Root, null, null)
+  rootFiber.dom = target as unknown as Node
+  const root: FiberRoot = {
+    container: target as any,
+    current: rootFiber,
+    pending: new Set(),
+    scheduled: false,
+    onRecoverableError: options.onRecoverableError,
+    onCaughtError: options.onCaughtError,
+    onUncaughtError: options.onUncaughtError,
+    identifierPrefix: options.identifierPrefix ?? ':r',
+    hydrating: false,
+  }
+  rootFiber.root = root
+  rootFiber.stateNode = target
+
+  // Preserve the user's scroll position across hydration (see feature impl
+  // for the details). No-op in SSR; no-op in the stub.
+  installHydrationScrollGuard()
+
+  beginHydration(root)
+  try {
+    flushSyncWork(() => {
+      renderRoot(root, initialChildren)
+    })
+  } finally {
+    endHydration(root)
+  }
+  drainReplayQueue()
+
+  return {
+    render(children) {
+      flushSyncWork(() => {
+        renderRoot(root, children)
+      })
+    },
+    unmount() {
+      flushSyncWork(() => {
+        renderRoot(root, null)
+      })
+    },
+  }
+}
+
+export { flushSyncWork as flushSync, batchedUpdates }

--- a/packages/redact/src/dom/test-utils.ts
+++ b/packages/redact/src/dom/test-utils.ts
@@ -1,0 +1,6 @@
+export async function act(fn: () => any): Promise<void> {
+  const r = fn()
+  if (r && typeof r.then === 'function') await r
+  // Drain pending microtasks
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+}

--- a/packages/redact/src/react/children.ts
+++ b/packages/redact/src/react/children.ts
@@ -1,0 +1,85 @@
+import { isValidElement, cloneElement } from './element'
+import type { ReactNode, ReactElement } from '../core'
+
+function flatten(node: ReactNode, out: any[], prefix: string): void {
+  if (node == null || typeof node === 'boolean') return
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) flatten(node[i], out, prefix + '.' + i)
+    return
+  }
+  out.push(node)
+}
+
+function getKey(node: any, index: number, prefix: string): string {
+  if (isValidElement(node) && node.key != null) return prefix + '$' + node.key
+  return prefix + ':' + index
+}
+
+function mapChildren(
+  children: ReactNode,
+  fn: (child: ReactNode, index: number) => any,
+  prefix = '',
+): any[] {
+  const flat: any[] = []
+  flatten(children, flat, prefix)
+  const out: any[] = []
+  for (let i = 0; i < flat.length; i++) {
+    const child = flat[i]
+    const mapped = fn(child, i)
+    if (mapped == null) continue
+    if (Array.isArray(mapped)) {
+      for (let j = 0; j < mapped.length; j++) {
+        const m = mapped[j]
+        if (m == null) continue
+        out.push(
+          isValidElement(m) && m.key == null
+            ? cloneElement(m as ReactElement, { key: getKey(child, i, prefix) + '/' + j })
+            : m,
+        )
+      }
+    } else {
+      out.push(
+        isValidElement(mapped) && mapped.key == null
+          ? cloneElement(mapped as ReactElement, { key: getKey(child, i, prefix) })
+          : mapped,
+      )
+    }
+  }
+  return out
+}
+
+export const Children = {
+  map(children: ReactNode, fn: (child: ReactNode, index: number) => any): any[] | null {
+    if (children == null) return null
+    return mapChildren(children, fn)
+  },
+  forEach(children: ReactNode, fn: (child: ReactNode, index: number) => void): void {
+    if (children == null) return
+    mapChildren(children, (c, i) => {
+      fn(c, i)
+      return null
+    })
+  },
+  count(children: ReactNode): number {
+    let n = 0
+    const flat: any[] = []
+    flatten(children, flat, '')
+    for (let i = 0; i < flat.length; i++) n++
+    return n
+  },
+  toArray(children: ReactNode): any[] {
+    const flat: any[] = []
+    flatten(children, flat, '')
+    return flat.map((c, i) =>
+      isValidElement(c) && c.key == null
+        ? cloneElement(c as ReactElement, { key: '' + i })
+        : c,
+    )
+  },
+  only(children: ReactNode): ReactElement {
+    if (!isValidElement(children)) {
+      throw new Error('Children.only expected a single React element.')
+    }
+    return children
+  },
+}

--- a/packages/redact/src/react/class.ts
+++ b/packages/redact/src/react/class.ts
@@ -1,0 +1,56 @@
+import type { ReactNode } from '../core'
+
+type SetStateCallback<S, P> =
+  | Partial<S>
+  | ((prev: S, props: P) => Partial<S> | null)
+  | null
+
+export class Component<P = {}, S = {}> {
+  static contextType?: any
+  static getDerivedStateFromProps?(props: any, state: any): any
+  static getDerivedStateFromError?(error: any): any
+  static defaultProps?: any
+  static displayName?: string
+
+  props: P
+  state: S = {} as S
+  context: any
+  refs: Record<string, any> = {}
+
+  // Injected by reconciler
+  _fiber: any = null
+  _enqueueUpdate: ((updater: SetStateCallback<S, P>, cb?: () => void) => void) | null = null
+  _forceUpdate: ((cb?: () => void) => void) | null = null
+
+  constructor(props: P, context?: any) {
+    this.props = props
+    this.context = context
+  }
+
+  setState(updater: SetStateCallback<S, P>, callback?: () => void): void {
+    if (!this._enqueueUpdate) {
+      throw new Error('Cannot call setState on an unmounted component.')
+    }
+    this._enqueueUpdate(updater, callback)
+  }
+
+  forceUpdate(callback?: () => void): void {
+    if (!this._forceUpdate) return
+    this._forceUpdate(callback)
+  }
+
+  render(): ReactNode {
+    throw new Error('Component subclass must implement render().')
+  }
+
+  componentDidMount?(): void
+  componentDidUpdate?(prevProps: P, prevState: S, snapshot?: any): void
+  componentWillUnmount?(): void
+  shouldComponentUpdate?(nextProps: P, nextState: S, nextCtx: any): boolean
+  getSnapshotBeforeUpdate?(prevProps: P, prevState: S): any
+  componentDidCatch?(error: any, info: { componentStack: string }): void
+}
+;(Component.prototype as any).isReactComponent = {}
+
+export class PureComponent<P = {}, S = {}> extends Component<P, S> {}
+;(PureComponent.prototype as any).isPureReactComponent = true

--- a/packages/redact/src/react/compiler-runtime.ts
+++ b/packages/redact/src/react/compiler-runtime.ts
@@ -1,0 +1,22 @@
+// React Compiler runtime — emitted code calls `c(size)` to obtain a
+// per-component-instance memo cache. Each slot starts as a sentinel; the
+// compiled code overwrites slots with computed values and uses sentinel
+// identity to detect first-run / dependency-change.
+//
+// The cache must persist across renders of the same fiber, so we lean on
+// `useRef`. Slots are filled with the canonical
+// `Symbol.for('react.memo_cache_sentinel')` so any tooling that compares
+// against the same well-known symbol stays interoperable.
+import { useRef } from './hooks'
+
+const MEMO_CACHE_SENTINEL = Symbol.for('react.memo_cache_sentinel')
+
+export function c(size: number): Array<unknown> {
+  const ref = useRef<Array<unknown> | null>(null)
+  if (ref.current === null) {
+    const arr = new Array<unknown>(size)
+    for (let i = 0; i < size; i++) arr[i] = MEMO_CACHE_SENTINEL
+    ref.current = arr
+  }
+  return ref.current
+}

--- a/packages/redact/src/react/context.ts
+++ b/packages/redact/src/react/context.ts
@@ -1,0 +1,50 @@
+import type { ReactElement, ReactNode } from '../core'
+import { useContext } from './hooks'
+
+export const REACT_CONTEXT_TYPE = Symbol.for('react.context')
+export const REACT_PROVIDER_TYPE = Symbol.for('react.provider')
+export const REACT_CONSUMER_TYPE = Symbol.for('react.consumer')
+
+export interface Context<T> {
+  $$typeof: typeof REACT_CONTEXT_TYPE
+  _currentValue: T
+  Provider: ProviderExoticComponent<{ value: T; children?: ReactNode }>
+  Consumer: ConsumerExoticComponent<T>
+  displayName?: string
+}
+
+export interface ProviderExoticComponent<P> {
+  $$typeof: typeof REACT_PROVIDER_TYPE
+  _context: Context<any>
+  (props: P): ReactElement
+}
+
+export interface ConsumerExoticComponent<T> {
+  $$typeof: typeof REACT_CONSUMER_TYPE
+  _context: Context<T>
+  (props: { children: (value: T) => ReactNode }): ReactElement
+}
+
+export function createContext<T>(defaultValue: T): Context<T> {
+  const context: Context<T> = {
+    $$typeof: REACT_CONTEXT_TYPE,
+    _currentValue: defaultValue,
+  } as Context<T>
+
+  const Provider: any = function Provider(_props: any): any {
+    throw new Error('Provider components are handled by the renderer.')
+  }
+  Provider.$$typeof = REACT_PROVIDER_TYPE
+  Provider._context = context
+
+  const Consumer: any = function Consumer(props: { children: (v: T) => any }): any {
+    return props.children(useContext(context))
+  }
+  Consumer.$$typeof = REACT_CONSUMER_TYPE
+  Consumer._context = context
+
+  context.Provider = Provider
+  context.Consumer = Consumer
+
+  return context
+}

--- a/packages/redact/src/react/element.ts
+++ b/packages/redact/src/react/element.ts
@@ -1,0 +1,80 @@
+import {
+  REACT_ELEMENT_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
+  REACT_FRAGMENT_TYPE,
+  type ReactElement,
+  type ReactNode,
+} from '../core'
+
+export const Fragment = REACT_FRAGMENT_TYPE as unknown as (props: {
+  children?: ReactNode
+}) => ReactElement
+
+const RESERVED_PROPS: Record<string, 1> = { key: 1, ref: 1, __self: 1, __source: 1 }
+
+export function createElement(
+  type: any,
+  config: Record<string, any> | null,
+  ...children: ReactNode[]
+): ReactElement {
+  let key: string | null = null
+  let ref: any = null
+  const props: Record<string, any> = {}
+
+  if (config != null) {
+    if (config.key !== undefined && config.key !== null) key = '' + config.key
+    if (config.ref !== undefined) ref = config.ref
+    for (const k in config) {
+      if (!RESERVED_PROPS[k] && Object.prototype.hasOwnProperty.call(config, k)) {
+        props[k] = config[k]
+      }
+    }
+  }
+
+  if (children.length === 1) props.children = children[0]
+  else if (children.length > 1) props.children = children
+
+  if (type && type.defaultProps) {
+    const dp = type.defaultProps
+    for (const k in dp) {
+      if (props[k] === undefined) props[k] = dp[k]
+    }
+  }
+
+  return { $$typeof: REACT_ELEMENT_TYPE, type, key, ref, props }
+}
+
+export function cloneElement(
+  element: ReactElement,
+  config: Record<string, any> | null,
+  ...children: ReactNode[]
+): ReactElement {
+  let key = element.key
+  let ref = element.ref
+  const props = { ...element.props }
+
+  if (config != null) {
+    if (config.ref !== undefined) ref = config.ref
+    if (config.key !== undefined) key = '' + config.key
+    const defaultProps = element.type?.defaultProps
+    for (const k in config) {
+      if (RESERVED_PROPS[k] || !Object.prototype.hasOwnProperty.call(config, k)) continue
+      props[k] = config[k] === undefined && defaultProps ? defaultProps[k] : config[k]
+    }
+  }
+
+  if (children.length === 1) props.children = children[0]
+  else if (children.length > 1) props.children = children
+
+  return { $$typeof: REACT_ELEMENT_TYPE, type: element.type, key, ref, props }
+}
+
+export function isValidElement(obj: any): obj is ReactElement {
+  if (typeof obj !== 'object' || obj === null) return false
+  const t = obj.$$typeof
+  return t === REACT_ELEMENT_TYPE || t === REACT_LEGACY_ELEMENT_TYPE
+}
+
+export function createRef<T = any>() {
+  return { current: null as T | null }
+}

--- a/packages/redact/src/react/hooks.ts
+++ b/packages/redact/src/react/hooks.ts
@@ -1,0 +1,190 @@
+import type {
+  Dispatch,
+  SetStateAction,
+  EffectCallback,
+  DependencyList,
+} from '../core'
+import type { Context } from './context'
+import { getDispatcher } from './shared-internals'
+
+export function useState<S>(initial: S | (() => S)): [S, Dispatch<SetStateAction<S>>] {
+  return getDispatcher().useState(initial)
+}
+
+export function useReducer<S, A>(
+  reducer: (s: S, a: A) => S,
+  initial: any,
+  init?: (a: any) => S,
+): [S, Dispatch<A>] {
+  return getDispatcher().useReducer(reducer, initial, init)
+}
+
+export function useEffect(create: EffectCallback, deps?: DependencyList): void {
+  getDispatcher().useEffect(create, deps)
+}
+
+export function useLayoutEffect(create: EffectCallback, deps?: DependencyList): void {
+  getDispatcher().useLayoutEffect(create, deps)
+}
+
+export function useInsertionEffect(create: EffectCallback, deps?: DependencyList): void {
+  getDispatcher().useInsertionEffect(create, deps)
+}
+
+export function useRef<T>(initial: T): { current: T }
+export function useRef<T>(initial: T | null): { current: T | null }
+export function useRef<T = undefined>(): { current: T | undefined }
+export function useRef(initial?: any): { current: any } {
+  return getDispatcher().useRef(initial)
+}
+
+export function useMemo<T>(factory: () => T, deps?: DependencyList): T {
+  return getDispatcher().useMemo(factory, deps)
+}
+
+export function useCallback<T extends Function>(fn: T, deps?: DependencyList): T {
+  return getDispatcher().useCallback(fn, deps)
+}
+
+export function useContext<T>(ctx: Context<T>): T {
+  return getDispatcher().useContext(ctx)
+}
+
+export function useImperativeHandle<T>(
+  ref: any,
+  factory: () => T,
+  deps?: DependencyList,
+): void {
+  getDispatcher().useImperativeHandle(ref, factory, deps)
+}
+
+export function useDebugValue<T>(value: T, formatter?: (v: T) => any): void {
+  getDispatcher().useDebugValue(value, formatter)
+}
+
+export function useId(): string {
+  return getDispatcher().useId()
+}
+
+export function useTransition(): [boolean, (fn: () => void) => void] {
+  return getDispatcher().useTransition()
+}
+
+export function useDeferredValue<T>(v: T): T {
+  return getDispatcher().useDeferredValue(v)
+}
+
+export function useSyncExternalStore<T>(
+  subscribe: (cb: () => void) => () => void,
+  getSnapshot: () => T,
+  getServerSnapshot?: () => T,
+): T {
+  return getDispatcher().useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+export function use<T>(resource: PromiseLike<T> | { _currentValue: T } | { $$typeof: symbol; _currentValue: T }): T {
+  return getDispatcher().use(resource)
+}
+
+export function startTransition(fn: () => void): void {
+  fn()
+}
+
+export function useActionState<S, P>(
+  _action: (state: Awaited<S>, payload: P) => S | Promise<S>,
+  initial: Awaited<S>,
+): [Awaited<S>, (payload: P) => void, boolean] {
+  return [initial, () => {}, false]
+}
+
+export function useFormStatus() {
+  return { pending: false, data: null, method: null, action: null }
+}
+
+export function useOptimistic<S, A = S>(
+  state: S,
+  _updateFn?: (s: S, a: A) => S,
+): [S, (action: A) => void] {
+  return [state, () => {}]
+}
+
+// Composed hook — returns a stable callback that always invokes the latest
+// `fn`. The ref is updated in useInsertionEffect so any useLayoutEffect /
+// useEffect reading ref.current in the next commit sees the fresh function.
+export function useEffectEvent<Args extends unknown[], Return>(
+  fn: (...args: Args) => Return,
+): (...args: Args) => Return {
+  const ref = useRef(fn)
+  useInsertionEffect(() => {
+    ref.current = fn
+  })
+  return useCallback(
+    ((...args: Args) => ref.current(...args)) as (...args: Args) => Return,
+    [],
+  )
+}
+
+// `useSyncExternalStoreWithSelector` — provided here so consumers (like
+// @tanstack/react-store) that historically import from
+// `use-sync-external-store/shim/with-selector` can be aliased to this
+// package via the @ss/redact/vite plugin. The CJS shim is unsuitable
+// for Cloudflare Workers (it does `var React = require('react')` which
+// fails in workerd). Implementation matches React's reference impl —
+// selector + isEqual gate to avoid re-renders when the selected slice is
+// unchanged across snapshots.
+export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
+  subscribe: (cb: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot: (() => Snapshot) | undefined,
+  selector: (snapshot: Snapshot) => Selection,
+  isEqual?: (a: Selection, b: Selection) => boolean,
+): Selection {
+  const instRef = useRef<{ hasValue: boolean; value: Selection | null } | null>(null)
+  let inst: { hasValue: boolean; value: Selection | null }
+  if (instRef.current === null) {
+    inst = { hasValue: false, value: null }
+    instRef.current = inst
+  } else {
+    inst = instRef.current
+  }
+
+  const [getSelection, getServerSelection] = useMemo(() => {
+    let hasMemo = false
+    let memoizedSnapshot: Snapshot
+    let memoizedSelection: Selection
+    const memoizedSelector = (nextSnapshot: Snapshot): Selection => {
+      if (!hasMemo) {
+        hasMemo = true
+        memoizedSnapshot = nextSnapshot
+        const nextSelection = selector(nextSnapshot)
+        if (isEqual !== undefined && inst.hasValue) {
+          const currentSelection = inst.value as Selection
+          if (isEqual(currentSelection, nextSelection)) {
+            memoizedSelection = currentSelection
+            return currentSelection
+          }
+        }
+        memoizedSelection = nextSelection
+        return nextSelection
+      }
+      const prevSnapshot: Snapshot = memoizedSnapshot
+      const prevSelection: Selection = memoizedSelection
+      if (Object.is(prevSnapshot, nextSnapshot)) return prevSelection
+      const nextSelection = selector(nextSnapshot)
+      if (isEqual !== undefined && isEqual(prevSelection, nextSelection)) return prevSelection
+      memoizedSnapshot = nextSnapshot
+      memoizedSelection = nextSelection
+      return nextSelection
+    }
+    const get = () => memoizedSelector(getSnapshot())
+    const getServer =
+      getServerSnapshot === undefined ? undefined : () => memoizedSelector(getServerSnapshot())
+    return [get, getServer] as const
+  }, [getSnapshot, getServerSnapshot, selector, isEqual])
+
+  const value = useSyncExternalStore(subscribe, getSelection, getServerSelection)
+  useDebugValue(value)
+  inst.hasValue = true
+  inst.value = value
+  return value
+}

--- a/packages/redact/src/react/index.ts
+++ b/packages/redact/src/react/index.ts
@@ -1,0 +1,149 @@
+export { createElement, cloneElement, isValidElement, createRef, Fragment } from './element'
+export type {
+  ReactElement,
+  ReactNode,
+  Key,
+  Ref,
+  RefObject,
+  RefCallback,
+  Dispatch,
+  SetStateAction,
+  EffectCallback,
+  DependencyList,
+} from '../core'
+
+// Lightweight functional-component alias — matches React's FC shape closely
+// enough for the common `const X: FC<P> = (props) => …` pattern used in
+// tests and downstream consumer code.
+export type FC<P = {}> = (props: P & { children?: import('../core').ReactNode }) => import('../core').ReactElement | null
+export {
+  useState,
+  useReducer,
+  useEffect,
+  useLayoutEffect,
+  useInsertionEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useDebugValue,
+  useId,
+  useTransition,
+  useDeferredValue,
+  useSyncExternalStore,
+  useSyncExternalStoreWithSelector,
+  use,
+  useActionState,
+  useFormStatus,
+  useOptimistic,
+  useEffectEvent,
+  startTransition,
+} from './hooks'
+export {
+  createContext,
+  REACT_CONTEXT_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_CONSUMER_TYPE,
+  type Context,
+  type ProviderExoticComponent,
+  type ConsumerExoticComponent,
+} from './context'
+export { Component, PureComponent } from './class'
+export {
+  memo, forwardRef, lazy,
+  REACT_MEMO_TYPE,
+  REACT_FORWARD_REF_TYPE,
+  REACT_LAZY_TYPE,
+} from './memo'
+export {
+  Suspense, StrictMode, Profiler,
+  REACT_SUSPENSE_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_PROFILER_TYPE,
+} from './suspense'
+export { REACT_PORTAL_TYPE } from './portal'
+export { Children } from './children'
+export { ReactSharedInternals } from './shared-internals'
+
+// Stub exports
+export const cache = <T extends Function>(fn: T): T => fn
+export const act = async (fn: () => any) => {
+  const r = fn()
+  if (r && typeof r.then === 'function') await r
+}
+export function taintUniqueValue(_msg: string, _lifetime: any, _value: any): void {}
+export function taintObjectReference(_msg: string, _object: any): void {}
+
+export const version = '19.2.3'
+
+// Default export for `import React from 'react'` usage
+import { createElement, cloneElement, isValidElement, createRef, Fragment } from './element'
+import {
+  useState,
+  useReducer,
+  useEffect,
+  useLayoutEffect,
+  useInsertionEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useDebugValue,
+  useId,
+  useTransition,
+  useDeferredValue,
+  useSyncExternalStore,
+  use,
+  useActionState,
+  useFormStatus,
+  useOptimistic,
+  useEffectEvent,
+  startTransition,
+} from './hooks'
+import { createContext } from './context'
+import { Component, PureComponent } from './class'
+import { memo, forwardRef, lazy } from './memo'
+import { Suspense, StrictMode, Profiler } from './suspense'
+import { Children } from './children'
+
+export default {
+  createElement,
+  cloneElement,
+  isValidElement,
+  createRef,
+  Fragment,
+  useState,
+  useReducer,
+  useEffect,
+  useLayoutEffect,
+  useInsertionEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useDebugValue,
+  useId,
+  useTransition,
+  useDeferredValue,
+  useSyncExternalStore,
+  use,
+  useActionState,
+  useFormStatus,
+  useOptimistic,
+  useEffectEvent,
+  startTransition,
+  createContext,
+  Component,
+  PureComponent,
+  memo,
+  forwardRef,
+  lazy,
+  Suspense,
+  StrictMode,
+  Profiler,
+  Children,
+  version: '19.2.3',
+}

--- a/packages/redact/src/react/jsx-runtime.ts
+++ b/packages/redact/src/react/jsx-runtime.ts
@@ -1,0 +1,36 @@
+import { REACT_ELEMENT_TYPE, type ReactElement } from '../core'
+
+export { Fragment } from './element'
+
+export function jsx(type: any, props: any, key?: any): ReactElement {
+  return {
+    $$typeof: REACT_ELEMENT_TYPE,
+    type,
+    key: key == null ? null : '' + key,
+    ref: props?.ref ?? null,
+    props,
+  }
+}
+
+export const jsxs = jsx
+export const jsxDEV = jsx
+
+// Permissive JSX namespace — picked up by TypeScript via the
+// `jsxImportSource: "@ss/redact"` + `jsx: "react-jsx"` pair. The
+// runtime accepts any element type and any props; matching that with strict
+// element typings would require an entire React.dom.d.ts surface, which
+// isn't a stated goal of redact (consumers who want strict JSX still alias
+// `react`/`react-dom` types from the real packages).
+export namespace JSX {
+  export type Element = ReactElement
+  export type ElementType = any
+  export interface IntrinsicElements {
+    [elemName: string]: any
+  }
+  export interface ElementChildrenAttribute {
+    children: {}
+  }
+  export interface ElementAttributesProperty {
+    props: {}
+  }
+}

--- a/packages/redact/src/react/memo.ts
+++ b/packages/redact/src/react/memo.ts
@@ -1,0 +1,61 @@
+import type { ReactElement, ReactNode, Ref } from '../core'
+
+export const REACT_MEMO_TYPE = Symbol.for('react.memo')
+export const REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref')
+export const REACT_LAZY_TYPE = Symbol.for('react.lazy')
+
+// Component-shaped return type so JSX usage of memo/forwardRef/lazy results
+// type-checks. The runtime value is a `$$typeof`-tagged record that the
+// reconciler recognizes via type-matchers; the cast lets TypeScript treat
+// it as a callable component at JSX sites without changing what the runtime
+// actually does. `children` is included for the common
+// `<Comp>...</Comp>` form even when the inner P doesn't list it.
+export type ExoticComponent<P> = ((
+  props: P & { children?: ReactNode; ref?: any; key?: any },
+) => ReactElement | null) & {
+  readonly $$typeof: symbol
+}
+
+export function memo<P>(
+  type: (props: P) => any,
+  areEqual?: (prev: Readonly<P>, next: Readonly<P>) => boolean,
+): ExoticComponent<P> {
+  return { $$typeof: REACT_MEMO_TYPE, type, compare: areEqual ?? null } as unknown as ExoticComponent<P>
+}
+
+export function forwardRef<R, P = {}>(
+  render: (props: P, ref: { current: R | null } | ((r: R | null) => void) | null) => any,
+): ExoticComponent<P & { ref?: Ref<R> }> {
+  return { $$typeof: REACT_FORWARD_REF_TYPE, render } as unknown as ExoticComponent<P & { ref?: Ref<R> }>
+}
+
+export function lazy<T extends { default: any }>(ctor: () => Promise<T>): ExoticComponent<
+  T['default'] extends (props: infer P) => any ? P : {}
+> {
+  const payload = {
+    status: -1 as -1 | 0 | 1 | 2,
+    result: undefined as any,
+  }
+  return {
+    $$typeof: REACT_LAZY_TYPE,
+    _payload: payload,
+    _init: (p: typeof payload): any => {
+      if (p.status === 1) return p.result
+      if (p.status === 2) throw p.result
+      if (p.status === 0) throw p.result // pending promise
+      const thenable = ctor().then(
+        (mod) => {
+          p.status = 1
+          p.result = mod.default
+        },
+        (err) => {
+          p.status = 2
+          p.result = err
+        },
+      )
+      p.status = 0
+      p.result = thenable
+      throw thenable
+    },
+  } as unknown as ExoticComponent<T['default'] extends (props: infer P) => any ? P : {}>
+}

--- a/packages/redact/src/react/portal.ts
+++ b/packages/redact/src/react/portal.ts
@@ -1,0 +1,1 @@
+export const REACT_PORTAL_TYPE = Symbol.for('react.portal')

--- a/packages/redact/src/react/shared-internals.ts
+++ b/packages/redact/src/react/shared-internals.ts
@@ -1,0 +1,79 @@
+import type { Fiber, FiberRoot, Hook } from '../core'
+
+export interface Dispatcher {
+  useState<S>(initial: S | (() => S)): [S, (s: S | ((p: S) => S)) => void]
+  useReducer<S, A>(
+    reducer: (s: S, a: A) => S,
+    initial: S | any,
+    init?: (a: any) => S,
+  ): [S, (a: A) => void]
+  useEffect(create: () => any, deps?: ReadonlyArray<unknown>): void
+  useLayoutEffect(create: () => any, deps?: ReadonlyArray<unknown>): void
+  useInsertionEffect(create: () => any, deps?: ReadonlyArray<unknown>): void
+  useRef<T>(initial: T): { current: T }
+  useMemo<T>(factory: () => T, deps?: ReadonlyArray<unknown>): T
+  useCallback<T extends Function>(fn: T, deps?: ReadonlyArray<unknown>): T
+  useContext<T>(ctx: any): T
+  useImperativeHandle<T>(ref: any, factory: () => T, deps?: ReadonlyArray<unknown>): void
+  useDebugValue<T>(value: T, formatter?: (v: T) => any): void
+  useId(): string
+  useTransition(): [boolean, (fn: () => void) => void]
+  useDeferredValue<T>(v: T): T
+  useSyncExternalStore<T>(
+    subscribe: (cb: () => void) => () => void,
+    getSnapshot: () => T,
+    getServerSnapshot?: () => T,
+  ): T
+  use<T>(promiseOrContext: any): T
+}
+
+interface SharedInternals {
+  H: Dispatcher | null
+  T: any
+  S: ((fn: () => void) => void) | null
+  currentFiber: Fiber | null
+  currentRoot: FiberRoot | null
+  currentHook: Hook | null
+  hookIndex: number
+}
+
+// Stash the singleton on `globalThis` under a registered symbol. Module-scoped
+// state goes wrong fast in environments that end up with multiple copies of
+// `@ss/redact` in flight — most notably Cloudflare's `vite-plugin` dev
+// mode, where the worker entry inlines `@ss/redact` once via `noExternal`
+// while user code reaches a separate pre-bundled `deps_ssr/redact.js` copy.
+// Each copy would otherwise have its own `ReactSharedInternals.H`, so the SSR
+// dispatcher installed by one would be invisible to hooks called through the
+// other and `useContext` would explode with "Hooks can only be called inside a
+// function component". `Symbol.for` survives module re-evaluation and isolate
+// boundaries, giving every copy the same backing object.
+const KEY = Symbol.for('@ss/redact.ReactSharedInternals')
+const g = globalThis as unknown as { [k: symbol]: SharedInternals | undefined }
+
+export const ReactSharedInternals: SharedInternals =
+  g[KEY] ??
+  (g[KEY] = {
+    H: null,
+    T: null,
+    S: null,
+    currentFiber: null,
+    currentRoot: null,
+    currentHook: null,
+    hookIndex: 0,
+  })
+
+export function getDispatcher(): Dispatcher {
+  const d = ReactSharedInternals.H
+  if (!d) {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        'Hooks can only be called inside a function component. ' +
+          'If this fires during SSR/RSC, the most common cause is a component that uses client-only hooks ' +
+          '(useState, useContext, useRouter, etc.) being rendered in the RSC server environment without a ' +
+          '"use client" directive at the top of its file.',
+      )
+    }
+    throw new Error('Hooks can only be called inside a function component.')
+  }
+  return d
+}

--- a/packages/redact/src/react/shared-internals.ts
+++ b/packages/redact/src/react/shared-internals.ts
@@ -50,9 +50,14 @@ interface SharedInternals {
 const KEY = Symbol.for('@ss/redact.ReactSharedInternals')
 const g = globalThis as unknown as { [k: symbol]: SharedInternals | undefined }
 
-export const ReactSharedInternals: SharedInternals =
-  g[KEY] ??
-  (g[KEY] = {
+// Use an explicit conditional-init instead of the `??` + assignment-in-
+// expression form. Biome's `noAssignInExpressions` lint flags the inline
+// `(g[KEY] = {...})` pattern, which gates CI in linters that treat warnings
+// as errors. Functionally identical: register-or-reuse the singleton.
+function initReactSharedInternals(): SharedInternals {
+  const existing = g[KEY]
+  if (existing) return existing
+  const fresh: SharedInternals = {
     H: null,
     T: null,
     S: null,
@@ -60,7 +65,12 @@ export const ReactSharedInternals: SharedInternals =
     currentRoot: null,
     currentHook: null,
     hookIndex: 0,
-  })
+  }
+  g[KEY] = fresh
+  return fresh
+}
+
+export const ReactSharedInternals: SharedInternals = initReactSharedInternals()
 
 export function getDispatcher(): Dispatcher {
   const d = ReactSharedInternals.H

--- a/packages/redact/src/react/suspense.ts
+++ b/packages/redact/src/react/suspense.ts
@@ -1,0 +1,18 @@
+export const REACT_SUSPENSE_TYPE = Symbol.for('react.suspense')
+export const REACT_STRICT_MODE_TYPE = Symbol.for('react.strict_mode')
+export const REACT_PROFILER_TYPE = Symbol.for('react.profiler')
+
+export const Suspense = REACT_SUSPENSE_TYPE as any as (props: {
+  children?: any
+  fallback?: any
+}) => any
+
+export const StrictMode = REACT_STRICT_MODE_TYPE as any as (props: {
+  children?: any
+}) => any
+
+export const Profiler = REACT_PROFILER_TYPE as any as (props: {
+  id: string
+  onRender?: any
+  children?: any
+}) => any

--- a/packages/redact/src/scheduler/index.ts
+++ b/packages/redact/src/scheduler/index.ts
@@ -1,0 +1,124 @@
+// Minimal `scheduler` package surface — enough for React-ecosystem libraries
+// (react-three/fiber, react-query's older scheduler calls, some devtools) to
+// resolve the import without crashing. We don't implement priority lanes or
+// interruptible work; everything runs on microtask or the next task.
+
+const PRIORITY_IMMEDIATE = 1
+const PRIORITY_USER_BLOCKING = 2
+const PRIORITY_NORMAL = 3
+const PRIORITY_LOW = 4
+const PRIORITY_IDLE = 5
+
+type Callback = () => unknown
+
+interface Task {
+  id: number
+  callback: Callback | null
+  priority: number
+  cancelled: boolean
+}
+
+let nextId = 0
+
+export function unstable_scheduleCallback(priority: number, cb: Callback): Task {
+  const task: Task = {
+    id: ++nextId,
+    callback: cb,
+    priority,
+    cancelled: false,
+  }
+  const run = () => {
+    if (task.cancelled || !task.callback) return
+    const fn = task.callback
+    task.callback = null
+    try {
+      fn()
+    } catch (e) {
+      // Re-throw on next task so the host sees it
+      setTimeout(() => {
+        throw e
+      }, 0)
+    }
+  }
+  // Immediate → microtask so ordering is predictable; everything else → next task.
+  if (priority <= PRIORITY_IMMEDIATE) {
+    queueMicrotask(run)
+  } else {
+    setTimeout(run, 0)
+  }
+  return task
+}
+
+export function unstable_cancelCallback(task: Task): void {
+  task.cancelled = true
+  task.callback = null
+}
+
+export function unstable_shouldYield(): boolean {
+  // We never yield — work runs to completion on whichever task schedules it.
+  return false
+}
+
+export function unstable_requestPaint(): void {
+  // no-op
+}
+
+export function unstable_now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+export function unstable_getCurrentPriorityLevel(): number {
+  return PRIORITY_NORMAL
+}
+
+export function unstable_runWithPriority<T>(_priority: number, fn: () => T): T {
+  return fn()
+}
+
+export function unstable_next<T>(fn: () => T): T {
+  return fn()
+}
+
+export function unstable_wrapCallback<T extends (...args: any[]) => any>(fn: T): T {
+  return fn
+}
+
+export function unstable_continueExecution(): void {
+  // no-op
+}
+
+export function unstable_pauseExecution(): void {
+  // no-op
+}
+
+export function unstable_getFirstCallbackNode(): Task | null {
+  return null
+}
+
+export const unstable_IdlePriority = PRIORITY_IDLE
+export const unstable_ImmediatePriority = PRIORITY_IMMEDIATE
+export const unstable_LowPriority = PRIORITY_LOW
+export const unstable_NormalPriority = PRIORITY_NORMAL
+export const unstable_UserBlockingPriority = PRIORITY_USER_BLOCKING
+
+// Some libraries (e.g. @react-three/fiber) import `scheduler` with a default
+// binding expecting the namespace object. Provide one.
+export default {
+  unstable_scheduleCallback,
+  unstable_cancelCallback,
+  unstable_shouldYield,
+  unstable_requestPaint,
+  unstable_now,
+  unstable_getCurrentPriorityLevel,
+  unstable_runWithPriority,
+  unstable_next,
+  unstable_wrapCallback,
+  unstable_continueExecution,
+  unstable_pauseExecution,
+  unstable_getFirstCallbackNode,
+  unstable_IdlePriority,
+  unstable_ImmediatePriority,
+  unstable_LowPriority,
+  unstable_NormalPriority,
+  unstable_UserBlockingPriority,
+}

--- a/packages/redact/src/server/bootstrap-script.ts
+++ b/packages/redact/src/server/bootstrap-script.ts
@@ -1,0 +1,52 @@
+/**
+ * Inline client runtime injected into the streamed HTML. Two jobs:
+ *
+ *  1. Reveal suspense boundaries as their resolved chunks arrive ($RC).
+ *  2. Capture interaction events from the moment the shell is visible so the
+ *     main bundle can replay them against un-hydrated subtrees ($RE_q buffer).
+ *
+ * Wire format:
+ *   Fallback:  <!--$?ID--><div hidden id="B:ID">fallback</div><!--/$-->
+ *   Resolved:  emits <div hidden id="S:ID">real</div><script>$RC(ID)</script>
+ *              which splices real into place and rewrites the comment to <!--$ID-->.
+ *
+ * Client hydration calls $RH(ID, cb) to register a callback invoked once the
+ * boundary has been revealed (or immediately, if it was already revealed).
+ *
+ * Early-event buffering: before the main bundle is parsed, we attach capture
+ * listeners for a small set of interactive events and push them into a buffer.
+ * The bundle drains and replays them via the replay code in @ss/redact/dom.
+ */
+export const BOUNDARY_REVEAL_RUNTIME =
+  `(function(){` +
+    `var c={};` +
+    `window.$RH=function(i,f){` +
+      `if(!document.getElementById("B:"+i))f();` +
+      `else c[i]=f;` +
+    `};` +
+    `window.$RC=function(i){` +
+      `var s=document.getElementById("S:"+i),b=document.getElementById("B:"+i);` +
+      `if(!s||!b)return;` +
+      `var p=b.parentNode,m=b.previousSibling;` +
+      `while(s.firstChild)p.insertBefore(s.firstChild,b);` +
+      `s.parentNode.removeChild(s);` +
+      `p.removeChild(b);` +
+      `if(m&&m.nodeType===8)m.data="$"+i;` +
+      `if(c[i]){var f=c[i];delete c[i];f()}` +
+    `};` +
+    `var q=[];window.$RE_q=q;` +
+    `var evs=["click","submit","input","change","keydown"];` +
+    `function h(e){q.push([e.type,e.target,e.timeStamp])}` +
+    `for(var j=0;j<evs.length;j++)document.addEventListener(evs[j],h,true);` +
+    `window.$RE_stop=function(){for(var j=0;j<evs.length;j++)document.removeEventListener(evs[j],h,true)};` +
+  `})();`
+
+export function injectBootstrapScript(nonce?: string): string {
+  const n = nonce ? ` nonce="${nonce}"` : ''
+  return `<script${n}>${BOUNDARY_REVEAL_RUNTIME}</script>`
+}
+
+export function revealScript(id: number, nonce?: string): string {
+  const n = nonce ? ` nonce="${nonce}"` : ''
+  return `<script${n}>$RC(${id})</script>`
+}

--- a/packages/redact/src/server/bootstrap-script.ts
+++ b/packages/redact/src/server/bootstrap-script.ts
@@ -41,12 +41,20 @@ export const BOUNDARY_REVEAL_RUNTIME =
     `window.$RE_stop=function(){for(var j=0;j<evs.length;j++)document.removeEventListener(evs[j],h,true)};` +
   `})();`
 
+import { escapeAttr } from './escape'
+
+// `nonce` is HTML-escaped on every interpolation. A correctly-issued CSP
+// nonce is base64 random and never contains `"`/`<`/`>`, but the runtime
+// can't enforce that on whatever the consumer passes — so we treat the
+// nonce as untrusted input at the attribute boundary. Without escaping, a
+// malformed or attacker-controlled nonce could break out of the attribute
+// context and inject markup adjacent to a script we control.
 export function injectBootstrapScript(nonce?: string): string {
-  const n = nonce ? ` nonce="${nonce}"` : ''
+  const n = nonce ? ` nonce="${escapeAttr(nonce)}"` : ''
   return `<script${n}>${BOUNDARY_REVEAL_RUNTIME}</script>`
 }
 
 export function revealScript(id: number, nonce?: string): string {
-  const n = nonce ? ` nonce="${nonce}"` : ''
+  const n = nonce ? ` nonce="${escapeAttr(nonce)}"` : ''
   return `<script${n}>$RC(${id})</script>`
 }

--- a/packages/redact/src/server/dispatcher.ts
+++ b/packages/redact/src/server/dispatcher.ts
@@ -1,0 +1,158 @@
+import { ReactSharedInternals, REACT_CONTEXT_TYPE } from '../react'
+
+interface SSRFrame {
+  idCounter: number
+  identifierPrefix: string
+  contextStack: Array<{ context: any; prev: any }>
+}
+
+let frame: SSRFrame | null = null
+
+export function beginSSR(identifierPrefix = ':R'): void {
+  frame = { idCounter: 0, identifierPrefix, contextStack: [] }
+}
+
+export function endSSR(): void {
+  // Restore any remaining pushed contexts (defensive)
+  if (frame) {
+    for (let i = frame.contextStack.length - 1; i >= 0; i--) {
+      const { context, prev } = frame.contextStack[i]!
+      context._currentValue = prev
+    }
+  }
+  frame = null
+}
+
+export function pushContext(context: any, value: any): void {
+  if (!frame) throw new Error('pushContext called outside SSR')
+  frame.contextStack.push({ context, prev: context._currentValue })
+  context._currentValue = value
+}
+
+export function popContext(context: any): void {
+  if (!frame) return
+  const top = frame.contextStack.pop()
+  if (top && top.context === context) context._currentValue = top.prev
+}
+
+export type ContextSnapshot = Array<{ context: any; value: any }>
+
+export function snapshotContexts(): ContextSnapshot {
+  if (!frame) return []
+  const out: ContextSnapshot = []
+  for (const entry of frame.contextStack) {
+    out.push({ context: entry.context, value: entry.context._currentValue })
+  }
+  return out
+}
+
+/**
+ * Push snapshot values and return a function that pops them.
+ * Called when we re-render a suspended boundary so it sees the same provider
+ * values that were active at suspension time.
+ */
+export function applyContextSnapshot(snapshot: ContextSnapshot): () => void {
+  for (const { context, value } of snapshot) pushContext(context, value)
+  return () => {
+    for (let i = snapshot.length - 1; i >= 0; i--) popContext(snapshot[i]!.context)
+  }
+}
+
+export const ssrDispatcher = {
+  useState<S>(initial: S | (() => S)) {
+    const v = typeof initial === 'function' ? (initial as () => S)() : initial
+    return [v, (() => {}) as any] as [S, any]
+  },
+  useReducer<S, A>(_reducer: (s: S, a: A) => S, initialArg: any, init?: (a: any) => S) {
+    const v = init ? init(initialArg) : initialArg
+    return [v, (() => {}) as any]
+  },
+  useEffect() {
+    // noop on server
+  },
+  useLayoutEffect() {
+    // noop on server
+  },
+  useInsertionEffect() {
+    // noop on server
+  },
+  useRef<T>(initial: T) {
+    return { current: initial }
+  },
+  useMemo<T>(factory: () => T) {
+    return factory()
+  },
+  useCallback<T extends Function>(fn: T) {
+    return fn
+  },
+  useContext<T>(ctx: any): T {
+    return ctx._currentValue
+  },
+  useImperativeHandle() {
+    // noop on server
+  },
+  useDebugValue() {
+    // noop
+  },
+  useId(): string {
+    if (!frame) return ':r0:'
+    return `${frame.identifierPrefix}${(frame.idCounter++).toString(36)}`
+  },
+  useTransition(): [boolean, (fn: () => void) => void] {
+    return [false, (fn) => fn()]
+  },
+  useDeferredValue<T>(v: T): T {
+    return v
+  },
+  useSyncExternalStore<T>(
+    _subscribe: (cb: () => void) => () => void,
+    getSnapshot: () => T,
+    getServerSnapshot?: () => T,
+  ): T {
+    return getServerSnapshot ? getServerSnapshot() : getSnapshot()
+  },
+  use<T>(resource: any): T {
+    if (resource == null) throw new Error('use() received null or undefined')
+    if (resource.$$typeof === REACT_CONTEXT_TYPE) {
+      return resource._currentValue
+    }
+    if (typeof resource.then === 'function') {
+      const thenable = resource
+      switch (thenable.status) {
+        case 'fulfilled':
+          return thenable.value
+        case 'rejected':
+          throw thenable.reason
+        default: {
+          if (thenable.status === undefined) {
+            thenable.status = 'pending'
+            thenable.then(
+              (v: any) => {
+                if (thenable.status === 'pending') {
+                  thenable.status = 'fulfilled'
+                  thenable.value = v
+                }
+              },
+              (e: any) => {
+                if (thenable.status === 'pending') {
+                  thenable.status = 'rejected'
+                  thenable.reason = e
+                }
+              },
+            )
+          }
+          throw thenable
+        }
+      }
+    }
+    throw new Error('use() expected a Promise or Context')
+  },
+}
+
+export function installSSRDispatcher(): void {
+  ReactSharedInternals.H = ssrDispatcher as any
+}
+
+export function uninstallSSRDispatcher(): void {
+  ReactSharedInternals.H = null
+}

--- a/packages/redact/src/server/escape.ts
+++ b/packages/redact/src/server/escape.ts
@@ -186,6 +186,17 @@ const BOOLEAN_ATTRS = new Set([
   'selected',
 ])
 
+// HTML attribute names: must start with a letter or underscore and contain
+// only letters/digits/`_.-:$`. Anything else (whitespace, quotes, `>`, `/`,
+// `=`, etc.) is illegal per the HTML spec and would break out of the
+// attribute-name context if emitted, opening attribute-injection XSS via
+// untrusted spread props (e.g. `<div {...untrustedJson} />`). React drops
+// invalid attribute names; we do the same. The character set is
+// deliberately narrow so it accepts every standard HTML/SVG attribute,
+// custom data-/aria-* names, and xlink:/xml: namespaced forms — but
+// nothing that contains attribute-context delimiters.
+const VALID_ATTR_NAME = /^[a-zA-Z_][a-zA-Z0-9_.\-:$]*$/
+
 export function attrToHtml(name: string, value: unknown): string {
   if (
     name === 'children' ||
@@ -201,6 +212,13 @@ export function attrToHtml(name: string, value: unknown): string {
   }
   if (name[0] === 'o' && name[1] === 'n' && typeof value === 'function') return ''
   if (value == null) return ''
+  // Reject attribute names that don't match the HTML spec. Without this
+  // gate, a prop named `foo"><script>` would render as literal markup
+  // because the `aria-`/`data-` branch and the catch-all both interpolate
+  // the name without escaping. Aliased names from ATTR_ALIASES (and the
+  // case-folded `name.toLowerCase()` form) are derived from `name` and
+  // can't introduce new characters, so validating `name` covers both.
+  if (!VALID_ATTR_NAME.test(name)) return ''
 
   const htmlName = ATTR_ALIASES[name] ?? name.toLowerCase()
 

--- a/packages/redact/src/server/escape.ts
+++ b/packages/redact/src/server/escape.ts
@@ -210,7 +210,20 @@ export function attrToHtml(name: string, value: unknown): string {
   ) {
     return ''
   }
-  if (name[0] === 'o' && name[1] === 'n' && typeof value === 'function') return ''
+  // Drop every on*-shaped prop on the server, regardless of value type or
+  // case. Functions can't be serialized; a string value would land in the
+  // catch-all and be emitted as `onclick="…"`, an inline event handler that
+  // browsers execute as JS — a direct XSS sink when untrusted props are
+  // spread onto a host element. Catches both the camelCase JSX form
+  // (`onClick`) and the lowercase HTML form (`onclick`); there is no
+  // legitimate non-handler HTML attribute starting with `on`.
+  if (
+    name.length >= 3 &&
+    (name[0] === 'o' || name[0] === 'O') &&
+    (name[1] === 'n' || name[1] === 'N')
+  ) {
+    return ''
+  }
   if (value == null) return ''
   // Reject attribute names that don't match the HTML spec. Without this
   // gate, a prop named `foo"><script>` would render as literal markup

--- a/packages/redact/src/server/escape.ts
+++ b/packages/redact/src/server/escape.ts
@@ -1,0 +1,286 @@
+const ATTR_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '"': '&quot;',
+  '<': '&lt;',
+  '>': '&gt;',
+}
+const TEXT_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+}
+
+export function escapeAttr(value: string): string {
+  return value.replace(/[&"<>]/g, (c) => ATTR_MAP[c]!)
+}
+
+export function escapeText(value: string): string {
+  return value.replace(/[&<>]/g, (c) => TEXT_MAP[c]!)
+}
+
+// Raw-text element body escaping: prevent any closing tag for the raw-text
+// elements (<script>, <style>) from terminating the element early, plus
+// `<!--` (which would start an HTML comment that survives even inside
+// raw-text bodies and can be exploited to alter following script content).
+// React's serializer follows the same approach.
+export function escapeScript(value: string): string {
+  return value
+    .replace(/<\/(script|style)/gi, '<\\/$1')
+    .replace(/<!--/g, '<\\!--')
+}
+
+export const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+
+export const RAW_TEXT_ELEMENTS = new Set(['script', 'style'])
+
+// Map JSX prop names to HTML attribute names where they differ. The fallback
+// in `attrToHtml` is `name.toLowerCase()`, so any attribute that needs a
+// hyphen, a colon (xlink:*), or case preservation MUST be listed here.
+// Mirrors `SVG_ATTR_RENAME` in dom/dom.ts so client and SSR output agree
+// at hydration time.
+export const ATTR_ALIASES: Record<string, string> = {
+  className: 'class',
+  htmlFor: 'for',
+  httpEquiv: 'http-equiv',
+  acceptCharset: 'accept-charset',
+  crossOrigin: 'crossorigin',
+  noModule: 'nomodule',
+  // SVG attributes whose case is preserved by spec (would otherwise be
+  // lowercased by the fallback). Keep this group together for grep-ability.
+  viewBox: 'viewBox',
+  preserveAspectRatio: 'preserveAspectRatio',
+  gradientTransform: 'gradientTransform',
+  gradientUnits: 'gradientUnits',
+  patternContentUnits: 'patternContentUnits',
+  patternTransform: 'patternTransform',
+  patternUnits: 'patternUnits',
+  attributeName: 'attributeName',
+  attributeType: 'attributeType',
+  calcMode: 'calcMode',
+  keySplines: 'keySplines',
+  keyTimes: 'keyTimes',
+  keyPoints: 'keyPoints',
+  repeatCount: 'repeatCount',
+  repeatDur: 'repeatDur',
+  tableValues: 'tableValues',
+  textLength: 'textLength',
+  lengthAdjust: 'lengthAdjust',
+  pathLength: 'pathLength',
+  baseFrequency: 'baseFrequency',
+  numOctaves: 'numOctaves',
+  stitchTiles: 'stitchTiles',
+  startOffset: 'startOffset',
+  // SVG presentation attributes — camelCase JSX → kebab-case DOM.
+  // stroke
+  strokeDasharray: 'stroke-dasharray',
+  strokeDashoffset: 'stroke-dashoffset',
+  strokeLinecap: 'stroke-linecap',
+  strokeLinejoin: 'stroke-linejoin',
+  strokeMiterlimit: 'stroke-miterlimit',
+  strokeOpacity: 'stroke-opacity',
+  strokeWidth: 'stroke-width',
+  // fill
+  fillOpacity: 'fill-opacity',
+  fillRule: 'fill-rule',
+  // clip / mask
+  clipPath: 'clip-path',
+  clipRule: 'clip-rule',
+  // color / lighting
+  colorInterpolation: 'color-interpolation',
+  colorInterpolationFilters: 'color-interpolation-filters',
+  colorProfile: 'color-profile',
+  colorRendering: 'color-rendering',
+  floodColor: 'flood-color',
+  floodOpacity: 'flood-opacity',
+  lightingColor: 'lighting-color',
+  stopColor: 'stop-color',
+  stopOpacity: 'stop-opacity',
+  // font
+  fontFamily: 'font-family',
+  fontSize: 'font-size',
+  fontSizeAdjust: 'font-size-adjust',
+  fontStretch: 'font-stretch',
+  fontStyle: 'font-style',
+  fontVariant: 'font-variant',
+  fontWeight: 'font-weight',
+  // text
+  textAnchor: 'text-anchor',
+  textDecoration: 'text-decoration',
+  textRendering: 'text-rendering',
+  alignmentBaseline: 'alignment-baseline',
+  baselineShift: 'baseline-shift',
+  dominantBaseline: 'dominant-baseline',
+  letterSpacing: 'letter-spacing',
+  wordSpacing: 'word-spacing',
+  writingMode: 'writing-mode',
+  // markers
+  markerEnd: 'marker-end',
+  markerMid: 'marker-mid',
+  markerStart: 'marker-start',
+  // rendering hints
+  pointerEvents: 'pointer-events',
+  shapeRendering: 'shape-rendering',
+  imageRendering: 'image-rendering',
+  vectorEffect: 'vector-effect',
+  paintOrder: 'paint-order',
+  // misc presentation
+  enableBackground: 'enable-background',
+  glyphOrientationHorizontal: 'glyph-orientation-horizontal',
+  glyphOrientationVertical: 'glyph-orientation-vertical',
+  unicodeBidi: 'unicode-bidi',
+  // xlink:* (deprecated in SVG2 but still parsed by browsers)
+  xlinkActuate: 'xlink:actuate',
+  xlinkArcrole: 'xlink:arcrole',
+  xlinkHref: 'xlink:href',
+  xlinkRole: 'xlink:role',
+  xlinkShow: 'xlink:show',
+  xlinkTitle: 'xlink:title',
+  xlinkType: 'xlink:type',
+  // xml:* and xmlns:xlink
+  xmlBase: 'xml:base',
+  xmlLang: 'xml:lang',
+  xmlSpace: 'xml:space',
+  xmlnsXlink: 'xmlns:xlink',
+}
+
+const BOOLEAN_ATTRS = new Set([
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+])
+
+export function attrToHtml(name: string, value: unknown): string {
+  if (
+    name === 'children' ||
+    name === 'key' ||
+    name === 'ref' ||
+    name === 'dangerouslySetInnerHTML' ||
+    name === 'defaultValue' ||
+    name === 'defaultChecked' ||
+    name === 'suppressHydrationWarning' ||
+    name === 'suppressContentEditableWarning'
+  ) {
+    return ''
+  }
+  if (name[0] === 'o' && name[1] === 'n' && typeof value === 'function') return ''
+  if (value == null) return ''
+
+  const htmlName = ATTR_ALIASES[name] ?? name.toLowerCase()
+
+  // aria-* and data-* stringify booleans to `"true"`/`"false"` rather than
+  // using boolean-attribute presence semantics — matches React and the ARIA
+  // spec. Must branch before the general `value === false` / BOOLEAN_ATTRS
+  // path, which would drop them.
+  if (name.startsWith('aria-') || name.startsWith('data-')) {
+    return ` ${htmlName}="${escapeAttr(String(value))}"`
+  }
+
+  if (value === false) return ''
+
+  if (value === true || BOOLEAN_ATTRS.has(htmlName)) {
+    return value ? ` ${htmlName}=""` : ''
+  }
+
+  if (name === 'style' && typeof value === 'object' && value !== null) {
+    return ` style="${escapeAttr(styleToString(value as Record<string, unknown>))}"`
+  }
+
+  return ` ${htmlName}="${escapeAttr(String(value))}"`
+}
+
+const UNITLESS_STYLE = new Set([
+  'animationIterationCount',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexPositive',
+  'flexShrink',
+  'flexNegative',
+  'flexOrder',
+  'gridArea',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowSpan',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnSpan',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+  'fillOpacity',
+  'floodOpacity',
+  'stopOpacity',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
+])
+
+function styleToString(style: Record<string, unknown>): string {
+  let out = ''
+  for (const key in style) {
+    const v = style[key]
+    if (v == null || v === false) continue
+    const kebab = key.startsWith('--')
+      ? key
+      : key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+    const value =
+      typeof v === 'number' && !UNITLESS_STYLE.has(key) && v !== 0 ? v + 'px' : v
+    out += `${kebab}:${value};`
+  }
+  return out
+}

--- a/packages/redact/src/server/index.ts
+++ b/packages/redact/src/server/index.ts
@@ -1,0 +1,26 @@
+export { renderToString, renderToStaticMarkup } from './renderToString'
+export { renderToReadableStream, renderToPipeableStream } from './stream'
+export type {
+  StreamOptions,
+  PipeableOptions,
+  PipeableHandle,
+  ReadableStreamResult,
+} from './stream'
+export { BOUNDARY_REVEAL_RUNTIME } from './bootstrap-script'
+
+export const version = '19.2.3'
+
+// Default export — React's real `react-dom/server` ships one, and TanStack
+// Router's SSR code does `import ReactDOMServer from 'react-dom/server'` and
+// reads `.renderToReadableStream` off the default.
+import { renderToString, renderToStaticMarkup } from './renderToString'
+import { renderToReadableStream, renderToPipeableStream } from './stream'
+import { BOUNDARY_REVEAL_RUNTIME } from './bootstrap-script'
+export default {
+  renderToString,
+  renderToStaticMarkup,
+  renderToReadableStream,
+  renderToPipeableStream,
+  BOUNDARY_REVEAL_RUNTIME,
+  version: '19.2.3',
+}

--- a/packages/redact/src/server/renderToString.ts
+++ b/packages/redact/src/server/renderToString.ts
@@ -1,0 +1,33 @@
+import type { ReactNode } from '../core'
+import { beginSSR, endSSR, installSSRDispatcher, uninstallSSRDispatcher } from './dispatcher'
+import { walk } from './walk'
+
+export function renderToString(
+  children: ReactNode,
+  options: { identifierPrefix?: string } = {},
+): string {
+  installSSRDispatcher()
+  beginSSR(options.identifierPrefix)
+  let output = ''
+  let id = 0
+  try {
+    walk(children, {
+      emit: (s) => {
+        output += s
+      },
+      nextBoundaryId: () => id++,
+    })
+  } finally {
+    endSSR()
+    uninstallSSRDispatcher()
+  }
+  return output
+}
+
+export function renderToStaticMarkup(
+  children: ReactNode,
+  options: { identifierPrefix?: string } = {},
+): string {
+  // For our purposes identical to renderToString (no hydration markers in static output)
+  return renderToString(children, options).replace(/<!--[^>]*-->/g, '')
+}

--- a/packages/redact/src/server/stream.ts
+++ b/packages/redact/src/server/stream.ts
@@ -1,0 +1,302 @@
+import type { ReactNode } from '../core'
+import {
+  beginSSR,
+  endSSR,
+  installSSRDispatcher,
+  uninstallSSRDispatcher,
+  applyContextSnapshot,
+} from './dispatcher'
+import { walk, type SuspendedBoundary } from './walk'
+import { BOUNDARY_REVEAL_RUNTIME, revealScript } from './bootstrap-script'
+
+export interface StreamOptions {
+  identifierPrefix?: string
+  nonce?: string
+  bootstrapScripts?: ReadonlyArray<string | { src: string; async?: boolean; nonce?: string }>
+  bootstrapModules?: ReadonlyArray<string | { src: string; nonce?: string }>
+  onError?: (error: unknown) => string | void
+  signal?: AbortSignal
+  progressiveChunkSize?: number
+}
+
+export interface ReadableStreamResult extends ReadableStream<Uint8Array> {
+  allReady: Promise<void>
+}
+
+export interface OrchestratorState {
+  nextId: number
+  pending: Set<Promise<void>>
+  closed: boolean
+  errored: unknown | null
+}
+
+type Emit = (chunk: string) => void
+
+export async function streamHtml(
+  children: ReactNode,
+  emit: Emit,
+  options: StreamOptions,
+  state: OrchestratorState,
+): Promise<void> {
+  installSSRDispatcher()
+  beginSSR(options.identifierPrefix)
+  const nonce = options.nonce
+
+  try {
+    const boundaries: SuspendedBoundary[] = []
+
+    // Buffer shell + bootstrap into a string[] and flush as a single emit.
+    // Per-emit overhead in renderToReadableStream is TextEncoder.encode +
+    // controller.enqueue — each walkHost normally fires 3+ emits (opening
+    // tag, per-attribute, closing bracket), which for a ~30-component tree
+    // is ~100 stream-controller round-trips. Batching collapses those into
+    // one encode and one enqueue per shell — measured ~2-4% of total SSR
+    // time on CPU profiles.
+    const shellChunks: string[] = []
+    const bufferedEmit: Emit = (chunk) => {
+      shellChunks.push(chunk)
+    }
+
+    // 1. Render the shell
+    walk(children, {
+      emit: bufferedEmit,
+      onSuspend: (b) => boundaries.push(b),
+      nextBoundaryId: () => state.nextId++,
+    })
+
+    // 2. Inject runtime + bootstrap scripts (once, after shell). Skip the
+    // reveal/event-replay runtime when nothing needs it — no suspensions to
+    // reveal and no bootstrap scripts to guard against early user input. That
+    // keeps fully-static SSR responses byte-equivalent to a plain walk and
+    // matches React's behavior where `renderToReadableStream` of a static
+    // tree emits only the markup.
+    const hasBootstrap =
+      (options.bootstrapScripts?.length ?? 0) > 0 ||
+      (options.bootstrapModules?.length ?? 0) > 0
+    if (boundaries.length > 0 || hasBootstrap) {
+      shellChunks.push(`<script${nonce ? ` nonce="${nonce}"` : ''}>${BOUNDARY_REVEAL_RUNTIME}</script>`)
+      for (const s of options.bootstrapScripts ?? []) {
+        shellChunks.push(bootstrapTag(s, 'script', nonce))
+      }
+      for (const m of options.bootstrapModules ?? []) {
+        shellChunks.push(bootstrapTag(m, 'module', nonce))
+      }
+    }
+
+    if (shellChunks.length) emit(shellChunks.join(''))
+
+    // 3. Stream suspended boundaries as they resolve
+    for (const b of boundaries) streamBoundary(b, emit, options, state)
+    await drain(state)
+  } catch (err) {
+    state.errored = err
+    if (options.onError) options.onError(err)
+    throw err
+  } finally {
+    endSSR()
+    uninstallSSRDispatcher()
+    state.closed = true
+  }
+}
+
+function streamBoundary(
+  b: SuspendedBoundary,
+  emit: Emit,
+  options: StreamOptions,
+  state: OrchestratorState,
+): void {
+  const task = (async () => {
+    try {
+      await b.thenable
+    } catch (err) {
+      if (options.onError) options.onError(err)
+    }
+    if (state.closed) return
+
+    // Re-render the boundary's children into a string, restoring the
+    // provider stack from when the boundary first suspended.
+    const parts: string[] = []
+    const sub: SuspendedBoundary[] = []
+    const restore = applyContextSnapshot(b.contextSnapshot)
+    try {
+      walk(b.children, {
+        emit: (s) => parts.push(s),
+        onSuspend: (n) => sub.push(n),
+        nextBoundaryId: () => state.nextId++,
+      })
+    } catch (err) {
+      if (options.onError) options.onError(err)
+      restore()
+      return
+    }
+    restore()
+
+    emit(`<div hidden id="S:${b.id}">${parts.join('')}</div>${revealScript(b.id, options.nonce)}`)
+
+    // Recurse: any nested suspensions inside the now-revealed content
+    for (const s of sub) streamBoundary(s, emit, options, state)
+  })()
+  state.pending.add(task)
+  task.finally(() => state.pending.delete(task))
+}
+
+async function drain(state: OrchestratorState): Promise<void> {
+  while (state.pending.size > 0) {
+    await Promise.race(state.pending)
+  }
+}
+
+function bootstrapTag(
+  entry: string | { src: string; async?: boolean; nonce?: string },
+  kind: 'script' | 'module',
+  defaultNonce: string | undefined,
+): string {
+  const src = typeof entry === 'string' ? entry : entry.src
+  const nonce = typeof entry === 'string' ? defaultNonce : entry.nonce ?? defaultNonce
+  const nAttr = nonce ? ` nonce="${nonce}"` : ''
+  if (kind === 'module') return `<script type="module"${nAttr} src="${src}"></script>`
+  return `<script async${nAttr} src="${src}"></script>`
+}
+
+// ---------------------------------------------------------------------------
+// Web Streams: renderToReadableStream
+// ---------------------------------------------------------------------------
+
+export function renderToReadableStream(
+  children: ReactNode,
+  options: StreamOptions = {},
+): Promise<ReadableStreamResult> {
+  const state: OrchestratorState = {
+    nextId: 0,
+    pending: new Set(),
+    closed: false,
+    errored: null,
+  }
+  const encoder = new TextEncoder()
+
+  let allReadyResolve!: () => void
+  let allReadyReject!: (e: unknown) => void
+  const allReady = new Promise<void>((r, rej) => {
+    allReadyResolve = r
+    allReadyReject = rej
+  })
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emit = (chunk: string) => {
+        try {
+          controller.enqueue(encoder.encode(chunk))
+        } catch {}
+      }
+
+      streamHtml(children, emit, options, state).then(
+        () => {
+          try {
+            controller.close()
+          } catch {}
+          allReadyResolve()
+        },
+        (err) => {
+          try {
+            controller.error(err)
+          } catch {}
+          allReadyReject(err)
+        },
+      )
+
+      options.signal?.addEventListener('abort', () => {
+        state.closed = true
+        try {
+          controller.close()
+        } catch {}
+      })
+    },
+  })
+
+  return Promise.resolve(Object.assign(stream, { allReady }))
+}
+
+// ---------------------------------------------------------------------------
+// Node Streams: renderToPipeableStream
+// ---------------------------------------------------------------------------
+
+export interface PipeableHandle {
+  pipe<T extends NodeJS.WritableStream>(dest: T): T
+  abort(reason?: unknown): void
+}
+
+export interface PipeableOptions extends StreamOptions {
+  onShellReady?: () => void
+  onShellError?: (err: unknown) => void
+  onAllReady?: () => void
+}
+
+export function renderToPipeableStream(
+  children: ReactNode,
+  options: PipeableOptions = {},
+): PipeableHandle {
+  const state: OrchestratorState = {
+    nextId: 0,
+    pending: new Set(),
+    closed: false,
+    errored: null,
+  }
+
+  const buffers: string[] = []
+  let dest: NodeJS.WritableStream | null = null
+  let shellReady = false
+  let finished = false
+  let aborted = false
+
+  const flushTo = (w: NodeJS.WritableStream) => {
+    if (!buffers.length) return
+    for (const b of buffers) w.write(b)
+    buffers.length = 0
+  }
+
+  const emit: Emit = (chunk) => {
+    if (aborted || finished) return
+    if (dest) dest.write(chunk)
+    else buffers.push(chunk)
+  }
+
+  // Kick off rendering
+  streamHtml(children, emit, options, state).then(
+    () => {
+      finished = true
+      if (dest) dest.end()
+      options.onAllReady?.()
+    },
+    (err) => {
+      if (!shellReady) {
+        options.onShellError?.(err)
+      } else {
+        options.onError?.(err)
+        if (dest) dest.end()
+      }
+    },
+  )
+
+  // We call onShellReady once the first synchronous emit has landed.
+  // streamHtml above runs the shell synchronously before the first await in drain(),
+  // so we can schedule onShellReady right after the first microtask.
+  queueMicrotask(() => {
+    if (aborted || finished) return
+    shellReady = true
+    options.onShellReady?.()
+  })
+
+  return {
+    pipe<T extends NodeJS.WritableStream>(target: T): T {
+      dest = target
+      flushTo(target)
+      if (finished) target.end()
+      return target
+    },
+    abort(_reason?: unknown) {
+      aborted = true
+      state.closed = true
+      if (dest) dest.end()
+    },
+  }
+}

--- a/packages/redact/src/server/stream.ts
+++ b/packages/redact/src/server/stream.ts
@@ -8,6 +8,7 @@ import {
 } from './dispatcher'
 import { walk, type SuspendedBoundary } from './walk'
 import { BOUNDARY_REVEAL_RUNTIME, revealScript } from './bootstrap-script'
+import { escapeAttr } from './escape'
 
 export interface StreamOptions {
   identifierPrefix?: string
@@ -74,7 +75,7 @@ export async function streamHtml(
       (options.bootstrapScripts?.length ?? 0) > 0 ||
       (options.bootstrapModules?.length ?? 0) > 0
     if (boundaries.length > 0 || hasBootstrap) {
-      shellChunks.push(`<script${nonce ? ` nonce="${nonce}"` : ''}>${BOUNDARY_REVEAL_RUNTIME}</script>`)
+      shellChunks.push(`<script${nonce ? ` nonce="${escapeAttr(nonce)}"` : ''}>${BOUNDARY_REVEAL_RUNTIME}</script>`)
       for (const s of options.bootstrapScripts ?? []) {
         shellChunks.push(bootstrapTag(s, 'script', nonce))
       }
@@ -153,9 +154,14 @@ function bootstrapTag(
 ): string {
   const src = typeof entry === 'string' ? entry : entry.src
   const nonce = typeof entry === 'string' ? defaultNonce : entry.nonce ?? defaultNonce
-  const nAttr = nonce ? ` nonce="${nonce}"` : ''
-  if (kind === 'module') return `<script type="module"${nAttr} src="${src}"></script>`
-  return `<script async${nAttr} src="${src}"></script>`
+  // Both `src` and `nonce` are interpolated into HTML attribute values.
+  // Even though the consumer typically controls them, we cannot assume
+  // they're free of `"`/`<`/`>` — a malformed config or runtime-derived
+  // URL could break out of the attribute context. Always escape.
+  const nAttr = nonce ? ` nonce="${escapeAttr(nonce)}"` : ''
+  const srcAttr = escapeAttr(src)
+  if (kind === 'module') return `<script type="module"${nAttr} src="${srcAttr}"></script>`
+  return `<script async${nAttr} src="${srcAttr}"></script>`
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/redact/src/server/stream.ts
+++ b/packages/redact/src/server/stream.ts
@@ -29,6 +29,32 @@ export interface OrchestratorState {
   pending: Set<Promise<void>>
   closed: boolean
   errored: unknown | null
+  // Resolves when the stream is forcibly closed (abort, controller error,
+  // pipeable handle.abort). `drain()` races pending boundary promises
+  // against this so a never-settling boundary doesn't keep the SSR
+  // dispatcher pinned forever after abort. Without it, an aborted stream
+  // with an unsettled `<Suspense>` would leak `installSSRDispatcher`'s
+  // module state past the lifetime of the request.
+  closePromise: Promise<void>
+  resolveClosed: () => void
+}
+
+// Lazily wires up the abort sentinel. Both render entry points create one
+// of these; threading a factory keeps the chicken-and-egg between
+// `closePromise` and `resolveClosed` in one place.
+function createOrchestratorState(): OrchestratorState {
+  let resolveClosed!: () => void
+  const closePromise = new Promise<void>((r) => {
+    resolveClosed = r
+  })
+  return {
+    nextId: 0,
+    pending: new Set(),
+    closed: false,
+    errored: null,
+    closePromise,
+    resolveClosed,
+  }
 }
 
 type Emit = (chunk: string) => void
@@ -142,8 +168,14 @@ function streamBoundary(
 }
 
 async function drain(state: OrchestratorState): Promise<void> {
+  // Race pending against the abort sentinel so a never-settling boundary
+  // doesn't keep us spinning after the consumer aborts. Re-check
+  // `state.closed` after the wait and bail without throwing — the abort
+  // path is responsible for surfacing the cancellation through its own
+  // channels (controller.close / dest.end).
   while (state.pending.size > 0) {
-    await Promise.race(state.pending)
+    if (state.closed) return
+    await Promise.race([...state.pending, state.closePromise])
   }
 }
 
@@ -172,12 +204,7 @@ export function renderToReadableStream(
   children: ReactNode,
   options: StreamOptions = {},
 ): Promise<ReadableStreamResult> {
-  const state: OrchestratorState = {
-    nextId: 0,
-    pending: new Set(),
-    closed: false,
-    errored: null,
-  }
+  const state = createOrchestratorState()
   const encoder = new TextEncoder()
 
   let allReadyResolve!: () => void
@@ -212,6 +239,7 @@ export function renderToReadableStream(
 
       options.signal?.addEventListener('abort', () => {
         state.closed = true
+        state.resolveClosed()
         try {
           controller.close()
         } catch {}
@@ -241,12 +269,7 @@ export function renderToPipeableStream(
   children: ReactNode,
   options: PipeableOptions = {},
 ): PipeableHandle {
-  const state: OrchestratorState = {
-    nextId: 0,
-    pending: new Set(),
-    closed: false,
-    errored: null,
-  }
+  const state = createOrchestratorState()
 
   const buffers: string[] = []
   let dest: NodeJS.WritableStream | null = null
@@ -302,6 +325,7 @@ export function renderToPipeableStream(
     abort(_reason?: unknown) {
       aborted = true
       state.closed = true
+      state.resolveClosed()
       if (dest) dest.end()
     },
   }

--- a/packages/redact/src/server/walk.ts
+++ b/packages/redact/src/server/walk.ts
@@ -1,0 +1,448 @@
+import {
+  REACT_ELEMENT_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
+  REACT_FRAGMENT_TYPE,
+  type ReactNode,
+  type ReactElement,
+} from '../core'
+import {
+  REACT_SUSPENSE_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_CONSUMER_TYPE,
+  REACT_FORWARD_REF_TYPE,
+  REACT_MEMO_TYPE,
+  REACT_LAZY_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_PROFILER_TYPE,
+  REACT_PORTAL_TYPE,
+} from '../react'
+import {
+  attrToHtml,
+  escapeText,
+  escapeScript,
+  VOID_ELEMENTS,
+  RAW_TEXT_ELEMENTS,
+} from './escape'
+import {
+  pushContext,
+  popContext,
+  snapshotContexts,
+  type ContextSnapshot,
+} from './dispatcher'
+
+export interface SuspendedBoundary {
+  id: number
+  fallbackHTML: string
+  children: ReactNode
+  thenable: Promise<any>
+  contextSnapshot: ContextSnapshot
+}
+
+export interface WalkOptions {
+  emit: (chunk: string) => void
+  onSuspend?: ((boundary: SuspendedBoundary) => void) | undefined
+  nextBoundaryId: () => number
+  bootstrapped?: boolean | undefined
+  isBoundaryResolution?: boolean | undefined
+  /**
+   * Tracks whether the most recent emission within the *current text flow*
+   * ended with a text node. When the next emission is also text, we emit a
+   * `<!-- -->` separator so the browser's HTML parser doesn't merge them
+   * into a single text node — required for hydration to line up text
+   * boundaries with the React tree. Reset to `false` whenever we enter a
+   * new host element (`<tag>` opens a fresh text flow).
+   */
+  textState?: { lastWasText: boolean }
+}
+
+/**
+ * Synchronously walk a React node and emit HTML string pieces to `opts.emit`.
+ * Suspended boundaries are emitted as fallbacks with marker IDs; if `opts.onSuspend`
+ * is provided, the suspension is recorded for later streaming.
+ */
+export function walk(node: ReactNode, opts: WalkOptions): void {
+  // Seed a text state if the caller didn't provide one so the separator logic
+  // is active for the whole tree.
+  if (!opts.textState) opts = { ...opts, textState: { lastWasText: false } }
+  walkNode(node, opts)
+}
+
+// --- <select> selection context ----------------------------------------------
+// Stack of active select values (or `undefined` when the current select has
+// no controlled value). `<option>` walks read the top of stack to decide
+// whether to emit `selected=""`.
+const selectValueStack: unknown[] = []
+function pushSelectContext(value: unknown): void {
+  selectValueStack.push(value)
+}
+function popSelectContext(): void {
+  selectValueStack.pop()
+}
+function currentSelectValue(): unknown {
+  return selectValueStack.length ? selectValueStack[selectValueStack.length - 1] : undefined
+}
+
+function optionChildText(children: unknown): string {
+  // `<option>Text</option>` — if no `value` prop, the option's value is its
+  // flat string/number child content. Matches DOM semantics (`option.value`
+  // defaults to `textContent` when no attribute is set).
+  if (children == null) return ''
+  if (typeof children === 'string' || typeof children === 'number') return '' + children
+  if (Array.isArray(children)) return children.map(optionChildText).join('')
+  return ''
+}
+
+function emitText(text: string, opts: WalkOptions): void {
+  // Empty string renders no text node and doesn't start/extend a text flow —
+  // skip entirely so sibling text isn't separated by a stray `<!-- -->`.
+  if (text === '') return
+  if (opts.textState?.lastWasText) opts.emit('<!-- -->')
+  opts.emit(escapeText(text))
+  if (opts.textState) opts.textState.lastWasText = true
+}
+
+function walkNode(node: ReactNode, opts: WalkOptions): void {
+  if (node == null || node === false || node === true) return
+
+  if (typeof node === 'string') {
+    emitText(node, opts)
+    return
+  }
+  if (typeof node === 'number') {
+    emitText(String(node), opts)
+    return
+  }
+  if (Array.isArray(node)) {
+    for (const c of node) walkNode(c, opts)
+    return
+  }
+  if (typeof (node as any)[Symbol.iterator] === 'function') {
+    for (const item of node as Iterable<ReactNode>) walkNode(item, opts)
+    return
+  }
+
+  if (typeof node !== 'object') return
+  const t = (node as any).$$typeof
+
+  // Raw React.lazy in the tree (RSC Flight encodes 'use client' components —
+  // CodeBlock, CodeExplorer, etc. — as bare Lazy objects directly in the
+  // tree, not wrapped in REACT_ELEMENT_TYPE). SSR previously dropped these
+  // here, so code snippets never made it into the server HTML. The RSC
+  // decoder server-side awaits payloads before rendering, so status is
+  // 'fulfilled' and `_init()` returns the resolved element synchronously.
+  // If still pending (shouldn't happen post-awaitLazyElements), throw the
+  // thenable so streaming SSR suspends the current boundary and retries.
+  if (t === REACT_LAZY_TYPE) {
+    const lazy = node as any
+    const resolved = lazy._init(lazy._payload)
+    walkNode(resolved, opts)
+    return
+  }
+
+  if (t !== REACT_ELEMENT_TYPE && t !== REACT_LEGACY_ELEMENT_TYPE) return
+
+  const el = node as ReactElement
+  walkElement(el, opts)
+}
+
+function walkElement(el: ReactElement, opts: WalkOptions): void {
+  const type = el.type
+  const props = el.props ?? {}
+
+  if (type === REACT_FRAGMENT_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_PROFILER_TYPE) {
+    walkNode(props.children, opts)
+    return
+  }
+
+  if (type === REACT_SUSPENSE_TYPE) {
+    walkSuspense(props, opts)
+    return
+  }
+
+  if (typeof type === 'string') {
+    walkHost(type, props, opts)
+    return
+  }
+
+  const marker = (type as any)?.$$typeof
+
+  if (marker === REACT_PORTAL_TYPE) {
+    // Portals don't render to the main HTML output on the server.
+    return
+  }
+
+  if (marker === REACT_PROVIDER_TYPE) {
+    const ctx = (type as any)._context
+    pushContext(ctx, props.value)
+    try {
+      walkNode(props.children, opts)
+    } finally {
+      popContext(ctx)
+    }
+    return
+  }
+
+  if (marker === REACT_CONSUMER_TYPE) {
+    const ctx = (type as any)._context
+    const render = props.children
+    if (typeof render === 'function') {
+      walkNode(render(ctx._currentValue), opts)
+    }
+    return
+  }
+
+  if (marker === REACT_FORWARD_REF_TYPE) {
+    const render = (type as any).render
+    const ref = (props as any).ref ?? null
+    const { ref: _omit, ...rest } = props as any
+    const rendered = render(rest, ref)
+    walkNode(rendered, opts)
+    return
+  }
+
+  if (marker === REACT_MEMO_TYPE) {
+    const inner = (type as any).type
+    walkElement({ ...el, type: inner } as ReactElement, opts)
+    return
+  }
+
+  if (marker === REACT_LAZY_TYPE) {
+    const { _payload, _init } = type as any
+    try {
+      const resolved = _init(_payload)
+      walkElement({ ...el, type: resolved } as ReactElement, opts)
+    } catch (thenable: any) {
+      if (isThenable(thenable)) {
+        // Suspend this point
+        throw thenable
+      }
+      throw thenable
+    }
+    return
+  }
+
+  if (typeof type === 'function') {
+    walkComponent(type, props, opts)
+    return
+  }
+}
+
+function walkHost(
+  tag: string,
+  props: Record<string, any>,
+  opts: WalkOptions,
+): void {
+  // <textarea value="..."> serializes its value as a TEXT CHILD, not an
+  // attribute. `defaultValue` is the fallback when `value` is absent. This
+  // matches React and the HTML spec — `<textarea value="x">` is not valid
+  // HTML; the value is the element's textContent.
+  const isTextarea = tag === 'textarea'
+  const textareaValue = isTextarea
+    ? props.value != null
+      ? props.value
+      : props.defaultValue
+    : undefined
+
+  // <input defaultValue="..."> should parse with that value — emit it as a
+  // `value` attribute. Similarly `defaultChecked` becomes `checked`. This
+  // keeps hydration consistent: the browser parser sees the initial value,
+  // and on client commit our setProp seeds `.defaultValue`/`.defaultChecked`
+  // without stomping the user-typed value.
+  const isInput = tag === 'input'
+  const inputValueAttr =
+    isInput && props.value == null && props.defaultValue != null
+      ? props.defaultValue
+      : undefined
+  const inputCheckedAttr =
+    isInput && props.checked == null && props.defaultChecked != null
+      ? props.defaultChecked
+      : undefined
+
+  // <select value="..."> does NOT become an attribute on `<select>` — the
+  // HTML spec has no such attribute. React resolves the selection by stamping
+  // `selected` on the matching `<option>` children during render. Stash the
+  // target value(s) on the walk state and the child `<option>` walk reads it.
+  const isSelect = tag === 'select'
+  if (isSelect) {
+    const val = props.value != null ? props.value : props.defaultValue
+    pushSelectContext(val)
+  }
+  const isOption = tag === 'option'
+
+  // Prepend the HTML5 doctype to the stream when rendering an <html> root.
+  // Without it the browser parses the document in quirks mode, which breaks
+  // CSS sizing (documentElement.clientHeight returns the content height, not
+  // the viewport) — and Floating-UI-based libraries (Radix dropdowns etc.)
+  // then compute off-screen positions for overlays.
+  if (tag === 'html') opts.emit('<!DOCTYPE html>')
+
+  opts.emit('<' + tag)
+  for (const k in props) {
+    if (isTextarea && (k === 'value' || k === 'defaultValue')) continue
+    if (isInput && (k === 'defaultValue' || k === 'defaultChecked')) continue
+    if (isSelect && (k === 'value' || k === 'defaultValue')) continue
+    if (isOption && k === 'selected') continue
+    opts.emit(attrToHtml(k, props[k]))
+  }
+  if (inputValueAttr !== undefined) {
+    opts.emit(attrToHtml('value', inputValueAttr))
+  }
+  if (inputCheckedAttr !== undefined) {
+    opts.emit(attrToHtml('checked', inputCheckedAttr))
+  }
+  if (isOption) {
+    const selectVal = currentSelectValue()
+    if (selectVal !== undefined) {
+      const optionValue =
+        props.value != null ? props.value : optionChildText(props.children)
+      const matches = Array.isArray(selectVal)
+        ? selectVal.some((v) => '' + v === '' + optionValue)
+        : '' + selectVal === '' + optionValue
+      if (matches) opts.emit(' selected=""')
+    } else if (props.selected) {
+      opts.emit(' selected=""')
+    }
+  }
+
+  if (VOID_ELEMENTS.has(tag)) {
+    opts.emit('/>')
+    if (opts.textState) opts.textState.lastWasText = false
+    return
+  }
+  opts.emit('>')
+  // Opening a host element starts a fresh text flow context for its children.
+  // Children's text separator tracking is independent of the outer context.
+  const parentTextState = opts.textState
+  const childOpts: WalkOptions = { ...opts, textState: { lastWasText: false } }
+
+  const dangerouslyHtml = props.dangerouslySetInnerHTML?.__html
+
+  if (isTextarea && textareaValue != null) {
+    opts.emit(escapeText(String(textareaValue)))
+    opts.emit(`</${tag}>`)
+    if (parentTextState) parentTextState.lastWasText = false
+    return
+  }
+
+  if (RAW_TEXT_ELEMENTS.has(tag)) {
+    // script/style: raw-text. React allows either a string/number child or
+    // dangerouslySetInnerHTML — some libs (Start's Scripts) use the latter.
+    if (dangerouslyHtml != null) {
+      opts.emit(escapeScript(String(dangerouslyHtml)))
+    } else {
+      const children = props.children
+      if (typeof children === 'string' || typeof children === 'number') {
+        opts.emit(escapeScript(String(children)))
+      } else if (Array.isArray(children)) {
+        opts.emit(escapeScript(children.filter((c) => c != null).join('')))
+      }
+    }
+    opts.emit(`</${tag}>`)
+    if (parentTextState) parentTextState.lastWasText = false
+    return
+  }
+
+  if (dangerouslyHtml != null) {
+    opts.emit(String(dangerouslyHtml))
+  } else {
+    walkNode(props.children, childOpts)
+  }
+  opts.emit(`</${tag}>`)
+  if (isSelect) popSelectContext()
+  // Host element closing resets outer flow — next sibling text starts fresh.
+  if (parentTextState) parentTextState.lastWasText = false
+}
+
+function walkComponent(
+  fn: Function,
+  props: Record<string, any>,
+  opts: WalkOptions,
+): void {
+  if ((fn as any).prototype?.isReactComponent) {
+    const ctxType = (fn as any).contextType
+    const ctxValue = ctxType ? ctxType._currentValue : undefined
+    const instance = new (fn as any)(props, ctxValue)
+    instance.props = props
+    instance.context = ctxValue
+    if ((fn as any).getDerivedStateFromProps) {
+      const d = (fn as any).getDerivedStateFromProps(props, instance.state)
+      if (d) instance.state = { ...instance.state, ...d }
+    }
+    walkNode(instance.render(), opts)
+    return
+  }
+  const rendered = (fn as any)(props)
+  walkNode(rendered, opts)
+}
+
+function walkSuspense(
+  props: Record<string, any>,
+  opts: WalkOptions,
+): void {
+  const id = opts.nextBoundaryId()
+  // Snapshot contexts BEFORE attempting children, so if a descendant suspends
+  // we can replay the same provider stack when re-rendering the boundary.
+  const contextSnapshot = snapshotContexts()
+
+  // Try to render the children synchronously. If a thenable is thrown,
+  // record the boundary and emit the fallback.
+  const childParts: string[] = []
+  const childEmit = (s: string) => childParts.push(s)
+  try {
+    walkNode(props.children, {
+      emit: childEmit,
+      onSuspend: opts.onSuspend,
+      nextBoundaryId: opts.nextBoundaryId,
+    })
+  } catch (thenable: any) {
+    if (isThenable(thenable)) {
+      const fallbackParts: string[] = []
+      try {
+        walkNode(props.fallback, {
+          emit: (s) => fallbackParts.push(s),
+          onSuspend: opts.onSuspend,
+          nextBoundaryId: opts.nextBoundaryId,
+        })
+      } catch {
+        // Fallback suspending is unsupported; emit nothing
+      }
+      emitBoundary(opts, id, fallbackParts.join(''))
+
+      if (opts.onSuspend) {
+        opts.onSuspend({
+          id,
+          fallbackHTML: fallbackParts.join(''),
+          children: props.children,
+          thenable,
+          contextSnapshot,
+        })
+      }
+      return
+    }
+    throw thenable
+  }
+
+  // Children rendered fully — emit them wrapped in resolved-boundary markers
+  // (`<!--$N-->` / `<!--/$-->`). Without markers, the client hydrator has no
+  // way to know this subtree is inside a Suspense, so if the client version
+  // of a descendant (e.g. `React.lazy`) suspends it can't pinpoint which DOM
+  // range to adopt on resolve — it creates fresh DOM next to the SSR content,
+  // producing visible duplicates (e.g. double navbar logos). Markers let the
+  // client treat this as a resolved boundary and hydrate in-place.
+  opts.emit(`<!--$${id}-->`)
+  opts.emit(childParts.join(''))
+  opts.emit(`<!--/$-->`)
+}
+
+function emitBoundary(opts: WalkOptions, id: number, fallbackHTML: string): void {
+  // Visible div wrapper so the fallback UI shows; B: id lets $RC locate it on
+  // reveal. The leading/trailing comments let hydration detect a pending
+  // boundary and register a reveal callback.
+  opts.emit(`<!--$?${id}--><div id="B:${id}">`)
+  opts.emit(fallbackHTML)
+  opts.emit(`</div><!--/$-->`)
+}
+
+function isThenable(x: any): x is Promise<any> {
+  return x != null && typeof x.then === 'function'
+}

--- a/packages/redact/src/vite/index.ts
+++ b/packages/redact/src/vite/index.ts
@@ -1,0 +1,401 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
+import { dirname, resolve as resolvePath } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export type RedactPreset = 'nano' | 'full'
+
+/**
+ * Opt-in feature set. Each flag toggles whether the feature's real
+ * implementation ships (`true`) or is swapped with a stub module that
+ * degrades gracefully (`false`). Missing keys fall back to the preset's
+ * default. Adding a feature to this interface propagates to consumer
+ * configs as autocompleted options.
+ */
+export interface RedactFeatures {
+  /**
+   * `createPortal`. When `false`, portal elements render in place as a
+   * Fragment (the `container` prop is ignored). `renderPortal` and its
+   * deps are stripped from the bundle.
+   */
+  portal?: boolean
+  /**
+   * `createContext` / `useContext` / `<Provider>` / `<Consumer>`. When
+   * `false`, Providers render as Fragments (value never propagates),
+   * Consumers invoke their function-children with the context's default
+   * value, and `useContext` returns the default. Provider-walk logic and
+   * `renderProvider` are stripped.
+   */
+  context?: boolean
+  /**
+   * `<Suspense>` boundaries + streaming hydration. When `false`, Suspense
+   * elements render as Fragments (children mount inline, `fallback` is
+   * ignored). Thrown thenables still schedule a re-render on settle, so
+   * eventual consistency works — just no fallback UI during the pending
+   * window. Boundary-handler stack and hydration integration are stripped.
+   */
+  suspense?: boolean
+  /**
+   * `React.memo`. When `false`, memoized components still render but without
+   * the prop-equality gate — every parent rerender passes through.
+   * `shallowEqual` and the force-rerender bypass are stripped.
+   */
+  memo?: boolean
+  /**
+   * `React.forwardRef`. When `false`, forwardRef components still render but
+   * the ref prop isn't forwarded to the inner function. React 19+ treats
+   * refs as normal props on function components anyway, so most apps can
+   * drop this. The dispatcher save/restore machinery is stripped.
+   */
+  forwardRef?: boolean
+  /**
+   * `React.lazy`. When `false`, lazy elements still resolve if their payload
+   * is already available synchronously (e.g. pre-awaited RSC Flight); async
+   * resolution throws a clear error. The hydration-deferred-reveal path and
+   * Suspense coordination are stripped.
+   */
+  lazy?: boolean
+  /**
+   * Class components (`extends Component`). When `false`, class components
+   * still render but only honor the core contract: constructor + `render()`
+   * + `setState`. Dropped: `contextType`, `getDerivedStateFromProps`,
+   * `shouldComponentUpdate`, `componentDidMount`/`Update`/`WillUnmount`,
+   * `getDerivedStateFromError`/`componentDidCatch` (error boundaries).
+   */
+  classComponents?: boolean
+  /**
+   * SSR hydration (`hydrateRoot`). When `false`, `hydrateRoot` throws
+   * (use `createRoot` for SPAs). The HydrationCursor / DOM adoption /
+   * streaming-boundary coordination / event-replay / scroll-guard
+   * machinery is stripped — the biggest single chunk of reducible code.
+   */
+  hydration?: boolean
+}
+
+interface ResolvedFeatures {
+  portal: boolean
+  context: boolean
+  suspense: boolean
+  memo: boolean
+  forwardRef: boolean
+  lazy: boolean
+  classComponents: boolean
+  hydration: boolean
+}
+
+const PRESET_DEFAULTS: Record<RedactPreset, ResolvedFeatures> = {
+  // Opt-in: everything off. Turn individual features on via `features`.
+  nano: {
+    portal: false, context: false, suspense: false, memo: false,
+    forwardRef: false, lazy: false, classComponents: false, hydration: false,
+  },
+  // Opt-out: everything on (drop-in React parity). Turn features off via `features`.
+  full: {
+    portal: true, context: true, suspense: true, memo: true,
+    forwardRef: true, lazy: true, classComponents: true, hydration: true,
+  },
+}
+
+function resolveFeatures(
+  preset: RedactPreset,
+  overrides: RedactFeatures,
+): ResolvedFeatures {
+  const p = PRESET_DEFAULTS[preset]
+  return {
+    portal: overrides.portal ?? p.portal,
+    context: overrides.context ?? p.context,
+    suspense: overrides.suspense ?? p.suspense,
+    memo: overrides.memo ?? p.memo,
+    forwardRef: overrides.forwardRef ?? p.forwardRef,
+    lazy: overrides.lazy ?? p.lazy,
+    classComponents: overrides.classComponents ?? p.classComponents,
+    hydration: overrides.hydration ?? p.hydration,
+  }
+}
+
+export interface RedactOptions {
+  /** Skip aliasing specific specifiers, e.g. if a consumer wants real React somewhere. */
+  skip?: ReadonlyArray<string>
+  /**
+   * Override package resolution root. Defaults to the Vite config root. Useful
+   * for monorepos where the plugin lives in a different workspace than the
+   * consumer app.
+   */
+  resolveFrom?: string
+  /**
+   * Explicit package roots, bypassing node_modules lookup. Keys are package
+   * names (e.g. `@ss/redact`), values are absolute paths to the package
+   * directory. Handy for cross-workspace testing / bring-your-own-build setups.
+   */
+  packageRoots?: Record<string, string>
+  /**
+   * Starting point for feature selection. `'full'` (default) turns every
+   * feature on — drop-in React parity, opt-out individual features via
+   * `features`. `'nano'` turns everything off — opt in to what you need.
+   */
+  preset?: RedactPreset
+  /**
+   * Per-feature overrides merged on top of the preset's defaults. Enables
+   * fine-grained "preset minus X" or "preset plus Y" configurations.
+   */
+  features?: RedactFeatures
+}
+
+// Alias map. ORDER MATTERS — Vite's alias matcher uses first-match against
+// prefix, so more-specific specifiers MUST come before less-specific ones.
+// Without this, `react-dom/server` would prefix-match `react-dom` first and
+// resolve to `@ss/redact/dom/server` (wrong) instead of
+// `@ss/redact/server`.
+//
+// `use-sync-external-store` aliases are here because its CJS-only React 17
+// compat shim does `var React = require('react')`. That survives Vite's
+// pre-bundling intact and explodes in Cloudflare Workers (no `require`).
+// Modern React has `useSyncExternalStore` built-in, and `@ss/redact`
+// additionally exports `useSyncExternalStoreWithSelector` so this alias
+// is safe everywhere.
+const ALIASES: Record<string, string> = {
+  // ---- most-specific first ----
+  'use-sync-external-store/shim/with-selector': '@ss/redact',
+  'use-sync-external-store/shim/with-selector.js': '@ss/redact',
+  'use-sync-external-store/with-selector': '@ss/redact',
+  'use-sync-external-store/with-selector.js': '@ss/redact',
+  'use-sync-external-store/shim': '@ss/redact',
+  'use-sync-external-store': '@ss/redact',
+
+  // React drop-in shim targets. Subpaths first.
+  'react/jsx-runtime': '@ss/redact/jsx-runtime',
+  'react/jsx-dev-runtime': '@ss/redact/jsx-dev-runtime',
+  'react/compiler-runtime': '@ss/redact/compiler-runtime',
+  'react-dom/client': '@ss/redact/dom-client',
+  'react-dom/server': '@ss/redact/server',
+  'react-dom/test-utils': '@ss/redact/dom-test-utils',
+  'react-dom': '@ss/redact/dom',
+  react: '@ss/redact',
+  scheduler: '@ss/redact/scheduler',
+
+  // Self-aliases so Vite resolves `@ss/redact/*` imports to the same
+  // canonical file path no matter where they originate (worker bundle vs
+  // deps_ssr pre-bundle vs source). Without these, Cloudflare's
+  // `noExternal: true` worker config inlines one copy while Vite's
+  // optimizeDeps pre-bundles another, ending up with two separate
+  // ReactSharedInternals instances and a null dispatcher in user hooks.
+  // Subpaths first here too.
+  '@ss/redact/jsx-runtime': '@ss/redact/jsx-runtime',
+  '@ss/redact/jsx-dev-runtime': '@ss/redact/jsx-dev-runtime',
+  '@ss/redact/compiler-runtime': '@ss/redact/compiler-runtime',
+  '@ss/redact/dom-client': '@ss/redact/dom-client',
+  '@ss/redact/dom-test-utils': '@ss/redact/dom-test-utils',
+  '@ss/redact/server': '@ss/redact/server',
+  '@ss/redact/scheduler': '@ss/redact/scheduler',
+  '@ss/redact/dom': '@ss/redact/dom',
+  '@ss/redact': '@ss/redact',
+}
+
+function splitSpecifier(specifier: string): { pkg: string; sub: string } {
+  if (specifier.startsWith('@')) {
+    const slash1 = specifier.indexOf('/')
+    const slash2 = specifier.indexOf('/', slash1 + 1)
+    if (slash2 < 0) return { pkg: specifier, sub: '' }
+    return { pkg: specifier.slice(0, slash2), sub: specifier.slice(slash2 + 1) }
+  }
+  const slash = specifier.indexOf('/')
+  if (slash < 0) return { pkg: specifier, sub: '' }
+  return { pkg: specifier.slice(0, slash), sub: specifier.slice(slash + 1) }
+}
+
+function findPackageDir(pkg: string, fromDir: string): string | null {
+  let dir = fromDir
+  while (true) {
+    const candidate = resolvePath(dir, 'node_modules', pkg)
+    if (existsSync(resolvePath(candidate, 'package.json'))) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+function resolveExport(packageDir: string, sub: string): string | null {
+  const pkgJsonPath = resolvePath(packageDir, 'package.json')
+  let pkg: any
+  try {
+    pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+  } catch {
+    return null
+  }
+  const key = sub ? './' + sub : '.'
+  const exp = pkg.exports?.[key]
+  // Prefer published `import` (dist/.js) over `source` — dist is a single
+  // transformed bundle so Vite's dep optimizer doesn't thrash on dozens of
+  // individual source files. The package keeps cross-subpath imports
+  // external, so there's still only one runtime instance.
+  const pick = (v: any): string | null => {
+    if (typeof v === 'string') return v
+    if (v && typeof v === 'object') {
+      return pick(v.import ?? v.module ?? v.source ?? v.default ?? null)
+    }
+    return null
+  }
+  const target = pick(exp)
+  if (target) return resolvePath(packageDir, target)
+  if (!sub) {
+    const main = pkg.module ?? pkg.main
+    if (typeof main === 'string') return resolvePath(packageDir, main)
+  }
+  return null
+}
+
+// When installed from npm, `@ss/redact` is declared as a `dependency`
+// of consumer apps. Under pnpm's strict mode it ends up nested under the
+// plugin's own `.pnpm/@tanstack+redact@.../node_modules/` rather than
+// hoisted to the consumer's root, so a `findPackageDir` walk starting at
+// the Vite project root won't always find it. Search from the plugin's own
+// directory first (which walks into its nested node_modules), then fall
+// back to the consumer root for hoisted installs.
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+
+function resolveSpecifier(
+  specifier: string,
+  fromDir: string,
+  packageRoots: Record<string, string>,
+): string | null {
+  const { pkg, sub } = splitSpecifier(specifier)
+  const packageDir =
+    packageRoots[pkg] ??
+    findPackageDir(pkg, pluginDir) ??
+    findPackageDir(pkg, fromDir)
+  if (!packageDir) return null
+  const target = resolveExport(packageDir, sub)
+  if (!target) return null
+  // Canonicalize through pnpm symlinks. Under strict pnpm, the package may
+  // live nested under `.pnpm/@tanstack+redact@.../node_modules/*`, but each
+  // of those is itself a symlink to the flat `.pnpm/@tanstack+redact@.../`
+  // entry. Vite's `fetchModule` (used by TanStack Start's server-fn
+  // compiler) follows the realpath, so the id seen by the capture-transform
+  // differs from the nested id we'd return. That leaves the compiler's
+  // moduleCache keyed on the realpath while `getModuleInfo` looks up the
+  // nested path → miss → "could not load module info". Returning the
+  // canonical realpath here keeps the two sides in agreement.
+  try {
+    return realpathSync(target)
+  } catch {
+    return target
+  }
+}
+
+export function redact(options: RedactOptions = {}): any {
+  const skip = new Set(options.skip ?? [])
+  const entries = Object.entries(ALIASES).filter(([k]) => !skip.has(k))
+  const features = resolveFeatures(options.preset ?? 'full', options.features ?? {})
+
+  const resolvedMap: Record<string, string> = {}
+  let done = false
+
+  function resolveAll(root: string): void {
+    if (done) return
+    const fromDir = options.resolveFrom ?? root
+    const packageRoots = options.packageRoots ?? {}
+    for (const [from, to] of entries) {
+      const resolved = resolveSpecifier(to, fromDir, packageRoots)
+      if (resolved) resolvedMap[from] = resolved
+    }
+    done = true
+  }
+
+  return {
+    name: 'redact',
+    enforce: 'pre',
+
+    config() {
+      const excludeList = entries.map(([k]) => k)
+      // Single package — only one name to dedupe / no-external.
+      const noExt = ['@ss/redact']
+      const aliasMap = Object.fromEntries(entries.filter(([from, to]) => from !== to))
+      // Dedupe `@ss/redact` so Vite resolves it to a single instance
+      // even when multiple packages (e.g. @tanstack/react-router and user
+      // code) drag it into different parts of the module graph.
+      const dedupe = noExt
+      // Scope `resolve.alias` to client + ssr environments ONLY. Do NOT set
+      // a top-level alias: it would apply to the `rsc` environment too,
+      // where `@vitejs/plugin-rsc`'s vendored `react-server-dom-server`
+      // imports `react` and needs the *real* React (with the `.d` field on
+      // ReactSharedInternals that our shim deliberately doesn't have).
+      // Aliasing `react` → `@ss/redact` in the RSC env crashes Flight
+      // serialization. The Cloudflare vite-plugin's rolldown worker-runner
+      // also pre-scans bare specifiers via Vite's alias map (not plugin
+      // hooks), but it scans within the *ssr* environment specifically —
+      // so per-env `environments.ssr.resolve.alias` covers it. The
+      // `enforce: 'pre'` resolveId hook below already skips RSC, so the
+      // remaining concern is alias placement. Object form is required —
+      // array form is silently ignored by rolldown's worker-runner.
+      return {
+        environments: {
+          client: {
+            optimizeDeps: { exclude: excludeList },
+            resolve: { alias: aliasMap, dedupe },
+          },
+          ssr: {
+            optimizeDeps: { exclude: excludeList },
+            resolve: { alias: aliasMap, dedupe, noExternal: noExt },
+          },
+        },
+        ssr: { noExternal: noExt },
+      }
+    },
+
+    configResolved(config: any) {
+      resolveAll(config.root)
+      // With `packageRoots`, package sources live outside the consumer's Vite
+      // project root, so the default server.fs.allow list blocks them. Append
+      // to the resolved allow list rather than replacing via `config()`, so we
+      // keep Vite's defaults (root + node_modules + client runtime).
+      const fsAllow = Object.values(options.packageRoots ?? {})
+      if (fsAllow.length && config.server?.fs?.allow) {
+        for (const p of fsAllow) {
+          if (!config.server.fs.allow.includes(p)) {
+            config.server.fs.allow.push(p)
+          }
+        }
+      }
+    },
+
+    async resolveId(this: any, id: string, importer?: string, opts?: any) {
+      // Skip the RSC environment — it relies on real React internals via
+      // @vitejs/plugin-rsc's vendored react-server-dom. Substituting our
+      // shim there breaks Flight serialization. Client + SSR envs still swap.
+      const envName = this?.environment?.name
+      if (envName === 'rsc') return null
+
+      // Feature-flag swap: when the reconciler's `features/index` module
+      // imports a feature by relative path, redirect to that feature's stub
+      // if the flag is off. The stub registers a graceful-degradation
+      // matcher (e.g. Portal → Fragment) so user code keeps working.
+      if (importer && /[\\/]features[\\/]index\.[jt]sx?$/.test(importer)) {
+        const m = id.match(/^\.\/([a-z-]+)$/)
+        if (m) {
+          const name = m[1] as keyof ResolvedFeatures
+          if (name in features && !features[name]) {
+            const r = await this.resolve(`./${name}/stub`, importer, {
+              ...opts,
+              skipSelf: true,
+            })
+            if (r) return r.id
+          }
+        }
+      }
+
+      // Hydration swap: hydration isn't self-registering, so it's imported
+      // from reconcile.ts, root.ts, and the Suspense/Lazy feature modules.
+      // Any specifier ending in `/hydration` that resolves to our feature
+      // module gets redirected to the stub when the flag is off.
+      if (!features.hydration && importer && /[\\/]hydration$/.test(id)) {
+        const r = await this.resolve(id, importer, { ...opts, skipSelf: true })
+        if (r && /features[\\/]hydration[\\/]index\.(ts|js)$/.test(r.id)) {
+          return r.id.replace(/index\.(ts|js)$/, 'stub.$1')
+        }
+      }
+
+      return resolvedMap[id] ?? null
+    },
+  }
+}
+
+export default redact

--- a/packages/redact/tests/basic.test.tsx
+++ b/packages/redact/tests/basic.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+describe('basic render', () => {
+  it('renders a single element', () => {
+    const container = setup()
+    const root = createRoot(container)
+    root.render(<div id="x">hello</div>)
+    expect(container.innerHTML).toBe('<div id="x">hello</div>')
+  })
+
+  it('renders a function component', () => {
+    const container = setup()
+    function App() {
+      return <span class="greeting">hi</span>
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<span class="greeting">hi</span>')
+  })
+
+  it('useState updates on event', () => {
+    const container = setup()
+    function Counter() {
+      const [n, setN] = React.useState(0)
+      return (
+        <button id="b" onClick={() => setN(n + 1)}>
+          {n}
+        </button>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<Counter />)
+    const btn = container.querySelector('#b') as HTMLButtonElement
+    expect(btn.textContent).toBe('0')
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('1')
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('2')
+  })
+
+  it('renders Fragment and arrays', () => {
+    const container = setup()
+    function App() {
+      return (
+        <>
+          <span>a</span>
+          <span>b</span>
+          {[<span key="c">c</span>, <span key="d">d</span>]}
+        </>
+      )
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<span>a</span><span>b</span><span>c</span><span>d</span>')
+  })
+
+  it('class component with setState', () => {
+    const container = setup()
+    class Counter extends React.Component<{}, { n: number }> {
+      state = { n: 0 }
+      render() {
+        return (
+          <button id="cb" onClick={() => this.setState({ n: this.state.n + 1 })}>
+            {this.state.n}
+          </button>
+        )
+      }
+    }
+    createRoot(container).render(<Counter />)
+    const btn = container.querySelector('#cb') as HTMLButtonElement
+    expect(btn.textContent).toBe('0')
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('1')
+  })
+
+  it('context propagates', () => {
+    const container = setup()
+    const Ctx = React.createContext('default')
+    function Child() {
+      return <span>{React.useContext(Ctx)}</span>
+    }
+    function App() {
+      return (
+        <Ctx.Provider value="hello">
+          <Child />
+        </Ctx.Provider>
+      )
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<span>hello</span>')
+  })
+
+  // Regression: with unkeyed children, a leading sibling flipping null → element
+  // (e.g. `showMenu` revealing a smallMenu above a stable largeMenu wrapped in
+  // a Fragment) used to trigger positional matching that stole a later same-
+  // type fiber's DOM and tore the drawer, which interrupted CSS transitions
+  // and caused a pop-in rather than a slide. The fix: budget-guided positional
+  // matching so insertions don't cascade.
+  //
+  // This mirrors the actual Navbar layout where largeMenu is `<>...</>`
+  // wrapping the drawer div.
+  it('preserves fragment-wrapped sibling when prepending a new sibling', () => {
+    const container = setup()
+    let toggle!: () => void
+    function App() {
+      const [show, setShow] = React.useState(false)
+      toggle = () => setShow((s) => !s)
+      return (
+        <div>
+          {show ? <div id="pop" /> : null}
+          <>
+            <div id="drawer" />
+          </>
+          <div id="content" />
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<App />)
+    const drawerBefore = container.querySelector('#drawer') as HTMLDivElement
+    const contentBefore = container.querySelector('#content') as HTMLDivElement
+    flushSync(() => toggle())
+    expect(container.querySelector('#drawer')).toBe(drawerBefore)
+    expect(container.querySelector('#content')).toBe(contentBefore)
+  })
+})

--- a/packages/redact/tests/callback-ref-commit-phase.test.tsx
+++ b/packages/redact/tests/callback-ref-commit-phase.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Callback refs must run during the commit phase, not during render.
+ *
+ * React's contract: callback refs fire from commitAttachRef in the layout-
+ * effect phase, AFTER the component finishes rendering. Calling them inline
+ * from renderHost violates the contract and breaks libraries that assert
+ * "no event handlers during render".
+ *
+ * Concrete repro this guards against: base-ui's `useStableCallback` returns
+ * a trampoline that throws "Base UI: Cannot call an event handler while
+ * rendering" until commit swaps in the real callback. base-ui's
+ * `useMergedRefs` composes refs through this trampoline, so any host
+ * element with a base-ui-merged ref blew up at mount when redact's
+ * attachRef ran callback refs synchronously.
+ *
+ * Beyond the base-ui assertion, render-time ref invocation is also a
+ * latent footgun for any ref that triggers a setState (which would re-enter
+ * the reconciler mid-traversal) — symptoms include unexpected child order,
+ * dropped subtrees, and double-mounted DOM.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('callback refs — commit-phase semantics', () => {
+  it('does not invoke a callback ref during render', () => {
+    let rendering = false
+    let calledDuringRender = false
+    let calledAtAll = false
+    let receivedNode: HTMLElement | null = null
+
+    function App() {
+      rendering = true
+      try {
+        return (
+          <div
+            id="target"
+            ref={(el: HTMLDivElement | null) => {
+              calledAtAll = true
+              if (rendering) calledDuringRender = true
+              receivedNode = el as HTMLElement | null
+            }}
+          />
+        )
+      } finally {
+        rendering = false
+      }
+    }
+
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<App />))
+
+    // Must have been called by now (commit ran synchronously inside flushSync).
+    expect(calledAtAll).toBe(true)
+    expect(calledDuringRender).toBe(false)
+    expect(receivedNode).toBe(container.querySelector('#target'))
+  })
+
+  it('runs the cleanup ref(null) on unmount', () => {
+    const calls: Array<HTMLElement | null> = []
+    function App({ show }: { show: boolean }) {
+      return (
+        <div>
+          {show ? <span ref={(el: HTMLSpanElement | null) => calls.push(el as HTMLElement | null)} /> : null}
+        </div>
+      )
+    }
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<App show={true} />))
+    expect(calls.length).toBe(1)
+    expect(calls[0]).not.toBeNull()
+
+    flushSync(() => root.render(<App show={false} />))
+    expect(calls.length).toBe(2)
+    expect(calls[1]).toBeNull()
+  })
+
+  it('runs the user-provided cleanup function returned from a callback ref', () => {
+    const events: string[] = []
+    function App({ show }: { show: boolean }) {
+      return (
+        <div>
+          {show ? (
+            <span
+              ref={() => {
+                events.push('attach')
+                return () => {
+                  events.push('cleanup')
+                }
+              }}
+            />
+          ) : null}
+        </div>
+      )
+    }
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<App show={true} />))
+    expect(events).toEqual(['attach'])
+
+    flushSync(() => root.render(<App show={false} />))
+    expect(events).toEqual(['attach', 'cleanup'])
+  })
+
+  it('host element with a callback ref renders in source order alongside siblings', () => {
+    // Repro shape from shadcn/ui Sidebar: a wrapped peer with a ref alongside
+    // a plain main element. With render-phase ref invocation, the reconciler
+    // could occasionally place children out of source order.
+    const Ctx = React.createContext<string | null>(null)
+    const refCallsDuringRender: number[] = []
+    let renderDepth = 0
+
+    function Peer() {
+      renderDepth++
+      try {
+        return (
+          <Ctx.Provider value="peer">
+            <div
+              data-slot="sidebar"
+              ref={() => {
+                refCallsDuringRender.push(renderDepth)
+              }}
+            />
+          </Ctx.Provider>
+        )
+      } finally {
+        renderDepth--
+      }
+    }
+
+    function App() {
+      renderDepth++
+      try {
+        return (
+          <div id="wrapper">
+            <Peer />
+            <main data-slot="sidebar-inset" />
+          </div>
+        )
+      } finally {
+        renderDepth--
+      }
+    }
+
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<App />))
+
+    // Slots must be in source order.
+    const slots = Array.from(container.querySelector('#wrapper')!.children).map(
+      (c) => c.getAttribute('data-slot'),
+    )
+    expect(slots).toEqual(['sidebar', 'sidebar-inset'])
+
+    // Ref must not have been called while any component was rendering.
+    expect(refCallsDuringRender.every((d) => d === 0)).toBe(true)
+  })
+})

--- a/packages/redact/tests/child-reorder.test.tsx
+++ b/packages/redact/tests/child-reorder.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * DOM placement when child order changes across re-renders.
+ *
+ * The reconciler's placeChildrenInOrder pass moves DOM nodes to match the
+ * new fiber order. It must iterate such that moving doms[i] doesn't
+ * disturb items not yet placed — otherwise a chain of moves cascades into
+ * the wrong final order.
+ *
+ * Reported symptoms this test locks down:
+ *   - tanstack.com application starter: after clicking Analyze and then
+ *     picking a different idea chip, the Analyze and "I'm feeling lucky"
+ *     buttons swap places. Concrete transition: existing=[A, R] (Analyze
+ *     + "Review" message div), new=[A, L, R] (Analyze + Lucky + "Prompt
+ *     changed" div). Forward iteration produced [L, A, R]; correct is
+ *     [A, L, R].
+ *   - npm stats library dropdown: library items reorder after filter
+ *     changes. Same root cause.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+function textsOf(parent: Element): string[] {
+  return Array.from(parent.children).map((c) => c.textContent || '')
+}
+
+describe('child reorder — DOM placement', () => {
+  it('inserts a new middle child between existing siblings without disturbing order', () => {
+    const container = setup()
+    function App({ state }: { state: 'initial' | 'analyzing' | 'changed' }) {
+      if (state === 'initial') {
+        return (
+          <div id="row">
+            <button>A</button>
+            <button>L</button>
+          </div>
+        )
+      }
+      if (state === 'analyzing') {
+        return (
+          <div id="row">
+            <button>A</button>
+            <div>R</div>
+          </div>
+        )
+      }
+      // changed: Lucky comes back, message div also present
+      return (
+        <div id="row">
+          <button>A</button>
+          <button>L</button>
+          <div>R</div>
+        </div>
+      )
+    }
+
+    const root = createRoot(container)
+    flushSync(() => root.render(<App state="initial" />))
+    expect(textsOf(container.querySelector('#row')!)).toEqual(['A', 'L'])
+
+    flushSync(() => root.render(<App state="analyzing" />))
+    expect(textsOf(container.querySelector('#row')!)).toEqual(['A', 'R'])
+
+    // The tricky transition that was broken: insert Lucky between
+    // existing Analyze and the Review div. Forward iteration produced
+    // [L, A, R] here; correct is [A, L, R].
+    flushSync(() => root.render(<App state="changed" />))
+    expect(textsOf(container.querySelector('#row')!)).toEqual(['A', 'L', 'R'])
+  })
+
+  it('swaps two adjacent unkeyed children', () => {
+    const container = setup()
+    function App({ swap }: { swap: boolean }) {
+      return (
+        <div id="row">
+          <button>{swap ? 'B' : 'A'}</button>
+          <button>{swap ? 'A' : 'B'}</button>
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    flushSync(() => root.render(<App swap={false} />))
+    expect(textsOf(container.querySelector('#row')!)).toEqual(['A', 'B'])
+    flushSync(() => root.render(<App swap={true} />))
+    expect(textsOf(container.querySelector('#row')!)).toEqual(['B', 'A'])
+  })
+
+  it('reorders keyed list items preserving DOM identity', () => {
+    const container = setup()
+    const itemRefs = new Map<string, HTMLLIElement>()
+    function App({ items }: { items: string[] }) {
+      return (
+        <ul id="list">
+          {items.map((item) => (
+            <li
+              key={item}
+              ref={(el: HTMLLIElement | null) => {
+                if (el) itemRefs.set(item, el)
+              }}
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      )
+    }
+    const root = createRoot(container)
+    flushSync(() => root.render(<App items={['a', 'b', 'c']} />))
+    const elA = itemRefs.get('a')!
+    const elB = itemRefs.get('b')!
+    const elC = itemRefs.get('c')!
+
+    // Reverse list — keyed so each li's DOM element must be preserved.
+    flushSync(() => root.render(<App items={['c', 'b', 'a']} />))
+    const list = container.querySelector('#list')!
+    expect(textsOf(list)).toEqual(['c', 'b', 'a'])
+    expect(list.children[0]).toBe(elC)
+    expect(list.children[1]).toBe(elB)
+    expect(list.children[2]).toBe(elA)
+  })
+
+  it('inserts a new keyed leading sibling without re-creating the rest', () => {
+    const container = setup()
+    function App({ lead }: { lead: boolean }) {
+      return (
+        <div id="row">
+          {lead ? <span key="x">X</span> : null}
+          <span key="a">A</span>
+          <span key="b">B</span>
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    flushSync(() => root.render(<App lead={false} />))
+    const rowBefore = container.querySelector('#row')!
+    const aEl = rowBefore.children[0]
+    const bEl = rowBefore.children[1]
+
+    flushSync(() => root.render(<App lead={true} />))
+    const rowAfter = container.querySelector('#row')!
+    expect(textsOf(rowAfter)).toEqual(['X', 'A', 'B'])
+    expect(rowAfter.children[1]).toBe(aEl)
+    expect(rowAfter.children[2]).toBe(bEl)
+  })
+})

--- a/packages/redact/tests/compiler-runtime.test.tsx
+++ b/packages/redact/tests/compiler-runtime.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * react/compiler-runtime contract.
+ *
+ * The React Compiler emits `import { c } from 'react/compiler-runtime'` and
+ * calls `c(size)` at the top of compiled components to get a per-instance
+ * memo cache. Slots start as the well-known sentinel
+ * `Symbol.for('react.memo_cache_sentinel')`. The compiled code overwrites
+ * slots with computed values and uses sentinel identity to detect first-run
+ * and dependency changes. The cache must persist across re-renders of the
+ * same component instance.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { c } from '@ss/redact/compiler-runtime'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+const MEMO_CACHE_SENTINEL = Symbol.for('react.memo_cache_sentinel')
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('react/compiler-runtime', () => {
+  it('returns an array of the requested size filled with the canonical sentinel', () => {
+    const seenCaches: Array<Array<unknown>> = []
+
+    function Probe() {
+      const cache = c(4)
+      seenCaches.push(cache)
+      return <div />
+    }
+
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<Probe />))
+
+    expect(seenCaches.length).toBe(1)
+    expect(seenCaches[0]!.length).toBe(4)
+    expect(seenCaches[0]!.every((slot) => slot === MEMO_CACHE_SENTINEL)).toBe(true)
+  })
+
+  it('returns the same cache array across re-renders of the same component instance', () => {
+    let renderCount = 0
+    const seenCaches: Array<Array<unknown>> = []
+
+    function Probe({ tick }: { tick: number }) {
+      renderCount++
+      const cache = c(2)
+      seenCaches.push(cache)
+      return <div data-tick={tick} />
+    }
+
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<Probe tick={0} />))
+    flushSync(() => root.render(<Probe tick={1} />))
+    flushSync(() => root.render(<Probe tick={2} />))
+
+    expect(renderCount).toBe(3)
+    expect(seenCaches[0]).toBe(seenCaches[1])
+    expect(seenCaches[1]).toBe(seenCaches[2])
+  })
+
+  it('preserves user-written slot values across re-renders (compiler memoization shape)', () => {
+    let computeCount = 0
+
+    function Probe({ a, b }: { a: number; b: number }) {
+      const $ = c(3)
+      // Slot 0/1 are dependency tracking; slot 2 caches the result.
+      let value: number
+      if ($[0] !== a || $[1] !== b) {
+        $[0] = a
+        $[1] = b
+        computeCount++
+        value = a + b
+        $[2] = value
+      } else {
+        value = $[2] as number
+      }
+      return <div data-value={value} />
+    }
+
+    const container = setup()
+    const root = createRoot(container)
+
+    flushSync(() => root.render(<Probe a={1} b={2} />))
+    expect(container.querySelector('div')!.getAttribute('data-value')).toBe('3')
+    expect(computeCount).toBe(1)
+
+    // Same deps → no recompute.
+    flushSync(() => root.render(<Probe a={1} b={2} />))
+    expect(computeCount).toBe(1)
+
+    // Different deps → recompute.
+    flushSync(() => root.render(<Probe a={5} b={7} />))
+    expect(container.querySelector('div')!.getAttribute('data-value')).toBe('12')
+    expect(computeCount).toBe(2)
+  })
+
+  it('gives sibling component instances independent caches', () => {
+    const caches: Array<Array<unknown>> = []
+    function Probe({ id }: { id: string }) {
+      caches.push(c(1))
+      return <span data-id={id} />
+    }
+    function App() {
+      return (
+        <div>
+          <Probe id="a" />
+          <Probe id="b" />
+        </div>
+      )
+    }
+    const container = setup()
+    const root = createRoot(container)
+    flushSync(() => root.render(<App />))
+
+    expect(caches.length).toBe(2)
+    expect(caches[0]).not.toBe(caches[1])
+  })
+})

--- a/packages/redact/tests/controlled-input.test.tsx
+++ b/packages/redact/tests/controlled-input.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Controlled-input behavior — parity with React.
+ *
+ * React's `onChange` on text-like <input>/<textarea> fires on every
+ * keystroke (i.e. is wired to the native `input` event, not `change`).
+ * The native `change` event only fires on blur/enter, which makes
+ * controlled inputs in DocSearch-style search modals appear dead: the
+ * user types, nothing re-renders, no results show up.
+ *
+ * These tests lock that contract down so we don't regress it again.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+function dispatchInput(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  el.value = value
+  el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+}
+
+describe('controlled inputs — onChange semantics', () => {
+  it('onChange on text input fires on each keystroke (native input event)', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <input
+          id="search"
+          value={v}
+          onChange={(e: any) => {
+            changes.push((e.target as HTMLInputElement).value)
+            setV((e.target as HTMLInputElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#search') as HTMLInputElement
+
+    flushSync(() => dispatchInput(input, 'h'))
+    flushSync(() => dispatchInput(input, 'he'))
+    flushSync(() => dispatchInput(input, 'hel'))
+
+    expect(changes).toEqual(['h', 'he', 'hel'])
+    expect(input.value).toBe('hel')
+  })
+
+  it('onChange on textarea fires on each keystroke', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <textarea
+          id="ta"
+          value={v}
+          onChange={(e: any) => {
+            changes.push((e.target as HTMLTextAreaElement).value)
+            setV((e.target as HTMLTextAreaElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const ta = container.querySelector('#ta') as HTMLTextAreaElement
+
+    flushSync(() => dispatchInput(ta, 'a'))
+    flushSync(() => dispatchInput(ta, 'ab'))
+
+    expect(changes).toEqual(['a', 'ab'])
+  })
+
+  it('onInput on text input still fires on input event', () => {
+    const container = setup()
+    const inputs: Array<string> = []
+    function App() {
+      return (
+        <input
+          id="search"
+          defaultValue=""
+          onInput={(e: any) => {
+            inputs.push((e.target as HTMLInputElement).value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#search') as HTMLInputElement
+
+    dispatchInput(input, 'x')
+    dispatchInput(input, 'xy')
+
+    expect(inputs).toEqual(['x', 'xy'])
+  })
+
+  it('onChange AND onInput can coexist on the same text input', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    const inputs: Array<string> = []
+    function App() {
+      return (
+        <input
+          id="both"
+          defaultValue=""
+          onChange={(e: any) => changes.push((e.target as HTMLInputElement).value)}
+          onInput={(e: any) => inputs.push((e.target as HTMLInputElement).value)}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#both') as HTMLInputElement
+
+    dispatchInput(input, 'z')
+
+    expect(changes).toEqual(['z'])
+    expect(inputs).toEqual(['z'])
+  })
+
+  it('onChange on checkbox fires on native change event (click)', () => {
+    const container = setup()
+    let fires = 0
+    function App() {
+      const [checked, setChecked] = React.useState(false)
+      return (
+        <input
+          id="cb"
+          type="checkbox"
+          checked={checked}
+          onChange={(e: any) => {
+            fires++
+            setChecked((e.target as HTMLInputElement).checked)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const cb = container.querySelector('#cb') as HTMLInputElement
+
+    flushSync(() => cb.click())
+    expect(fires).toBe(1)
+    expect(cb.checked).toBe(true)
+  })
+
+  it('onChange on radio fires on native change event (click)', () => {
+    const container = setup()
+    let fires = 0
+    function App() {
+      const [v, setV] = React.useState('a')
+      return (
+        <>
+          <input
+            id="ra"
+            type="radio"
+            name="g"
+            checked={v === 'a'}
+            onChange={() => {
+              fires++
+              setV('a')
+            }}
+          />
+          <input
+            id="rb"
+            type="radio"
+            name="g"
+            checked={v === 'b'}
+            onChange={() => {
+              fires++
+              setV('b')
+            }}
+          />
+        </>
+      )
+    }
+    createRoot(container).render(<App />)
+    const rb = container.querySelector('#rb') as HTMLInputElement
+    flushSync(() => rb.click())
+    expect(fires).toBe(1)
+    expect(rb.checked).toBe(true)
+  })
+
+  it('onChange on select fires on native change event', () => {
+    const container = setup()
+    const changes: Array<string> = []
+    function App() {
+      const [v, setV] = React.useState('a')
+      return (
+        <select
+          id="s"
+          value={v}
+          onChange={(e: any) => {
+            const next = (e.target as HTMLSelectElement).value
+            changes.push(next)
+            setV(next)
+          }}
+        >
+          <option value="a">a</option>
+          <option value="b">b</option>
+          <option value="c">c</option>
+        </select>
+      )
+    }
+    createRoot(container).render(<App />)
+    const sel = container.querySelector('#s') as HTMLSelectElement
+
+    sel.value = 'b'
+    flushSync(() => sel.dispatchEvent(new Event('change', { bubbles: true })))
+
+    expect(changes).toEqual(['b'])
+  })
+
+  it('controlled value is written back after user types (re-render wins)', () => {
+    const container = setup()
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <input
+          id="ctrl"
+          value={v.toUpperCase()}
+          onChange={(e: any) => setV((e.target as HTMLInputElement).value)}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#ctrl') as HTMLInputElement
+
+    flushSync(() => dispatchInput(input, 'foo'))
+    expect(input.value).toBe('FOO')
+  })
+})

--- a/packages/redact/tests/create-root-clear-container.test.tsx
+++ b/packages/redact/tests/create-root-clear-container.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Regression: createRoot must clear pre-existing children of the container on
+ * the initial commit (matching real React's `clearContainer` semantics), but
+ * must NOT re-clear on subsequent renders (which would tear down the React
+ * tree just rendered).
+ *
+ * Without the first-render clear, an app that ships a `<div id="root"><div
+ * id="splash">…</div></div>` placeholder will stack the splash markup behind
+ * the React tree until React happens to overdraw the same coordinates —
+ * commonly observed as a splash logo persisting after mount.
+ *
+ * Without the firstRender gate, every re-render would wipe the reconciled DOM
+ * leaving fibers pointing at detached nodes; subsequent renders would update
+ * detached DOM and the screen would go blank.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('createRoot container clearing', () => {
+  it('clears pre-existing children on the first render', () => {
+    const container = setup()
+    container.innerHTML = '<span>kept?</span>'
+    expect(container.querySelector('span')?.textContent).toBe('kept?')
+
+    const root = createRoot(container)
+    root.render(<div id="app">react</div>)
+
+    expect(container.querySelector('span')).toBeNull()
+    expect(container.innerHTML).toBe('<div id="app">react</div>')
+  })
+
+  it('does not re-clear on subsequent renders (preserves reconciled DOM)', () => {
+    const container = setup()
+    const root = createRoot(container)
+    root.render(<div id="first">first</div>)
+
+    const firstDiv = container.querySelector('#first') as HTMLDivElement
+    expect(firstDiv).toBeInstanceOf(HTMLDivElement)
+    expect(firstDiv.textContent).toBe('first')
+
+    root.render(<div id="first">updated</div>)
+
+    // The same DOM node was reused (reconciler updated text in place); a
+    // second clearContainer would have detached it and rendered nothing.
+    expect(container.querySelector('#first')).toBe(firstDiv)
+    expect(firstDiv.textContent).toBe('updated')
+    expect(container.innerHTML).toBe('<div id="first">updated</div>')
+  })
+})

--- a/packages/redact/tests/document-hydration.test.tsx
+++ b/packages/redact/tests/document-hydration.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { renderToString } from 'react-dom/server'
+
+// Reproduces the pattern Start uses: hydrateRoot(document, <html>...</html>).
+// The document already has <!doctype html><html>...</html> parsed from the
+// server HTML; our shim must adopt the existing <html> element, not append a
+// new one. After hydration, state updates in descendants must re-render
+// without trying to add a second <html> to the document.
+
+describe('hydrateRoot(document, <html/>)', () => {
+  function buildDocumentFrom(html: string): Document {
+    const dom = new (globalThis as any).DOMParser().parseFromString(html, 'text/html')
+    return dom
+  }
+
+  it('adopts existing <html> without recreating', () => {
+    function App() {
+      return (
+        <html>
+          <head>
+            <title>test</title>
+          </head>
+          <body>
+            <h1>hi</h1>
+          </body>
+        </html>
+      )
+    }
+    const html = renderToString(<App />)
+    const doc = buildDocumentFrom('<!doctype html>' + html)
+    const origHtml = doc.documentElement
+    hydrateRoot(doc as any, <App />)
+    expect(doc.documentElement).toBe(origHtml)
+    expect(doc.documentElement.querySelector('h1')?.textContent).toBe('hi')
+  })
+
+  it('a root-level component suspending during hydration does not append a second <html>', async () => {
+    // Mirrors Start's <StartClient/> → <Await promise={...}> pattern: the
+    // root-most component throws a promise synchronously during hydrateRoot.
+    // While pending, the DOM must be left as-is. When the promise resolves,
+    // the real tree (with its own <html>) must ADOPT the existing <html>,
+    // not create a new one.
+    // Mirrors Start's actual tree shape:
+    //   hydrateRoot(document, <StartClient/>) where StartClient returns <Await>
+    //   and Await suspends BEFORE any <html> has been rendered.
+    let resolve!: (app: () => React.ReactElement) => void
+    const p = new Promise<() => React.ReactElement>((r) => (resolve = r))
+    function Await() {
+      const Component = React.use(p)
+      return <Component />
+    }
+    function StartClientLike() {
+      return <Await />
+    }
+    function RealApp() {
+      return (
+        <html>
+          <head>
+            <title>x</title>
+          </head>
+          <body>
+            <h1 id="real">real</h1>
+          </body>
+        </html>
+      )
+    }
+    // Server output: assume Inner already resolved server-side (like Start).
+    const serverHtml = '<!doctype html><html><head><title>x</title></head><body><h1 id="real">real</h1></body></html>'
+    const doc = buildDocumentFrom(serverHtml)
+    const origHtml = doc.documentElement
+
+    // Client: promise NOT yet resolved — StartClientLike → Await will suspend
+    // before ever reaching the <html>.
+    const errors: unknown[] = []
+    hydrateRoot(doc as any, <StartClientLike />, {
+      onRecoverableError: (e) => errors.push(e),
+      onUncaughtError: (e) => errors.push(e),
+    })
+    // DOM shouldn't have been mutated yet (fallback wasn't rendered; root is untouched)
+    expect(doc.documentElement).toBe(origHtml)
+    const htmlCountPending = Array.from(doc.childNodes).filter(
+      (n) => n.nodeType === 1 && (n as Element).tagName.toLowerCase() === 'html',
+    ).length
+    expect(htmlCountPending).toBe(1)
+
+    // Now resolve with the real app component. Flush microtasks.
+    resolve(RealApp)
+    await new Promise((r) => setTimeout(r, 0))
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+
+    // After resolve, existing DOM is adopted — still one <html>
+    const htmlCountDone = Array.from(doc.childNodes).filter(
+      (n) => n.nodeType === 1 && (n as Element).tagName.toLowerCase() === 'html',
+    ).length
+    expect(htmlCountDone).toBe(1)
+    expect(doc.documentElement).toBe(origHtml)
+    expect(errors).toEqual([])
+  })
+
+  it('state update in a descendant does not try to append a second <html>', async () => {
+    function Inner() {
+      const [n, setN] = React.useState(0)
+      return (
+        <button id="b" onClick={() => setN(n + 1)}>
+          {n}
+        </button>
+      )
+    }
+    function App() {
+      return (
+        <html>
+          <head>
+            <title>test</title>
+          </head>
+          <body>
+            <Inner />
+          </body>
+        </html>
+      )
+    }
+    const html = renderToString(<App />)
+    const doc = buildDocumentFrom('<!doctype html>' + html)
+    hydrateRoot(doc as any, <App />)
+
+    const btn = doc.querySelector('#b') as HTMLButtonElement
+    expect(btn.textContent).toBe('0')
+    // The click triggers a tree re-render; if our reconciler mis-handles
+    // the root/document relationship, it throws "Only one element on document".
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('1')
+    // And there's still exactly one documentElement
+    expect(doc.childNodes.length).toBeGreaterThan(0)
+    const htmlEls = Array.from(doc.childNodes).filter(
+      (n) => n.nodeType === 1 && (n as Element).tagName.toLowerCase() === 'html',
+    )
+    expect(htmlEls.length).toBe(1)
+  })
+})

--- a/packages/redact/tests/external-store-unmount.test.tsx
+++ b/packages/redact/tests/external-store-unmount.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Regression: useSyncExternalStore must unsubscribe on unmount.
+ *
+ * Previously the dispatcher stashed the unsubscribe in `hook.cleanup` but
+ * never registered it in `fiber.cleanups`, so `unmountFiber` never ran it.
+ * The store kept a live reference to `forceUpdate`; any subsequent
+ * notification called `scheduleUpdate(fiber)` on the now-unmounted fiber,
+ * which walked the stale `.parent` pointer and mounted a fresh copy of the
+ * subtree's DOM into the old host parent. Visible in tanstack.com as
+ * extra Log-In buttons accumulating in the navbar after navigation.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+type Store<T> = {
+  get: () => T
+  set: (next: T) => void
+  subscribe: (cb: () => void) => () => void
+  subscriberCount: () => number
+}
+
+function makeStore<T>(initial: T): Store<T> {
+  let value = initial
+  const listeners = new Set<() => void>()
+  return {
+    get: () => value,
+    set: (next: T) => {
+      value = next
+      listeners.forEach((l) => l())
+    },
+    subscribe: (cb) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    subscriberCount: () => listeners.size,
+  }
+}
+
+describe('useSyncExternalStore cleanup on unmount', () => {
+  it('runs unsubscribe when parent stops rendering child', async () => {
+    const container = setup()
+    const store = makeStore(0)
+    function Child() {
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      return <span>{v}</span>
+    }
+    function App({ show }: { show: boolean }) {
+      return <div>{show ? <Child /> : null}</div>
+    }
+    const root = createRoot(container)
+    root.render(<App show={true} />)
+    await Promise.resolve()
+    expect(store.subscriberCount()).toBe(1)
+    root.render(<App show={false} />)
+    await Promise.resolve()
+    expect(store.subscriberCount()).toBe(0)
+  })
+
+  it('runs unsubscribe on root.unmount', async () => {
+    const container = setup()
+    const store = makeStore('a')
+    function Leaf() {
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      return <span>{v}</span>
+    }
+    const root = createRoot(container)
+    root.render(<Leaf />)
+    await Promise.resolve()
+    expect(store.subscriberCount()).toBe(1)
+    root.unmount()
+    expect(store.subscriberCount()).toBe(0)
+  })
+
+  it('store notifications after unmount do not resurrect DOM', async () => {
+    // This is the exact shape of the tanstack.com leak: a subscribed child
+    // is unmounted, then the store fires. With the bug, `scheduleUpdate`
+    // was invoked on the zombie fiber; `rerenderFiber` walked its stale
+    // `.parent` and re-appended the child's DOM into the old host.
+    const container = setup()
+    const store = makeStore(0)
+    function Badge() {
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      return <a aria-label="badge">{v}</a>
+    }
+    function App({ show }: { show: boolean }) {
+      return (
+        <div id="host">
+          <span>keep</span>
+          {show ? <Badge /> : null}
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<App show={true} />)
+    await Promise.resolve()
+
+    const host = container.querySelector('#host')!
+    expect(host.querySelectorAll('a[aria-label="badge"]').length).toBe(1)
+
+    root.render(<App show={false} />)
+    await Promise.resolve()
+    expect(host.querySelectorAll('a[aria-label="badge"]').length).toBe(0)
+
+    // Fire the store after unmount. With the bug, this schedules the dead
+    // Badge fiber, which re-renders and inserts a new <a> into #host via
+    // the stale .parent pointer. With the fix, forceUpdate was unsubscribed
+    // when the fiber was unmounted, so nothing fires; the defensive
+    // scheduleUpdate guard catches any remaining stray callers.
+    store.set(1)
+    await Promise.resolve()
+    expect(host.querySelectorAll('a[aria-label="badge"]').length).toBe(0)
+    expect(host.querySelector('span')!.textContent).toBe('keep')
+  })
+
+  it('still fires forceUpdate while mounted', async () => {
+    const container = setup()
+    const store = makeStore(10)
+    function View() {
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      return <span>v={v}</span>
+    }
+    const root = createRoot(container)
+    root.render(<View />)
+    await Promise.resolve()
+    expect(container.querySelector('span')!.textContent).toBe('v=10')
+
+    store.set(20)
+    await Promise.resolve()
+    expect(container.querySelector('span')!.textContent).toBe('v=20')
+  })
+})

--- a/packages/redact/tests/feature-stubs.test.tsx
+++ b/packages/redact/tests/feature-stubs.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Stub smoke test: each feature's stub module must load, self-register, and
+ * not crash. This catches broken imports, stale API references, and missing
+ * exports on the stub side. Full behavior tests live in feature-specific
+ * test files.
+ */
+import { describe, it, expect } from 'vitest'
+
+describe('feature stubs — load & register', () => {
+  it('portal/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/portal/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('context/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/context/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('suspense/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/suspense/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('memo/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/memo/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('forward-ref/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/forward-ref/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('lazy/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/lazy/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('class/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/class/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+  it('hydration/stub loads', async () => {
+    await expect(
+      import('../src/dom/features/hydration/stub.ts'),
+    ).resolves.toBeTruthy()
+  })
+})

--- a/packages/redact/tests/floating-ui-pattern.test.tsx
+++ b/packages/redact/tests/floating-ui-pattern.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Regression: `getHostParent` returned `undefined` for descendants of a
+ * Portal, because Portal fibers don't store their container on `.dom` or
+ * `.stateNode` — the container lives in `fiber.pendingProps.container`.
+ *
+ * This broke `rerenderFiber` on any Portal descendant: once a Floating-UI /
+ * Radix DropdownMenu's `computePosition(...).then(...)` called
+ * `ReactDOM.flushSync(() => setData(...))`, the subsequent `rerenderFiber`
+ * on the popper wrapper resolved `domParent = undefined` via `getHostParent`,
+ * and the next `renderHost` crashed silently on
+ * `(domParent as Element).namespaceURI` — so the popper wrapper's
+ * `style.transform` never updated from its `translate(0, -200%)` "hidden
+ * while measuring" default. User-visible as dropdowns/tooltips being stuck
+ * off-screen after opening.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { createPortal, flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+function useLatestRef<T>(value: T): { current: T } {
+  const ref = React.useRef<T>(value)
+  React.useLayoutEffect(() => {
+    ref.current = value
+  })
+  return ref
+}
+
+describe('Floating-UI-style useFloating pattern', () => {
+  it('matches exact useFloating hook sequence and ref-callback flow', async () => {
+    const container = setup()
+    let thenFires = 0
+    let guardPasses = 0
+    let isMountedAtThen: boolean[] = []
+
+    function useFloating() {
+      const [data, setData] = React.useState({ x: 0, y: 0, isPositioned: false })
+      const [middleware, setMiddleware] = React.useState<any[]>([])
+      void setMiddleware
+      const [_reference, _setReference] = React.useState<HTMLElement | null>(null)
+      const [_floating, _setFloating] = React.useState<HTMLElement | null>(null)
+      const setReference = React.useCallback(
+        (node: HTMLElement | null) => {
+          if (node !== referenceRef.current) {
+            referenceRef.current = node
+            _setReference(node)
+          }
+        },
+        [],
+      )
+      const setFloating = React.useCallback(
+        (node: HTMLElement | null) => {
+          if (node !== floatingRef.current) {
+            floatingRef.current = node
+            _setFloating(node)
+          }
+        },
+        [],
+      )
+      const referenceEl = _reference
+      const floatingEl = _floating
+      const referenceRef = React.useRef<HTMLElement | null>(null)
+      const floatingRef = React.useRef<HTMLElement | null>(null)
+      const dataRef = React.useRef(data)
+      const whileElementsMountedRef = useLatestRef<any>(undefined)
+      void whileElementsMountedRef
+      const platformRef = useLatestRef<any>(undefined)
+      void platformRef
+      const openRef = useLatestRef<any>(undefined)
+      void openRef
+      const update = React.useCallback(() => {
+        if (!referenceRef.current || !floatingRef.current) return
+        Promise.resolve({ x: 999, y: 777 }).then((computed) => {
+          thenFires++
+          const fullData = { ...computed, isPositioned: openRef.current !== false }
+          isMountedAtThen.push(isMountedRef.current)
+          if (isMountedRef.current && dataRef.current.x !== fullData.x) {
+            guardPasses++
+            dataRef.current = fullData
+            flushSync(() => setData(fullData))
+          }
+        })
+      }, [])
+      React.useLayoutEffect(() => {
+        // openRef effect equivalent
+      }, [])
+      const isMountedRef = React.useRef(false)
+      React.useLayoutEffect(() => {
+        isMountedRef.current = true
+        return () => {
+          isMountedRef.current = false
+        }
+      }, [])
+      React.useLayoutEffect(() => {
+        if (referenceEl) referenceRef.current = referenceEl
+        if (floatingEl) floatingRef.current = floatingEl
+        if (referenceEl && floatingEl) update()
+      }, [referenceEl, floatingEl, update])
+      return { data, setReference, setFloating }
+    }
+
+    function App() {
+      const { data, setReference, setFloating } = useFloating()
+      return (
+        <div>
+          <button ref={setReference}>trigger</button>
+          <span ref={setFloating}>
+            x={data.x} y={data.y} pos={data.isPositioned ? 'yes' : 'no'}
+          </span>
+        </div>
+      )
+    }
+
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(thenFires).toBeGreaterThan(0)
+    expect(isMountedAtThen.every((b) => b === true)).toBe(true)
+    expect(guardPasses).toBeGreaterThan(0)
+    expect(container.querySelector('span')!.textContent).toContain('x=999')
+  })
+
+  it('re-renders a Portal descendant when its own state updates (getHostParent on Portal)', async () => {
+    // Tight repro: a component inside a portal that updates its own state
+    // from a Promise.then (no refs, no guards) — relies solely on
+    // rerenderFiber → getHostParent resolving a Portal container.
+    const container = setup()
+    const portalHost = document.createElement('div')
+    document.body.appendChild(portalHost)
+
+    function Badge() {
+      const [n, setN] = React.useState(0)
+      React.useEffect(() => {
+        Promise.resolve(42).then((v) => {
+          flushSync(() => setN(v))
+        })
+      }, [])
+      return <span data-testid="badge">n={n}</span>
+    }
+
+    function App() {
+      return <div>{createPortal(<Badge />, portalHost)}</div>
+    }
+
+    createRoot(container).render(<App />)
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+
+    expect(portalHost.querySelector('[data-testid="badge"]')!.textContent).toBe(
+      'n=42',
+    )
+    document.body.removeChild(portalHost)
+  })
+
+  it('exercises the pattern through a Portal (Radix.DropdownMenu.Portal shape)', async () => {
+    // Same pattern but content rendered via portal
+    const container = setup()
+    const portalHost = document.createElement('div')
+    portalHost.id = 'portal-host'
+    document.body.appendChild(portalHost)
+    let thenFires = 0
+    let isMountedAtThen: boolean[] = []
+
+    function PopperContent() {
+      const [data, setData] = React.useState({ x: 0, y: 0 })
+      const [floating, setFloating] = React.useState<HTMLElement | null>(null)
+      const floatingRef = React.useRef<HTMLElement | null>(null)
+      const dataRef = React.useRef(data)
+      const isMountedRef = React.useRef(false)
+      React.useLayoutEffect(() => {
+        isMountedRef.current = true
+        return () => {
+          isMountedRef.current = false
+        }
+      }, [])
+      React.useLayoutEffect(() => {
+        if (!floating) return
+        Promise.resolve({ x: 500, y: 600 }).then((v) => {
+          thenFires++
+          isMountedAtThen.push(isMountedRef.current)
+          if (isMountedRef.current && dataRef.current.x !== v.x) {
+            dataRef.current = v
+            flushSync(() => setData(v))
+          }
+        })
+      }, [floating])
+      const setFloatingCB = React.useCallback((node: HTMLElement | null) => {
+        if (node !== floatingRef.current) {
+          floatingRef.current = node
+          setFloating(node)
+        }
+      }, [])
+      return (
+        <div ref={setFloatingCB} data-testid="popper">
+          x={data.x},y={data.y}
+        </div>
+      )
+    }
+
+    function App() {
+      return (
+        <div>
+          <span>trigger</span>
+          {createPortal(<PopperContent />, portalHost)}
+        </div>
+      )
+    }
+
+    createRoot(container).render(<App />)
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+
+    expect(thenFires).toBeGreaterThan(0)
+    expect(isMountedAtThen.every((b) => b === true)).toBe(true)
+    expect(portalHost.querySelector('[data-testid="popper"]')!.textContent).toBe(
+      'x=500,y=600',
+    )
+
+    document.body.removeChild(portalHost)
+  })
+})

--- a/packages/redact/tests/global.d.ts
+++ b/packages/redact/tests/global.d.ts
@@ -1,0 +1,18 @@
+// Permissive JSX shim for type-checking the test suite. Vitest runs tests
+// with the @ss/redact JSX runtime, which doesn't ship a strict element
+// type surface (and isn't trying to). Tests use a lot of `<div>`-style
+// markup as fixtures, so a permissive global JSX namespace keeps them
+// type-checkable without requiring a full React.dom.d.ts re-implementation.
+declare namespace JSX {
+  type Element = any
+  type ElementType = any
+  interface IntrinsicElements {
+    [elemName: string]: any
+  }
+  interface ElementChildrenAttribute {
+    children: {}
+  }
+  interface ElementAttributesProperty {
+    props: {}
+  }
+}

--- a/packages/redact/tests/hooks.test.tsx
+++ b/packages/redact/tests/hooks.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('hooks', () => {
+  it('useEffect runs after mount', async () => {
+    const container = setup()
+    let calls = 0
+    function App() {
+      React.useEffect(() => {
+        calls++
+      }, [])
+      return <span>hi</span>
+    }
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+    expect(calls).toBe(1)
+  })
+
+  it('useEffect cleanup runs on unmount', async () => {
+    const container = setup()
+    let cleanups = 0
+    function App() {
+      React.useEffect(() => () => {
+        cleanups++
+      }, [])
+      return <span>hi</span>
+    }
+    const root = createRoot(container)
+    root.render(<App />)
+    await Promise.resolve()
+    root.unmount()
+    expect(cleanups).toBe(1)
+  })
+
+  it('useLayoutEffect runs before paint (synchronously)', () => {
+    const container = setup()
+    let ran = false
+    function App() {
+      React.useLayoutEffect(() => {
+        ran = true
+      }, [])
+      return <span>hi</span>
+    }
+    createRoot(container).render(<App />)
+    expect(ran).toBe(true) // no await needed
+  })
+
+  it('useRef persists across renders', () => {
+    const container = setup()
+    let refVal: { current: number } | null = null
+    function App({ n }: { n: number }) {
+      const ref = React.useRef(0)
+      if (!refVal) refVal = ref
+      else expect(ref).toBe(refVal) // same ref each render
+      ref.current = n
+      return <span>{n}</span>
+    }
+    const root = createRoot(container)
+    root.render(<App n={1} />)
+    root.render(<App n={2} />)
+    expect(refVal!.current).toBe(2)
+  })
+
+  it('useMemo respects deps', () => {
+    const container = setup()
+    let computes = 0
+    function App({ n }: { n: number }) {
+      const v = React.useMemo(() => {
+        computes++
+        return n * 2
+      }, [n])
+      return <span>{v}</span>
+    }
+    const root = createRoot(container)
+    root.render(<App n={1} />)
+    expect(computes).toBe(1)
+    root.render(<App n={1} />)
+    expect(computes).toBe(1)
+    root.render(<App n={2} />)
+    expect(computes).toBe(2)
+  })
+
+  it('useReducer', () => {
+    const container = setup()
+    function reducer(s: number, a: 'inc' | 'dec') {
+      return a === 'inc' ? s + 1 : s - 1
+    }
+    function App() {
+      const [n, dispatch] = React.useReducer(reducer, 0)
+      return (
+        <button id="r" onClick={() => dispatch('inc')}>
+          {n}
+        </button>
+      )
+    }
+    createRoot(container).render(<App />)
+    const btn = container.querySelector('#r') as HTMLButtonElement
+    flushSync(() => btn.click())
+    flushSync(() => btn.click())
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('3')
+  })
+
+  it('forwardRef', () => {
+    const container = setup()
+    let capturedNode: Element | null = null
+    const Comp = React.forwardRef<HTMLDivElement>((props: any, ref) => (
+      <div ref={ref}>{props.children}</div>
+    ))
+    function App() {
+      const r = React.useRef<HTMLDivElement>(null)
+      React.useLayoutEffect(() => {
+        capturedNode = r.current
+      }, [])
+      return <Comp ref={r}>x</Comp>
+    }
+    createRoot(container).render(<App />)
+    expect(capturedNode).toBeInstanceOf(HTMLDivElement)
+  })
+
+  it('memo prevents re-render', () => {
+    const container = setup()
+    let renders = 0
+    const Child = React.memo(function Child({ x }: { x: number }) {
+      renders++
+      return <span>{x}</span>
+    })
+    function App({ n, x }: { n: number; x: number }) {
+      return (
+        <div>
+          {n}-<Child x={x} />
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<App n={1} x={10} />)
+    expect(renders).toBe(1)
+    root.render(<App n={2} x={10} />)
+    expect(renders).toBe(1)
+    root.render(<App n={3} x={20} />)
+    expect(renders).toBe(2)
+  })
+})
+
+describe('lists and keys', () => {
+  it('renders arrays', () => {
+    const container = setup()
+    function App({ items }: { items: string[] }) {
+      return (
+        <ul>
+          {items.map((x) => (
+            <li key={x}>{x}</li>
+          ))}
+        </ul>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<App items={['a', 'b', 'c']} />)
+    expect(container.innerHTML).toBe('<ul><li>a</li><li>b</li><li>c</li></ul>')
+    root.render(<App items={['a', 'c']} />)
+    expect(container.innerHTML).toBe('<ul><li>a</li><li>c</li></ul>')
+    root.render(<App items={['d', 'a', 'c']} />)
+    expect(container.innerHTML).toBe('<ul><li>d</li><li>a</li><li>c</li></ul>')
+  })
+})

--- a/packages/redact/tests/hydration.test.tsx
+++ b/packages/redact/tests/hydration.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { renderToString } from 'react-dom/server'
+
+function setupWithHTML(html: string) {
+  const c = document.createElement('div')
+  c.innerHTML = html
+  document.body.appendChild(c)
+  return c
+}
+
+describe('hydrateRoot', () => {
+  it('adopts existing DOM without recreating', () => {
+    function App() {
+      return (
+        <div id="x">
+          <span>hi</span>
+        </div>
+      )
+    }
+    const html = renderToString(<App />)
+    expect(html).toBe('<div id="x"><span>hi</span></div>')
+    const container = setupWithHTML(html)
+    const originalDiv = container.querySelector('div')
+    const originalSpan = container.querySelector('span')
+
+    hydrateRoot(container, <App />)
+
+    // Same DOM nodes — not re-created
+    expect(container.querySelector('div')).toBe(originalDiv)
+    expect(container.querySelector('span')).toBe(originalSpan)
+  })
+
+  it('attaches event handlers to adopted DOM', () => {
+    function App() {
+      const [n, setN] = React.useState(0)
+      return (
+        <button id="b" onClick={() => setN(n + 1)}>
+          {n}
+        </button>
+      )
+    }
+    const html = renderToString(<App />)
+    const container = setupWithHTML(html)
+    const btn = container.querySelector('#b') as HTMLButtonElement
+    expect(btn.textContent).toBe('0')
+
+    hydrateRoot(container, <App />)
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('1')
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('2')
+  })
+
+  it('useEffect fires after hydration', async () => {
+    let fired = 0
+    function App() {
+      React.useEffect(() => {
+        fired++
+      }, [])
+      return <span>x</span>
+    }
+    const html = renderToString(<App />)
+    const container = setupWithHTML(html)
+    hydrateRoot(container, <App />)
+    await Promise.resolve()
+    expect(fired).toBe(1)
+  })
+
+  it('recovers from mismatch by reporting and rendering fresh', () => {
+    function App() {
+      return <div>client</div>
+    }
+    // Server rendered a <span>, client expects a <div>
+    const container = setupWithHTML('<span>server</span>')
+    let recovered: unknown = null
+    hydrateRoot(container, <App />, {
+      onRecoverableError: (e) => {
+        recovered = e
+      },
+    })
+    expect(recovered).toBeInstanceOf(Error)
+    // Should eventually contain the client-rendered div
+    expect(container.querySelector('div')?.textContent).toBe('client')
+  })
+
+  // Regression: on tanstack.com /stats/npm the chart never renders. SSR
+  // rendered a Spinner (isFetching=true server-side); on client after the
+  // query settles a Suspense boundary mounts containing a `React.lazy`
+  // component. The lazy resolves fine, but a nested component that calls
+  // setState in useEffect (e.g. ParentSize measuring the container) doesn't
+  // re-render — the chart stays hidden behind `size.width === 0`. This
+  // reproduces the whole flow: hydrate mismatch → client-only Suspense →
+  // lazy resolves → inner useEffect setState must re-render.
+  it('client-only lazy inside suspense mounted post-hydration re-renders on effect setState', async () => {
+    // SSR output was different content; hydrate mismatches and falls through.
+    const container = setupWithHTML('<div><span>server</span></div>')
+
+    let resolveMod: (v: { default: () => any }) => void
+    const Lazy = React.lazy(
+      () =>
+        new Promise<{ default: () => any }>((r) => {
+          resolveMod = r
+        }),
+    )
+
+    function Measured() {
+      const [w, setW] = React.useState(0)
+      React.useEffect(() => {
+        setW(42)
+      }, [])
+      return <span>w={w}</span>
+    }
+
+    let setShow: (b: boolean) => void = () => {}
+    function App() {
+      const [show, _setShow] = React.useState(false)
+      setShow = _setShow
+      return (
+        <div>
+          {show ? (
+            <React.Suspense fallback={<i>load</i>}>
+              <Lazy />
+            </React.Suspense>
+          ) : (
+            <span>server</span>
+          )}
+        </div>
+      )
+    }
+
+    hydrateRoot(container, <App />)
+    // Post-hydrate state change: Suspense+Lazy appears.
+    flushSync(() => setShow(true))
+    expect(container.querySelector('i')?.textContent).toBe('load')
+    resolveMod!({ default: Measured })
+    // Let the thenable settle, the Suspense re-render fire, and the nested
+    // useEffect's setState re-render follow.
+    for (let i = 0; i < 30; i++) await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelector('span')?.textContent).toBe('w=42')
+    expect(container.querySelector('i')).toBeNull()
+  })
+
+  // Closer to tanstack.com: the conditional branch uses a nested wrapper
+  // element (like the Resizable container) and the state update is async
+  // (microtask, not flushSync). The lazy's module resolves asynchronously
+  // and the inner component's useEffect fires a setState shortly after.
+  it('async-toggled suspense+lazy with intermediate wrapper swaps fallback for real content', async () => {
+    const container = setupWithHTML(
+      '<div class="wrap"><div class="spinner">spin</div></div>',
+    )
+
+    let resolveMod: (v: { default: () => any }) => void
+    const Lazy = React.lazy(
+      () =>
+        new Promise<{ default: () => any }>((r) => {
+          resolveMod = r
+        }),
+    )
+
+    function Measured() {
+      const [w, setW] = React.useState(0)
+      React.useEffect(() => {
+        setW(42)
+      }, [])
+      return <span data-testid="real">w={w}</span>
+    }
+
+    let setReady: (b: boolean) => void = () => {}
+    function App() {
+      const [ready, _setReady] = React.useState(false)
+      setReady = _setReady
+      return (
+        <div className="wrap">
+          {!ready ? (
+            <div className="spinner">spin</div>
+          ) : (
+            <div className="resizable">
+              <React.Suspense fallback={<i data-testid="fb">load</i>}>
+                <Lazy />
+              </React.Suspense>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    hydrateRoot(container, <App />)
+    // Async state flip (no flushSync).
+    setReady(true)
+    // Wait a few microtasks for the flush.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelector('[data-testid="fb"]')?.textContent).toBe(
+      'load',
+    )
+    resolveMod!({ default: Measured })
+    for (let i = 0; i < 30; i++) await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelector('[data-testid="real"]')?.textContent).toBe(
+      'w=42',
+    )
+    expect(container.querySelector('[data-testid="fb"]')).toBeNull()
+  })
+})

--- a/packages/redact/tests/memo-state-rerender.test.tsx
+++ b/packages/redact/tests/memo-state-rerender.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Regressions around memo + state-triggered rerenders and zombie rerenders.
+ *
+ * 1. `React.memo`-wrapped components must re-render when their own hook state
+ *    changes, even if their props are unchanged. Previously `renderMemo` ran
+ *    the prop-equality gate on all rerenders — so a `useSyncExternalStore`
+ *    notification on a memo component (e.g., TanStack Router's `Outlet`,
+ *    `Match`, `MatchInner`) bailed, and route content never updated after
+ *    navigation even though the URL had changed.
+ *
+ * 2. `rerenderFiber` must skip fibers that were unmounted between scheduling
+ *    and flush. When a shallow-first flush unmounts a deeper pending fiber,
+ *    the deeper fiber's slot in `root.pending` still points at it; running
+ *    its render after unmount mounts fresh DOM into the old (still-attached)
+ *    parent. Visible as previous-route content lingering after nav because
+ *    the old LibraryLandingPage rerendered into its stale parent.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+type Store<T> = {
+  get: () => T
+  set: (next: T) => void
+  subscribe: (cb: () => void) => () => void
+}
+
+function makeStore<T>(initial: T): Store<T> {
+  let value = initial
+  const listeners = new Set<() => void>()
+  return {
+    get: () => value,
+    set: (next) => {
+      value = next
+      listeners.forEach((l) => l())
+    },
+    subscribe: (cb) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+  }
+}
+
+describe('React.memo + state-triggered rerender', () => {
+  it('re-renders a memo component when its useSyncExternalStore fires, even with unchanged props', async () => {
+    const container = setup()
+    const store = makeStore(0)
+    let impl = 0
+    const Inner = React.memo(function Inner() {
+      impl++
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      return <span>v={v}</span>
+    })
+    function App() {
+      return <Inner />
+    }
+    const root = createRoot(container)
+    root.render(<App />)
+    await Promise.resolve()
+    expect(container.querySelector('span')!.textContent).toBe('v=0')
+    const initialCalls = impl
+
+    store.set(42)
+    await Promise.resolve()
+    expect(container.querySelector('span')!.textContent).toBe('v=42')
+    expect(impl).toBeGreaterThan(initialCalls)
+  })
+
+  it('still bails when a parent re-renders with shallow-equal props (no state change)', async () => {
+    const container = setup()
+    let childImpl = 0
+    const Child = React.memo(function Child({ n }: { n: number }) {
+      childImpl++
+      return <span>n={n}</span>
+    })
+    function Parent({ version }: { version: number }) {
+      // Parent re-renders on `version` change but always passes n={1} to child.
+      return (
+        <div>
+          <i>v={version}</i>
+          <Child n={1} />
+        </div>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<Parent version={1} />)
+    await Promise.resolve()
+    expect(childImpl).toBe(1)
+    root.render(<Parent version={2} />)
+    await Promise.resolve()
+    // Child props unchanged — memo bails (this is the normal path; the
+    // state-triggered bypass must not affect parent-triggered renders).
+    expect(childImpl).toBe(1)
+  })
+
+  it('nested memo: child state rerender does not bypass grandchild memo', async () => {
+    const container = setup()
+    const store = makeStore('a')
+    let grandImpl = 0
+    const Grand = React.memo(function Grand({ label }: { label: string }) {
+      grandImpl++
+      return <span>{label}</span>
+    })
+    const Child = React.memo(function Child() {
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      // Pass a stable label to Grand so it can bail.
+      void v
+      return <Grand label="stable" />
+    })
+    function App() {
+      return <Child />
+    }
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+    expect(grandImpl).toBe(1)
+
+    store.set('b')
+    await Promise.resolve()
+    // Child re-runs (state change), but Grand's label didn't change — memo bails.
+    expect(grandImpl).toBe(1)
+  })
+})
+
+describe('rerenderFiber skips unmounted fibers', () => {
+  it('does not mount DOM when a pending fiber was unmounted between scheduling and flush', async () => {
+    // Simulate the route-nav shape: a parent that re-renders and replaces its
+    // child subtree. The OLD child's store fires between its unmount and the
+    // pending flush — previously the flush ran the zombie fiber, mounting a
+    // duplicate DOM node into the (still-attached) old parent.
+    const container = setup()
+    const store = makeStore(0)
+    let leafMounts = 0
+    let leafUnmounts = 0
+
+    function Leaf() {
+      // Each store tick triggers a rerender of this fiber (from useSyncExternalStore).
+      const v = React.useSyncExternalStore(store.subscribe, store.get)
+      React.useEffect(() => {
+        leafMounts++
+        return () => {
+          leafUnmounts++
+        }
+      }, [])
+      return <a data-testid="leaf">{v}</a>
+    }
+
+    function App({ show }: { show: boolean }) {
+      return <div data-testid="host">{show ? <Leaf /> : <b>other</b>}</div>
+    }
+
+    const root = createRoot(container)
+    root.render(<App show={true} />)
+    await Promise.resolve()
+    expect(container.querySelectorAll('a[data-testid="leaf"]').length).toBe(1)
+    expect(leafMounts).toBe(1)
+
+    // Swap Leaf out, then fire the store. Without the rerenderFiber zombie
+    // guard, the pending Leaf would rerender and re-append an <a> into #host.
+    root.render(<App show={false} />)
+    await Promise.resolve()
+    expect(leafUnmounts).toBe(1)
+    expect(container.querySelectorAll('a[data-testid="leaf"]').length).toBe(0)
+
+    // Simulate the race: queue an update on the leaf fiber via store, then
+    // verify no zombie DOM appears. (Fiber is already unmounted so the
+    // scheduleUpdate guard drops it; this test mostly guards that the
+    // behavior holds end-to-end without requiring the inner flag to be set.)
+    store.set(1)
+    await Promise.resolve()
+    expect(container.querySelectorAll('a[data-testid="leaf"]').length).toBe(0)
+    // The <b>other</b> host must still be the single child.
+    const host = container.querySelector('[data-testid="host"]')!
+    expect(host.childElementCount).toBe(1)
+    expect(host.firstElementChild!.tagName).toBe('B')
+  })
+})

--- a/packages/redact/tests/place-children-anchor.test.tsx
+++ b/packages/redact/tests/place-children-anchor.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import * as ReactDOM from 'react-dom'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(() => r()))
+const tick = async () => {
+  for (let i = 0; i < 5; i++) await flushMicrotasks()
+}
+
+// Reproduces the t3code @ss/redact layout bug.
+// When a top-level state change cascades down through a Provider that
+// re-reconciles its children, each child gets the parent's `null` anchor
+// (not its own getAnchor result). If one of those children's render output
+// type changes (e.g. Sidebar swaps its rendered element from a Portal-
+// rendering Sheet to an in-flow <div data-slot=sidebar>), the new host gets
+// appended at the END of domParent. placeChildrenInOrder for the child
+// fiber then sees doms[0].parentNode === domParent and bails on the
+// in-order check — but the dom is at the wrong ABSOLUTE position
+// relative to its later siblings. Net effect in t3code: chat content
+// renders centered on the page instead of the content area, because the
+// sidebar div ends up after the chat-inset main.
+describe('placeChildrenInOrder: anchor-vs-absolute-position regression', () => {
+  it('Sidebar Portal→div via Provider cascade: new div lands BEFORE chat', async () => {
+    const container = setup()
+    let setIsMobile!: (m: boolean) => void
+
+    const portalContainer = document.createElement('div')
+    document.body.appendChild(portalContainer)
+
+    const Ctx = React.createContext<{ isMobile: boolean }>({ isMobile: false })
+
+    function Sheet({ children }: { children: React.ReactNode }) {
+      return ReactDOM.createPortal(<div>{children}</div>, portalContainer)
+    }
+
+    function Sidebar() {
+      const { isMobile } = React.useContext(Ctx)
+      if (isMobile)
+        return (
+          <Sheet>
+            <span>M</span>
+          </Sheet>
+        )
+      return <div data-slot="sidebar">D</div>
+    }
+
+    function ChatView() {
+      return <main data-slot="sidebar-inset">CHAT</main>
+    }
+
+    // Provider is the one whose state flips, mirroring t3code's
+    // SidebarProvider that calls useIsMobile() at the top level.
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [isMobile, _setIsMobile] = React.useState(true)
+      setIsMobile = _setIsMobile
+      const value = React.useMemo(() => ({ isMobile }), [isMobile])
+      return (
+        <Ctx.Provider value={value}>
+          <div data-slot="sidebar-wrapper">{children}</div>
+        </Ctx.Provider>
+      )
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <Sidebar />
+          <ChatView />
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    let wrapper = container.querySelector('[data-slot="sidebar-wrapper"]')!
+    let kids = Array.from(wrapper.children).map((c) => c.getAttribute('data-slot'))
+    // Sheet portal'd elsewhere; only chat is in the wrapper
+    expect(kids).toEqual(['sidebar-inset'])
+
+    // Flip the Provider's state — cascades through children reconcile
+    flushSync(() => setIsMobile(false))
+    await tick()
+
+    wrapper = container.querySelector('[data-slot="sidebar-wrapper"]')!
+    kids = Array.from(wrapper.children).map((c) => c.getAttribute('data-slot'))
+    // The bug (before fix): kids = ['sidebar-inset', 'sidebar']
+    // After fix: kids = ['sidebar', 'sidebar-inset']
+    expect(kids).toEqual(['sidebar', 'sidebar-inset'])
+  })
+
+  // Same bug, exercised through three siblings to confirm placement is
+  // correct relative to ALL later siblings, not just the immediate next.
+  it('first child swaps Portal→div with multiple later siblings', async () => {
+    const container = setup()
+    let setMode!: (m: 'portal' | 'inline') => void
+
+    const portalContainer = document.createElement('div')
+    document.body.appendChild(portalContainer)
+
+    const Ctx = React.createContext<'portal' | 'inline'>('portal')
+
+    function PortalChild() {
+      return ReactDOM.createPortal(<div>P</div>, portalContainer)
+    }
+
+    function FirstChild() {
+      const mode = React.useContext(Ctx)
+      if (mode === 'portal') return <PortalChild />
+      return <div data-slot="first">FIRST</div>
+    }
+
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [mode, _setMode] = React.useState<'portal' | 'inline'>('portal')
+      setMode = _setMode
+      return <Ctx.Provider value={mode}>{children}</Ctx.Provider>
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <div data-slot="parent">
+            <FirstChild />
+            <main data-slot="second">SECOND</main>
+            <aside data-slot="third">THIRD</aside>
+          </div>
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    let parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'second',
+      'third',
+    ])
+
+    flushSync(() => setMode('inline'))
+    await tick()
+
+    parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'first',
+      'second',
+      'third',
+    ])
+  })
+
+  // Returning null and then a host element triggers the same code path:
+  // FirstChild has no DOM initially, then gets a DOM that should land at
+  // index 0.
+  it('first child goes null→div via Provider cascade: new div at index 0', async () => {
+    const container = setup()
+    let show!: (b: boolean) => void
+
+    const Ctx = React.createContext(false)
+
+    function FirstChild() {
+      const visible = React.useContext(Ctx)
+      if (!visible) return null
+      return <div data-slot="first">FIRST</div>
+    }
+
+    function Provider({ children }: { children: React.ReactNode }) {
+      const [v, _show] = React.useState(false)
+      show = _show
+      return <Ctx.Provider value={v}>{children}</Ctx.Provider>
+    }
+
+    const root = createRoot(container)
+    flushSync(() =>
+      root.render(
+        <Provider>
+          <div data-slot="parent">
+            <FirstChild />
+            <main data-slot="second">SECOND</main>
+          </div>
+        </Provider>,
+      ),
+    )
+    await tick()
+
+    flushSync(() => show(true))
+    await tick()
+
+    const parent = container.querySelector('[data-slot="parent"]')!
+    expect(Array.from(parent.children).map((c) => c.getAttribute('data-slot'))).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  // A child whose existing DOM stays (just toggled visibility) should not
+  // get reordered — verify the new anchor check doesn't cause spurious
+  // reattachments on stable re-renders.
+  it('stable re-render does not reorder stable DOM', async () => {
+    const container = setup()
+    let bump!: () => void
+    let attaches = 0
+
+    function App() {
+      const [, setN] = React.useState(0)
+      bump = () => setN((n) => n + 1)
+      return (
+        <div data-slot="parent">
+          <div data-slot="first">FIRST</div>
+          <div data-slot="second">SECOND</div>
+        </div>
+      )
+    }
+
+    const root = createRoot(container)
+    flushSync(() => root.render(<App />))
+    await tick()
+
+    const first = container.querySelector('[data-slot="first"]')!
+    const second = container.querySelector('[data-slot="second"]')!
+
+    // Listen for moves: any insertBefore that re-attaches our nodes counts
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        for (const n of Array.from(m.addedNodes)) {
+          if (n === first || n === second) attaches++
+        }
+      }
+    })
+    obs.observe(container.querySelector('[data-slot="parent"]')!, { childList: true })
+
+    flushSync(() => bump())
+    await tick()
+
+    obs.disconnect()
+    expect(attaches).toBe(0)
+  })
+})

--- a/packages/redact/tests/portal-doctype.test.tsx
+++ b/packages/redact/tests/portal-doctype.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Regressions:
+ *
+ * 1. Portal elements were silently dropped by `pushChildren` because its
+ *    element-type guard only accepted REACT_ELEMENT_TYPE /
+ *    REACT_LEGACY_ELEMENT_TYPE — portals carry REACT_PORTAL_TYPE as their
+ *    `$$typeof`. `fiberFromChild` also bucketed them wrong (it read
+ *    `element.type.$$typeof`, but for a portal `element.type` is the
+ *    REACT_PORTAL_TYPE symbol and has no `$$typeof`). Together, portals
+ *    never rendered — every Radix/Floating-UI dropdown, dialog, or tooltip
+ *    silently vanished.
+ *
+ * 2. SSR didn't emit `<!DOCTYPE html>`. Without the doctype, browsers use
+ *    "BackCompat" (quirks) mode — `document.documentElement.clientHeight`
+ *    returns content height instead of viewport height, CSS sizing breaks,
+ *    and viewport-relative positioning (Floating UI middleware, sticky
+ *    elements) collapses.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { createPortal } from 'react-dom'
+import { renderToString } from 'react-dom/server'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('createPortal renders into target container', () => {
+  it('mounts portal children into the supplied container', async () => {
+    const container = setup()
+    const portalHost = document.createElement('section')
+    portalHost.id = 'portal-host'
+    document.body.appendChild(portalHost)
+
+    function App() {
+      return (
+        <div data-testid="app-root">
+          <span>in-tree</span>
+          {createPortal(<em data-testid="portal-child">portaled</em>, portalHost)}
+        </div>
+      )
+    }
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+
+    // In-tree child rendered into `container`
+    const appRoot = container.querySelector('[data-testid="app-root"]')!
+    expect(appRoot.querySelector('span')?.textContent).toBe('in-tree')
+    // Portal child rendered into the portal host (NOT in the root container)
+    expect(portalHost.querySelector('em[data-testid="portal-child"]')?.textContent).toBe(
+      'portaled',
+    )
+    expect(container.querySelector('em[data-testid="portal-child"]')).toBeNull()
+
+    document.body.removeChild(portalHost)
+  })
+
+  it('unmounts portal children when the parent stops rendering them', async () => {
+    const container = setup()
+    const portalHost = document.createElement('section')
+    document.body.appendChild(portalHost)
+
+    function App({ show }: { show: boolean }) {
+      return (
+        <div>{show ? createPortal(<b data-testid="p">x</b>, portalHost) : null}</div>
+      )
+    }
+    const root = createRoot(container)
+    root.render(<App show={true} />)
+    await Promise.resolve()
+    expect(portalHost.querySelector('[data-testid="p"]')).not.toBeNull()
+
+    root.render(<App show={false} />)
+    await Promise.resolve()
+    expect(portalHost.querySelector('[data-testid="p"]')).toBeNull()
+
+    document.body.removeChild(portalHost)
+  })
+
+  it('renders portal alongside sibling elements correctly', async () => {
+    // Repro shape of Radix DropdownMenu: a Trigger element in the tree, plus
+    // a Content element rendered via portal into document.body.
+    const container = setup()
+    const portalHost = document.createElement('section')
+    document.body.appendChild(portalHost)
+
+    function DropdownMenu() {
+      return (
+        <>
+          <button data-testid="trigger">toggle</button>
+          {createPortal(
+            <div role="menu" data-testid="menu">
+              <a data-testid="item">item</a>
+            </div>,
+            portalHost,
+          )}
+        </>
+      )
+    }
+    createRoot(container).render(<DropdownMenu />)
+    await Promise.resolve()
+
+    expect(container.querySelector('[data-testid="trigger"]')).not.toBeNull()
+    expect(portalHost.querySelector('[role="menu"]')).not.toBeNull()
+    expect(portalHost.querySelectorAll('[data-testid="item"]').length).toBe(1)
+
+    document.body.removeChild(portalHost)
+  })
+})
+
+describe('SSR emits <!DOCTYPE html> for html roots', () => {
+  it('prepends a DOCTYPE when the root element is <html>', () => {
+    function Doc() {
+      return (
+        <html lang="en">
+          <head>
+            <title>hi</title>
+          </head>
+          <body>
+            <main>ok</main>
+          </body>
+        </html>
+      )
+    }
+    const html = renderToString(<Doc />)
+    // Must start with doctype — otherwise browser uses quirks mode and
+    // documentElement.clientHeight (used by Floating-UI etc.) returns
+    // content height instead of viewport height, breaking overlays.
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(html).toContain('<html')
+    expect(html).toContain('<main>ok</main>')
+  })
+
+  it('does not prepend a DOCTYPE for non-html roots', () => {
+    const html = renderToString(<div>not a doc</div>)
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(false)
+    expect(html.startsWith('<div')).toBe(true)
+  })
+})

--- a/packages/redact/tests/public-exports.test.ts
+++ b/packages/redact/tests/public-exports.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Public API surface lock-in.
+ *
+ * Why this test exists: it catches the class of bug where you add a function
+ * to a sub-module (e.g. `react/hooks.ts`) but forget to add it to the
+ * subpath's top-level `index.ts` re-export block. The function exists, types
+ * check, the build succeeds — but consumers importing the package by name
+ * get a silent `SyntaxError: does not provide an export named 'X'` at
+ * module-link time, which is invisible to runtime descriptive errors.
+ *
+ * The snapshots are intentionally exhaustive and inline. Any deliberate
+ * change to a subpath's public API requires updating the corresponding
+ * snapshot, which forces the diff to surface in code review.
+ */
+import { describe, it, expect } from 'vitest'
+
+import * as redact from '@ss/redact'
+import * as redactJsxRuntime from '@ss/redact/jsx-runtime'
+import * as redactCompilerRuntime from '@ss/redact/compiler-runtime'
+import * as redactDom from '@ss/redact/dom'
+import * as redactDomClient from '@ss/redact/dom-client'
+import * as redactDomTestUtils from '@ss/redact/dom-test-utils'
+import * as redactServer from '@ss/redact/server'
+
+const surface = (mod: Record<string, unknown>): Array<string> =>
+  Object.keys(mod).sort()
+
+describe('public API surface', () => {
+  it('@ss/redact', () => {
+    expect(surface(redact)).toMatchInlineSnapshot(`
+      [
+        "Children",
+        "Component",
+        "Fragment",
+        "Profiler",
+        "PureComponent",
+        "REACT_CONSUMER_TYPE",
+        "REACT_CONTEXT_TYPE",
+        "REACT_FORWARD_REF_TYPE",
+        "REACT_LAZY_TYPE",
+        "REACT_MEMO_TYPE",
+        "REACT_PORTAL_TYPE",
+        "REACT_PROFILER_TYPE",
+        "REACT_PROVIDER_TYPE",
+        "REACT_STRICT_MODE_TYPE",
+        "REACT_SUSPENSE_TYPE",
+        "ReactSharedInternals",
+        "StrictMode",
+        "Suspense",
+        "act",
+        "cache",
+        "cloneElement",
+        "createContext",
+        "createElement",
+        "createRef",
+        "default",
+        "forwardRef",
+        "isValidElement",
+        "lazy",
+        "memo",
+        "startTransition",
+        "taintObjectReference",
+        "taintUniqueValue",
+        "use",
+        "useActionState",
+        "useCallback",
+        "useContext",
+        "useDebugValue",
+        "useDeferredValue",
+        "useEffect",
+        "useEffectEvent",
+        "useFormStatus",
+        "useId",
+        "useImperativeHandle",
+        "useInsertionEffect",
+        "useLayoutEffect",
+        "useMemo",
+        "useOptimistic",
+        "useReducer",
+        "useRef",
+        "useState",
+        "useSyncExternalStore",
+        "useSyncExternalStoreWithSelector",
+        "useTransition",
+        "version",
+      ]
+    `)
+  })
+
+  it('@ss/redact/jsx-runtime', () => {
+    expect(surface(redactJsxRuntime)).toMatchInlineSnapshot(`
+      [
+        "Fragment",
+        "jsx",
+        "jsxDEV",
+        "jsxs",
+      ]
+    `)
+  })
+
+  it('@ss/redact/compiler-runtime', () => {
+    expect(surface(redactCompilerRuntime)).toMatchInlineSnapshot(`
+      [
+        "c",
+      ]
+    `)
+  })
+
+  it('@ss/redact/dom', () => {
+    expect(surface(redactDom)).toMatchInlineSnapshot(`
+      [
+        "createPortal",
+        "default",
+        "flushSync",
+        "preconnect",
+        "prefetchDNS",
+        "preinit",
+        "preinitModule",
+        "preload",
+        "preloadModule",
+        "unstable_batchedUpdates",
+        "version",
+      ]
+    `)
+  })
+
+  it('@ss/redact/dom-client', () => {
+    expect(surface(redactDomClient)).toMatchInlineSnapshot(`
+      [
+        "createRoot",
+        "default",
+        "hydrateRoot",
+      ]
+    `)
+  })
+
+  it('@ss/redact/dom-test-utils', () => {
+    expect(surface(redactDomTestUtils)).toMatchInlineSnapshot(`
+      [
+        "act",
+      ]
+    `)
+  })
+
+  it('@ss/redact/server', () => {
+    expect(surface(redactServer)).toMatchInlineSnapshot(`
+      [
+        "BOUNDARY_REVEAL_RUNTIME",
+        "default",
+        "renderToPipeableStream",
+        "renderToReadableStream",
+        "renderToStaticMarkup",
+        "renderToString",
+        "version",
+      ]
+    `)
+  })
+})
+
+describe('aliased shim names — what `redact()` claims to provide', () => {
+  /**
+   * The Vite plugin aliases `use-sync-external-store/shim/with-selector` →
+   * `@ss/redact`, promising consumers that the module exposes
+   * `useSyncExternalStoreWithSelector`. Likewise for the bare
+   * `use-sync-external-store` paths. If `@ss/redact` ever drops these
+   * names, every router/store user breaks at link time. This test guards
+   * the contract.
+   */
+  it('exposes hooks needed by use-sync-external-store/shim/* aliases', () => {
+    expect(redact).toHaveProperty('useSyncExternalStore')
+    expect(redact).toHaveProperty('useSyncExternalStoreWithSelector')
+    expect(typeof (redact as any).useSyncExternalStore).toBe('function')
+    expect(typeof (redact as any).useSyncExternalStoreWithSelector).toBe(
+      'function',
+    )
+  })
+})

--- a/packages/redact/tests/react-integration/attributes.test.tsx
+++ b/packages/redact/tests/react-integration/attributes.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Port of a subset of React's `ReactDOMServerIntegrationAttributes-test.js`.
+ * Covers the attribute-mapping surface: string/numeric/boolean props, enum
+ * HTML attributes (hidden, download), `className`/`htmlFor` aliasing, special
+ * React props (ref/key/children/dangerouslySetInnerHTML), aria/data
+ * passthroughs, and HTML entity escaping.
+ *
+ * Skipped from the upstream file:
+ *   - Dev-mode warning assertions (React uses `assertConsoleErrorDev`; we
+ *     don't emit dev warnings, so cases that check for specific console
+ *     messages won't apply). The expected *rendered output* of those cases
+ *     is still here — we just don't count warnings.
+ *   - URL-scheme sanitization (`javascript:` etc.) — that's a dev-mode
+ *     hardening that's intentionally absent from the shim.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / attributes', () => {
+  describe('string properties', () => {
+    itRenders('simple numbers', async (render) => {
+      const e = (await render(<div width={30} />)) as HTMLElement
+      expect(e.getAttribute('width')).toBe('30')
+    })
+
+    itRenders('simple strings', async (render) => {
+      const e = (await render(<div width={'30'} />)) as HTMLElement
+      expect(e.getAttribute('width')).toBe('30')
+    })
+
+    itRenders('empty href on anchor', async (render) => {
+      const e = (await render(<a href="" />)) as HTMLElement
+      expect(e.getAttribute('href')).toBe('')
+    })
+
+    itRenders('no string prop with null value', async (render) => {
+      const e = (await render(<div width={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('width')).toBe(false)
+    })
+  })
+
+  describe('boolean properties', () => {
+    itRenders('boolean prop with true value', async (render) => {
+      const e = (await render(<div hidden={true} />)) as HTMLElement
+      expect(e.getAttribute('hidden')).toBe('')
+    })
+
+    itRenders('boolean prop with false value', async (render) => {
+      const e = (await render(<div hidden={false} />)) as HTMLElement
+      expect(e.getAttribute('hidden')).toBe(null)
+    })
+
+    itRenders('no boolean prop with null value', async (render) => {
+      const e = (await render(<div hidden={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('hidden')).toBe(false)
+    })
+  })
+
+  describe('download property (combined boolean/string)', () => {
+    itRenders('download prop with true value', async (render) => {
+      const e = (await render(<a download={true as any} />)) as HTMLElement
+      expect(e.getAttribute('download')).toBe('')
+    })
+
+    itRenders('download prop with false value', async (render) => {
+      const e = (await render(<a download={false as any} />)) as HTMLElement
+      expect(e.getAttribute('download')).toBe(null)
+    })
+
+    itRenders('download prop with string value', async (render) => {
+      const e = (await render(<a download="myfile" />)) as HTMLElement
+      expect(e.getAttribute('download')).toBe('myfile')
+    })
+
+    itRenders('download prop with number 0 value', async (render) => {
+      const e = (await render(<a download={0 as any} />)) as HTMLElement
+      expect(e.getAttribute('download')).toBe('0')
+    })
+
+    itRenders('no download prop with null value', async (render) => {
+      const e = (await render(<div download={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('download')).toBe(false)
+    })
+
+    itRenders('no download prop with undefined value', async (render) => {
+      const e = (await render(<div download={undefined as any} />)) as HTMLElement
+      expect(e.hasAttribute('download')).toBe(false)
+    })
+  })
+
+  describe('className property', () => {
+    itRenders('className prop with string value', async (render) => {
+      const e = (await render(<div className="myClassName" />)) as HTMLElement
+      expect(e.getAttribute('class')).toBe('myClassName')
+    })
+
+    itRenders('className prop with empty string value', async (render) => {
+      const e = (await render(<div className="" />)) as HTMLElement
+      expect(e.getAttribute('class')).toBe('')
+    })
+
+    itRenders('no className prop with null value', async (render) => {
+      const e = (await render(<div className={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('className')).toBe(false)
+    })
+
+    itRenders('className prop when given the alias', async (render) => {
+      const e = (await render(<div class="test" />)) as HTMLElement
+      expect(e.className).toBe('test')
+    })
+  })
+
+  describe('htmlFor property', () => {
+    itRenders('htmlFor with string value', async (render) => {
+      const e = (await render(<div htmlFor="myFor" />)) as HTMLElement
+      expect(e.getAttribute('for')).toBe('myFor')
+    })
+
+    itRenders('htmlFor with an empty string', async (render) => {
+      const e = (await render(<div htmlFor="" />)) as HTMLElement
+      expect(e.getAttribute('for')).toBe('')
+    })
+
+    itRenders('no htmlFor prop with null value', async (render) => {
+      const e = (await render(<div htmlFor={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('htmlFor')).toBe(false)
+    })
+  })
+
+  describe('numeric properties', () => {
+    itRenders('positive numeric property with positive value', async (render) => {
+      const e = (await render(<input size={2} />)) as HTMLElement
+      expect(e.getAttribute('size')).toBe('2')
+    })
+
+    itRenders('numeric property with zero value', async (render) => {
+      const e = (await render(<ol start={0} />)) as HTMLElement
+      expect(e.getAttribute('start')).toBe('0')
+    })
+  })
+
+  describe('props with special meaning in React', () => {
+    itRenders('no children attribute', async (render) => {
+      const e = (await render(React.createElement('div', {}, 'foo'))) as HTMLElement
+      expect(e.getAttribute('children')).toBe(null)
+    })
+
+    itRenders('no key attribute', async (render) => {
+      const e = (await render(<div key="foo" />)) as HTMLElement
+      expect(e.getAttribute('key')).toBe(null)
+    })
+
+    itRenders('no dangerouslySetInnerHTML attribute', async (render) => {
+      const e = (await render(
+        <div dangerouslySetInnerHTML={{ __html: '<foo />' }} />,
+      )) as HTMLElement
+      expect(e.getAttribute('dangerouslySetInnerHTML')).toBe(null)
+    })
+  })
+
+  describe('aria attributes', () => {
+    itRenders('simple aria-* attribute', async (render) => {
+      const e = (await render(<div aria-label="foo" />)) as HTMLElement
+      expect(e.getAttribute('aria-label')).toBe('foo')
+    })
+
+    itRenders('aria-* attribute with true value', async (render) => {
+      const e = (await render(<div aria-hidden={true} />)) as HTMLElement
+      expect(e.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    itRenders('aria-* attribute with false value', async (render) => {
+      const e = (await render(<div aria-hidden={false} />)) as HTMLElement
+      expect(e.getAttribute('aria-hidden')).toBe('false')
+    })
+
+    itRenders('aria-* attribute with number value', async (render) => {
+      const e = (await render(<div aria-valuenow={2} />)) as HTMLElement
+      expect(e.getAttribute('aria-valuenow')).toBe('2')
+    })
+
+    itRenders('aria-* attribute with null value', async (render) => {
+      const e = (await render(<div aria-label={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('aria-label')).toBe(false)
+    })
+  })
+
+  describe('data-* attributes', () => {
+    itRenders('simple data-* attribute', async (render) => {
+      const e = (await render(<div data-foo="bar" />)) as HTMLElement
+      expect(e.getAttribute('data-foo')).toBe('bar')
+    })
+
+    itRenders('data-* attribute with number value', async (render) => {
+      const e = (await render(<div data-count={3} />)) as HTMLElement
+      expect(e.getAttribute('data-count')).toBe('3')
+    })
+
+    itRenders('data-* attribute with null value', async (render) => {
+      const e = (await render(<div data-foo={null as any} />)) as HTMLElement
+      expect(e.hasAttribute('data-foo')).toBe(false)
+    })
+
+    itRenders('data-* attribute with true value', async (render) => {
+      const e = (await render(<div data-foo={true} />)) as HTMLElement
+      expect(e.getAttribute('data-foo')).toBe('true')
+    })
+  })
+
+  describe('no-value attributes', () => {
+    itRenders('allowFullScreen as allowfullscreen', async (render) => {
+      const e = (await render(<div allowFullScreen={true} />)) as HTMLElement
+      expect(e.hasAttribute('allowfullscreen')).toBe(true)
+    })
+
+    itRenders('autoPlay as autoplay', async (render) => {
+      const e = (await render(<video autoPlay={true} />)) as HTMLElement
+      expect(e.hasAttribute('autoplay')).toBe(true)
+    })
+  })
+
+  describe('attribute escaping', () => {
+    itRenders('escapes HTML-reserved chars in attribute values', async (render) => {
+      const e = (await render(<div title={'<a&b"c'} />)) as HTMLElement
+      expect(e.getAttribute('title')).toBe('<a&b"c')
+    })
+  })
+
+  describe('style property', () => {
+    itRenders('style as object', async (render) => {
+      const e = (await render(
+        <div style={{ color: 'red', marginTop: 4 }} />,
+      )) as HTMLElement
+      expect(e.style.color).toBe('red')
+      expect(e.style.marginTop).toBe('4px')
+    })
+
+    itRenders('empty style object', async (render) => {
+      const e = (await render(<div style={{}} />)) as HTMLElement
+      // Either no style attr or empty cssText — both are acceptable.
+      expect(e.getAttribute('style') === null || e.getAttribute('style') === '').toBe(true)
+    })
+  })
+})

--- a/packages/redact/tests/react-integration/basic.test.tsx
+++ b/packages/redact/tests/react-integration/basic.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationBasic-test.js`. See harness.tsx
+ * for the strategy matrix — every `itRenders` case runs 4 times.
+ */
+import { describe } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+const TEXT_NODE_TYPE = 3
+
+describe('ReactDOMServerIntegration / basic rendering', () => {
+  itRenders('a blank div', async (render) => {
+    const e = (await render(<div />)) as HTMLElement
+    expect(e.tagName).toBe('DIV')
+  })
+
+  itRenders('a self-closing tag', async (render) => {
+    const e = (await render(<br />)) as HTMLElement
+    expect(e.tagName).toBe('BR')
+  })
+
+  itRenders('a self-closing tag as a child', async (render) => {
+    const e = (await render(
+      <div>
+        <br />
+      </div>,
+    )) as HTMLElement
+    expect(e.childNodes.length).toBe(1)
+    expect((e.firstChild as HTMLElement).tagName).toBe('BR')
+  })
+
+  itRenders('a string', async (render) => {
+    const e = (await render('Hello')) as Text
+    expect(e.nodeType).toBe(TEXT_NODE_TYPE)
+    expect(e.nodeValue).toMatch('Hello')
+  })
+
+  itRenders('a number', async (render) => {
+    const e = (await render(42)) as Text
+    expect(e.nodeType).toBe(TEXT_NODE_TYPE)
+    expect(e.nodeValue).toMatch('42')
+  })
+
+  itRenders('an array with one child', async (render) => {
+    const e = await render([<div key={1}>text1</div>])
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+  })
+
+  itRenders('an array with several children', async (render) => {
+    const Header = () => <p>header</p>
+    const Footer = () => [<h2 key={1}>footer</h2>, <h3 key={2}>about</h3>]
+    const e = await render([
+      <div key={1}>text1</div>,
+      <span key={2}>text2</span>,
+      <Header key={3} />,
+      <Footer key={4} />,
+    ])
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+    expect((parent.childNodes[3] as HTMLElement).tagName).toBe('H2')
+    expect((parent.childNodes[4] as HTMLElement).tagName).toBe('H3')
+  })
+
+  itRenders('a nested array', async (render) => {
+    const e = await render([
+      [<div key={1}>text1</div>],
+      <span key={1}>text2</span>,
+      [[[null, <p key={1} />], false]],
+    ])
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+  })
+
+  itRenders('an iterable', async (render) => {
+    const threeDivIterable = {
+      [Symbol.iterator]: function () {
+        let i = 0
+        return {
+          next: function () {
+            if (i++ < 3) {
+              return { value: <div key={i} />, done: false }
+            }
+            return { value: undefined, done: true }
+          },
+        }
+      },
+    }
+    const e = await render(threeDivIterable as any)
+    const parent = e?.parentNode as HTMLElement
+    expect(parent.childNodes.length).toBe(3)
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('DIV')
+  })
+
+  itRenders('emptyish values', async (render) => {
+    const e = (await render(0)) as Text
+    expect(e.nodeType).toBe(TEXT_NODE_TYPE)
+    expect(e.nodeValue).toMatch('0')
+
+    expect(((await render(<div>{''}</div>)) as HTMLElement).textContent).toBe('')
+
+    expect(await render([])).toBe(null)
+    expect(await render(false)).toBe(null)
+    expect(await render(true)).toBe(null)
+    expect(await render([[[false]], undefined])).toBe(null)
+  })
+})
+
+// Re-export vitest's `expect` so these React-ported files can use the global-
+// style `expect(...)` without importing it in every case.
+import { expect } from 'vitest'

--- a/packages/redact/tests/react-integration/class-context-type.test.tsx
+++ b/packages/redact/tests/react-integration/class-context-type.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationClassContextType-test.js`.
+ * Verifies `static contextType = Ctx` on class components plumbs the
+ * current Provider value into `this.context` during render.
+ */
+import { describe, beforeEach, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / class contextType', () => {
+  let Context: React.Context<string>
+  let PurpleProvider: React.FC<{ children: React.ReactNode }>
+  let RedProvider: React.FC<{ children: React.ReactNode }>
+
+  beforeEach(() => {
+    Context = React.createContext('none')
+    PurpleProvider = ({ children }) => (
+      <Context.Provider value="purple">{children}</Context.Provider>
+    )
+    RedProvider = ({ children }) => (
+      <Context.Provider value="red">{children}</Context.Provider>
+    )
+  })
+
+  itRenders('class child with contextType', async (render) => {
+    class ClassChild extends React.Component {
+      static contextType = Context
+      render() {
+        return <div>{this.context as string}</div>
+      }
+    }
+    const e = (await render(
+      <PurpleProvider>
+        <ClassChild />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('purple')
+  })
+
+  itRenders('class child without contextType', async (render) => {
+    class ClassChild extends React.Component {
+      render() {
+        return (
+          <div>
+            {typeof this.context === 'string' ? (this.context as string) : ''}
+          </div>
+        )
+      }
+    }
+    const e = (await render(
+      <PurpleProvider>
+        <ClassChild />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('')
+  })
+
+  itRenders('context passed through to a grandchild', async (render) => {
+    class Grandchild extends React.Component {
+      static contextType = Context
+      render() {
+        return <div>{this.context as string}</div>
+      }
+    }
+    const Child = () => <Grandchild />
+    const e = (await render(
+      <PurpleProvider>
+        <Child />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('purple')
+  })
+
+  itRenders('child context overriding parent context', async (render) => {
+    class Grandchild extends React.Component {
+      static contextType = Context
+      render() {
+        return <div>{this.context as string}</div>
+      }
+    }
+    const e = (await render(
+      <PurpleProvider>
+        <RedProvider>
+          <Grandchild />
+        </RedProvider>
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('red')
+  })
+
+  itRenders('multiple contexts via contextType', async (render) => {
+    const Theme = React.createContext('dark')
+    const Language = React.createContext('french')
+    class Parent extends React.Component {
+      render() {
+        return (
+          <Theme.Provider value="light">
+            <Child />
+          </Theme.Provider>
+        )
+      }
+    }
+    function Child() {
+      return (
+        <Language.Provider value="english">
+          <Grandchild />
+        </Language.Provider>
+      )
+    }
+    class ThemeComponent extends React.Component {
+      static contextType = Theme
+      render() {
+        return <div id="theme">{this.context as string}</div>
+      }
+    }
+    class LanguageComponent extends React.Component {
+      static contextType = Language
+      render() {
+        return <div id="language">{this.context as string}</div>
+      }
+    }
+    const Grandchild = () => (
+      <div>
+        <ThemeComponent />
+        <LanguageComponent />
+      </div>
+    )
+    const e = (await render(<Parent />)) as HTMLElement
+    expect(e.querySelector('#theme')!.textContent).toBe('light')
+    expect(e.querySelector('#language')!.textContent).toBe('english')
+  })
+})

--- a/packages/redact/tests/react-integration/context.test.tsx
+++ b/packages/redact/tests/react-integration/context.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationNewContext-test.js`. Covers
+ * `createContext`, Provider/Consumer, default value, nested overrides,
+ * and context unwinding after children exit a Provider.
+ *
+ * Skipped from upstream:
+ *   - `readContext()` internal-dispatcher API test (uses
+ *     `__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE` —
+ *     an internal hook not part of the public surface).
+ *   - The post-error context-pollution test: depends on throwing-during-
+ *     render + re-render with clean context. Our SSR doesn't implement the
+ *     error-recovery slot needed to assert this cleanly.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / context', () => {
+  let Context: React.Context<string>
+  let PurpleProvider: React.FC<{ children: React.ReactNode }>
+  let RedProvider: React.FC<{ children: React.ReactNode }>
+  let Consumer: React.Context<string>['Consumer']
+
+  // React's harness re-creates these per test via beforeEach → `resetModules`.
+  // We don't reset modules in vitest but the semantic is the same — each
+  // test closes over fresh Provider/Consumer references.
+  beforeEach(() => {
+    Context = React.createContext('none')
+    Consumer = Context.Consumer
+    PurpleProvider = ({ children }) => (
+      <Context.Provider value="purple">{children}</Context.Provider>
+    )
+    RedProvider = ({ children }) => (
+      <Context.Provider value="red">{children}</Context.Provider>
+    )
+  })
+
+  itRenders('class child with context', async (render) => {
+    class ClassChild extends React.Component {
+      render() {
+        return (
+          <div>
+            <Consumer>{(text) => text}</Consumer>
+          </div>
+        )
+      }
+    }
+    const e = (await render(
+      <PurpleProvider>
+        <ClassChild />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('purple')
+  })
+
+  itRenders('function child with context', async (render) => {
+    function FnChild() {
+      return <Consumer>{(text) => text}</Consumer>
+    }
+    const e = (await render(
+      <PurpleProvider>
+        <FnChild />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('purple')
+  })
+
+  itRenders('class child with default context', async (render) => {
+    class ClassChild extends React.Component {
+      render() {
+        return (
+          <div>
+            <Consumer>{(text) => text}</Consumer>
+          </div>
+        )
+      }
+    }
+    const e = (await render(<ClassChild />)) as HTMLElement
+    expect(e.textContent).toBe('none')
+  })
+
+  itRenders('function child with default context', async (render) => {
+    function FnChild() {
+      return (
+        <div>
+          <Consumer>{(text) => text}</Consumer>
+        </div>
+      )
+    }
+    const e = (await render(<FnChild />)) as HTMLElement
+    expect(e.textContent).toBe('none')
+  })
+
+  itRenders('context passed through to a grandchild', async (render) => {
+    function Grandchild() {
+      return (
+        <div>
+          <Consumer>{(text) => text}</Consumer>
+        </div>
+      )
+    }
+    const Child = () => <Grandchild />
+    const e = (await render(
+      <PurpleProvider>
+        <Child />
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('purple')
+  })
+
+  itRenders('child context overriding parent context', async (render) => {
+    const Grandchild = () => (
+      <div>
+        <Consumer>{(text) => text}</Consumer>
+      </div>
+    )
+    const e = (await render(
+      <PurpleProvider>
+        <RedProvider>
+          <Grandchild />
+        </RedProvider>
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('red')
+  })
+
+  itRenders('useContext in different component shapes', async (render) => {
+    const readCtx = () => React.useContext(Context)
+    function Fn() {
+      return readCtx() as any
+    }
+    const Memo = React.memo(() => readCtx() as any)
+    const FwdRef = React.forwardRef((_props: any, _ref: any) => readCtx() as any)
+    const e = (await render(
+      <PurpleProvider>
+        <RedProvider>
+          <span>
+            <Fn />
+            <Memo />
+            <FwdRef />
+            <Consumer>{(t) => t}</Consumer>
+          </span>
+        </RedProvider>
+      </PurpleProvider>,
+    )) as HTMLElement
+    expect(e.textContent).toBe('redredredred')
+  })
+
+  itRenders('multiple independent contexts', async (render) => {
+    const Theme = React.createContext('dark')
+    const Language = React.createContext('french')
+    class Parent extends React.Component {
+      render() {
+        return (
+          <Theme.Provider value="light">
+            <Child />
+          </Theme.Provider>
+        )
+      }
+    }
+    function Child() {
+      return (
+        <Language.Provider value="english">
+          <Grandchild />
+        </Language.Provider>
+      )
+    }
+    const Grandchild = () => (
+      <div>
+        <Theme.Consumer>
+          {(theme) => <div id="theme">{theme}</div>}
+        </Theme.Consumer>
+        <Language.Consumer>
+          {(lang) => <div id="language">{lang}</div>}
+        </Language.Consumer>
+      </div>
+    )
+    const e = (await render(<Parent />)) as HTMLElement
+    expect(e.querySelector('#theme')!.textContent).toBe('light')
+    expect(e.querySelector('#language')!.textContent).toBe('english')
+  })
+
+  itRenders('nested context unwinding', async (render) => {
+    const Theme = React.createContext('dark')
+    const Language = React.createContext('french')
+    const App = () => (
+      <div>
+        <Theme.Provider value="light">
+          <Language.Provider value="english">
+            <Theme.Provider value="dark">
+              <Theme.Consumer>
+                {(theme) => <div id="theme1">{theme}</div>}
+              </Theme.Consumer>
+            </Theme.Provider>
+            <Theme.Consumer>
+              {(theme) => <div id="theme2">{theme}</div>}
+            </Theme.Consumer>
+            <Language.Provider value="sanskrit">
+              <Theme.Provider value="blue">
+                <Theme.Provider value="red">
+                  <Language.Consumer>
+                    {() => (
+                      <Language.Provider value="chinese">
+                        <Language.Consumer>
+                          {(language) => <div id="language1">{language}</div>}
+                        </Language.Consumer>
+                      </Language.Provider>
+                    )}
+                  </Language.Consumer>
+                </Theme.Provider>
+                <Language.Consumer>
+                  {(language) => (
+                    <>
+                      <Theme.Consumer>
+                        {(theme) => <div id="theme3">{theme}</div>}
+                      </Theme.Consumer>
+                      <div id="language2">{language}</div>
+                    </>
+                  )}
+                </Language.Consumer>
+              </Theme.Provider>
+            </Language.Provider>
+          </Language.Provider>
+        </Theme.Provider>
+        <Language.Consumer>
+          {(language) => <div id="language3">{language}</div>}
+        </Language.Consumer>
+      </div>
+    )
+    const e = (await render(<App />)) as HTMLElement
+    expect(e.querySelector('#theme1')!.textContent).toBe('dark')
+    expect(e.querySelector('#theme2')!.textContent).toBe('light')
+    expect(e.querySelector('#theme3')!.textContent).toBe('blue')
+    expect(e.querySelector('#language1')!.textContent).toBe('chinese')
+    expect(e.querySelector('#language2')!.textContent).toBe('sanskrit')
+    expect(e.querySelector('#language3')!.textContent).toBe('french')
+  })
+})
+
+// Re-import beforeEach for clarity above.
+import { beforeEach } from 'vitest'

--- a/packages/redact/tests/react-integration/elements.test.tsx
+++ b/packages/redact/tests/react-integration/elements.test.tsx
@@ -1,0 +1,386 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationElements-test.js`. Covers the
+ * most-used element/children rendering surface: text/number children, the
+ * `<!-- -->` separator for adjacent text nodes, null/false children, SVG and
+ * MathML namespaces, void elements, custom elements, and
+ * `dangerouslySetInnerHTML` in its many forms.
+ *
+ * Skipped from upstream:
+ *   - `<nonstandard>` tag dev-mode warning (we don't warn on unknown tags).
+ *   - `xlinkHref` → `xlink:href` namespaced attribute. Our shim writes `xlinkHref`
+ *     as `xlink:href` only on the SSR path; the client adoption path would
+ *     need a namespaced-attribute map that doesn't exist yet. Keeping the
+ *     simpler SSR attribute-only case would test only half the matrix and
+ *     mislead; dropped for now.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import {
+  itRenders,
+  serverRender,
+  streamRender,
+  hydrateOnServerString,
+  expectTextNode,
+  TEXT_NODE_TYPE,
+} from './harness'
+
+/** True when the markup went through SSR (and therefore has `<!-- -->` text
+ * separators between adjacent text children). */
+function isServerPath(render: unknown): boolean {
+  return (
+    render === serverRender ||
+    render === streamRender ||
+    render === hydrateOnServerString
+  )
+}
+
+describe('ReactDOMServerIntegration / elements', () => {
+  describe('text children', () => {
+    itRenders('a div with text', async (render) => {
+      const e = (await render(<div>Text</div>)) as HTMLElement
+      expect(e.tagName).toBe('DIV')
+      expect(e.childNodes.length).toBe(1)
+      expect(e.firstChild!.nodeType).toBe(TEXT_NODE_TYPE)
+      expect(e.firstChild!.nodeValue).toBe('Text')
+    })
+
+    itRenders('a div with text with flanking whitespace', async (render) => {
+      const e = (await render(<div>{'  Text '}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], '  Text ')
+    })
+
+    itRenders('a div with an empty text child', async (render) => {
+      const e = (await render(<div>{''}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+
+    itRenders('a div with multiple empty text children', async (render) => {
+      const e = (await render(
+        <div>
+          {''}
+          {''}
+          {''}
+        </div>,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+      expect(e.textContent).toBe('')
+    })
+
+    itRenders('a div with text sibling to a node', async (render) => {
+      const e = (await render(
+        <div>
+          Text<span>More Text</span>
+        </div>,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(2)
+      const spanNode = e.childNodes[1] as HTMLElement
+      expectTextNode(e.childNodes[0], 'Text')
+      expect(spanNode.tagName).toBe('SPAN')
+      expect(spanNode.childNodes.length).toBe(1)
+      expect(spanNode.firstChild!.nodeValue).toBe('More Text')
+    })
+
+    itRenders('a leading blank child with a text sibling', async (render) => {
+      const e = (await render(<div>{''}foo</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], 'foo')
+    })
+
+    itRenders('a trailing blank child with a text sibling', async (render) => {
+      const e = (await render(<div>foo{''}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], 'foo')
+    })
+
+    itRenders('an element with two text children', async (render) => {
+      const e = (await render(
+        <div>
+          {'foo'}
+          {'bar'}
+        </div>,
+      )) as HTMLElement
+      if (isServerPath(render)) {
+        // `<!-- -->` separator between adjacent text nodes — required by
+        // React's hydration algorithm so the browser's parser doesn't merge
+        // adjacent text runs into one text node.
+        expect(e.childNodes.length).toBe(3)
+        expectTextNode(e.childNodes[0], 'foo')
+        expectTextNode(e.childNodes[2], 'bar')
+      } else {
+        expect(e.childNodes.length).toBe(2)
+        expectTextNode(e.childNodes[0], 'foo')
+        expectTextNode(e.childNodes[1], 'bar')
+      }
+    })
+
+    itRenders('a component returning text node between two text nodes', async (render) => {
+      const B = () => 'b'
+      const e = (await render(
+        <div>
+          {'a'}
+          <B />
+          {'c'}
+        </div>,
+      )) as HTMLElement
+      if (isServerPath(render)) {
+        expect(e.childNodes.length).toBe(5)
+        expectTextNode(e.childNodes[0], 'a')
+        expectTextNode(e.childNodes[2], 'b')
+        expectTextNode(e.childNodes[4], 'c')
+      } else {
+        expect(e.childNodes.length).toBe(3)
+        expectTextNode(e.childNodes[0], 'a')
+        expectTextNode(e.childNodes[1], 'b')
+        expectTextNode(e.childNodes[2], 'c')
+      }
+    })
+  })
+
+  describe('number children', () => {
+    itRenders('a number as single child', async (render) => {
+      const e = (await render(<div>{3}</div>)) as HTMLElement
+      expect(e.textContent).toBe('3')
+    })
+
+    itRenders('zero as single child', async (render) => {
+      const e = (await render(<div>{0}</div>)) as HTMLElement
+      expect(e.textContent).toBe('0')
+    })
+
+    itRenders('an element with number and text children', async (render) => {
+      const e = (await render(
+        <div>
+          {'foo'}
+          {40}
+        </div>,
+      )) as HTMLElement
+      if (isServerPath(render)) {
+        expect(e.childNodes.length).toBe(3)
+        expectTextNode(e.childNodes[0], 'foo')
+        expectTextNode(e.childNodes[2], '40')
+      } else {
+        expect(e.childNodes.length).toBe(2)
+        expectTextNode(e.childNodes[0], 'foo')
+        expectTextNode(e.childNodes[1], '40')
+      }
+    })
+  })
+
+  describe('null, false, and undefined children', () => {
+    itRenders('null single child as blank', async (render) => {
+      const e = (await render(<div>{null}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+
+    itRenders('false single child as blank', async (render) => {
+      const e = (await render(<div>{false}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+
+    itRenders('undefined single child as blank', async (render) => {
+      const e = (await render(<div>{undefined}</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+
+    itRenders('a null component children as empty', async (render) => {
+      const NullComponent = () => null
+      const e = (await render(
+        <div>
+          <NullComponent />
+        </div>,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+
+    itRenders('null children as blank', async (render) => {
+      const e = (await render(<div>{null}foo</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], 'foo')
+    })
+
+    itRenders('false children as blank', async (render) => {
+      const e = (await render(<div>{false}foo</div>)) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], 'foo')
+    })
+
+    itRenders('null and false children together as blank', async (render) => {
+      const e = (await render(
+        <div>
+          {false}
+          {null}foo{null}
+          {false}
+        </div>,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expectTextNode(e.childNodes[0], 'foo')
+    })
+
+    itRenders('only null and false children as blank', async (render) => {
+      const e = (await render(
+        <div>
+          {false}
+          {null}
+          {null}
+          {false}
+        </div>,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+  })
+
+  describe('elements with implicit namespaces', () => {
+    itRenders('an svg element', async (render) => {
+      const e = (await render(<svg />)) as SVGElement
+      expect(e.childNodes.length).toBe(0)
+      expect(e.tagName).toBe('svg')
+      expect(e.namespaceURI).toBe('http://www.w3.org/2000/svg')
+    })
+
+    itRenders('svg child element with an attribute', async (render) => {
+      const e = (await render(<svg viewBox="0 0 0 0" />)) as SVGElement
+      expect(e.tagName).toBe('svg')
+      expect(e.namespaceURI).toBe('http://www.w3.org/2000/svg')
+      expect(e.getAttribute('viewBox')).toBe('0 0 0 0')
+    })
+
+    itRenders('svg element with a mixed case name', async (render) => {
+      const e = (await render(
+        <svg>
+          <filter>
+            <feMorphology />
+          </filter>
+        </svg>,
+      )) as SVGElement
+      const feMorphology = (e.firstChild as Element).firstChild as Element
+      expect(feMorphology.childNodes.length).toBe(0)
+      expect(feMorphology.tagName).toBe('feMorphology')
+      expect((feMorphology as SVGElement).namespaceURI).toBe('http://www.w3.org/2000/svg')
+    })
+
+    itRenders('svg presentation attrs camelCase → kebab-case', async (render) => {
+      // strokeWidth must become `stroke-width` and clipPath must become
+      // `clip-path` for the browser to apply them. The camelCase form is
+      // silently ignored, which makes strokes default to 1px and clip
+      // references no-op — the visible symptom is an SVG that renders
+      // just its bounding rect.
+      const e = (await render(
+        <svg viewBox="0 0 100 100">
+          <path
+            d="M0,0 L100,100"
+            stroke="black"
+            strokeWidth="14"
+            strokeLinecap="round"
+          />
+          <g clipPath="url(#c)" fillRule="evenodd">
+            <rect x="0" y="0" width="100" height="100" />
+          </g>
+        </svg>,
+      )) as SVGElement
+      const path = e.firstChild as Element
+      const g = e.lastChild as Element
+      expect(path.getAttribute('stroke-width')).toBe('14')
+      expect(path.getAttribute('strokeWidth')).toBe(null)
+      expect(path.getAttribute('stroke-linecap')).toBe('round')
+      expect(g.getAttribute('clip-path')).toBe('url(#c)')
+      expect(g.getAttribute('clipPath')).toBe(null)
+      expect(g.getAttribute('fill-rule')).toBe('evenodd')
+    })
+
+    itRenders('svg case-preserving attrs are untouched', async (render) => {
+      // `viewBox`, `preserveAspectRatio`, `gradientTransform`, etc. are
+      // spec'd as camelCase in SVG and must NOT be lowercased.
+      const e = (await render(
+        <svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid meet">
+          <linearGradient gradientTransform="rotate(45)" gradientUnits="userSpaceOnUse" />
+        </svg>,
+      )) as SVGElement
+      const grad = e.firstChild as Element
+      expect(e.getAttribute('viewBox')).toBe('0 0 10 10')
+      expect(e.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet')
+      expect(grad.getAttribute('gradientTransform')).toBe('rotate(45)')
+      expect(grad.getAttribute('gradientUnits')).toBe('userSpaceOnUse')
+    })
+
+    itRenders('svg renames are applied by attribute name on any element', async (render) => {
+      // React applies the camelCase→kebab rename based on attribute name
+      // alone, not based on element namespace — so a `strokeWidth` prop on
+      // a `<div>` still emits as `stroke-width`. Critically, this keeps
+      // client and SSR output identical so hydration doesn't mismatch when
+      // a known SVG-prop name appears on a non-SVG element.
+      const e = (await render(
+        <div {...({ strokeWidth: '14' } as any)} />,
+      )) as HTMLElement
+      expect(e.getAttribute('stroke-width')).toBe('14')
+      expect(e.getAttribute('strokeWidth')).toBe(null)
+    })
+  })
+
+  describe('void / custom / misc elements', () => {
+    itRenders('an img', async (render) => {
+      const e = (await render(<img />)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+      expect(e.nextSibling).toBe(null)
+      expect(e.tagName).toBe('IMG')
+    })
+
+    itRenders('a button', async (render) => {
+      const e = (await render(<button />)) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+      expect(e.tagName).toBe('BUTTON')
+    })
+
+    itRenders('a custom element with text', async (render) => {
+      const e = (await render(
+        <custom-element {...({} as any)}>Text</custom-element>,
+      )) as HTMLElement
+      expect(e.tagName).toBe('CUSTOM-ELEMENT')
+      expect(e.childNodes.length).toBe(1)
+      expect(e.firstChild!.nodeValue).toBe('Text')
+    })
+  })
+
+  describe('dangerouslySetInnerHTML', () => {
+    itRenders('dangerouslySetInnerHTML number', async (render) => {
+      const parent = (await render(
+        <div>
+          <span dangerouslySetInnerHTML={{ __html: 0 as any }} />
+        </div>,
+      )) as HTMLElement
+      const e = parent.firstChild as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expect(e.firstChild!.nodeType).toBe(TEXT_NODE_TYPE)
+      expect(e.textContent).toBe('0')
+    })
+
+    itRenders('dangerouslySetInnerHTML text string', async (render) => {
+      const parent = (await render(
+        <div>
+          <span dangerouslySetInnerHTML={{ __html: 'hello' }} />
+        </div>,
+      )) as HTMLElement
+      const e = parent.firstChild as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      expect(e.firstChild!.nodeType).toBe(TEXT_NODE_TYPE)
+      expect(e.textContent).toBe('hello')
+    })
+
+    itRenders('dangerouslySetInnerHTML element string', async (render) => {
+      const e = (await render(
+        <div dangerouslySetInnerHTML={{ __html: "<span id='child'/>" }} />,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(1)
+      const child = e.firstChild as HTMLElement
+      expect(child.tagName).toBe('SPAN')
+      expect(child.getAttribute('id')).toBe('child')
+    })
+
+    itRenders('dangerouslySetInnerHTML set to null', async (render) => {
+      const e = (await render(
+        <div dangerouslySetInnerHTML={{ __html: null as any }} />,
+      )) as HTMLElement
+      expect(e.childNodes.length).toBe(0)
+    })
+  })
+})

--- a/packages/redact/tests/react-integration/form-controls.test.tsx
+++ b/packages/redact/tests/react-integration/form-controls.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationInput`, `Checkbox`, and
+ * `Textarea` tests. Covers the form-control surface where React has subtle
+ * value/defaultValue and checked/defaultChecked semantics.
+ *
+ * Matches React's behavior under `disableInputAttributeSyncing=true` — the
+ * feature-flag mode which simply passes `value`/`checked` through to the
+ * `.value`/`.checked` DOM properties without syncing them to attributes.
+ * Our shim's IDL-attribute handling is in that mode by design. The
+ * non-flagged React path adds extra attribute mirroring for legacy form
+ * libraries; we don't replicate that.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / input (checkbox)', () => {
+  itRenders('a checkbox that is checked with an onChange', async (render) => {
+    const e = (await render(
+      <input type="checkbox" checked={true} onChange={() => {}} />,
+    )) as HTMLInputElement
+    expect(e.checked).toBe(true)
+  })
+
+  itRenders('a checkbox that is checked with readOnly', async (render) => {
+    const e = (await render(
+      <input type="checkbox" checked={true} readOnly={true} />,
+    )) as HTMLInputElement
+    expect(e.checked).toBe(true)
+  })
+
+  itRenders('a checkbox with defaultChecked', async (render) => {
+    const e = (await render(
+      <input type="checkbox" defaultChecked={true} />,
+    )) as HTMLInputElement
+    expect(e.checked).toBe(true)
+    expect(e.getAttribute('defaultChecked')).toBe(null)
+  })
+
+  itRenders('checked overrides defaultChecked', async (render) => {
+    const e = (await render(
+      <input
+        type="checkbox"
+        checked={true}
+        defaultChecked={false}
+        readOnly={true}
+      />,
+    )) as HTMLInputElement
+    expect(e.checked).toBe(true)
+    expect(e.getAttribute('defaultChecked')).toBe(null)
+  })
+})
+
+describe('ReactDOMServerIntegration / input (text)', () => {
+  itRenders('an input with a value and an onChange', async (render) => {
+    const e = (await render(
+      <input value="foo" onChange={() => {}} />,
+    )) as HTMLInputElement
+    expect(e.value).toBe('foo')
+  })
+
+  itRenders('an input with a value and readOnly', async (render) => {
+    const e = (await render(
+      <input value="foo" readOnly={true} />,
+    )) as HTMLInputElement
+    expect(e.value).toBe('foo')
+  })
+
+  itRenders('an input with a defaultValue', async (render) => {
+    const e = (await render(<input defaultValue="foo" />)) as HTMLInputElement
+    expect(e.value).toBe('foo')
+    expect(e.getAttribute('defaultValue')).toBe(null)
+  })
+
+  itRenders('an input value overrides defaultValue', async (render) => {
+    const e = (await render(
+      <input value="foo" defaultValue="bar" readOnly={true} />,
+    )) as HTMLInputElement
+    expect(e.value).toBe('foo')
+    expect(e.getAttribute('defaultValue')).toBe(null)
+  })
+})
+
+describe('ReactDOMServerIntegration / textarea', () => {
+  itRenders('a textarea with a value and an onChange', async (render) => {
+    const e = (await render(
+      <textarea value="foo" onChange={() => {}} />,
+    )) as HTMLTextAreaElement
+    // textarea stores its value as a child text node, not a `value` attribute.
+    expect(e.getAttribute('value')).toBe(null)
+    expect(e.value).toBe('foo')
+  })
+
+  itRenders('a textarea with a value of undefined', async (render) => {
+    const e = (await render(
+      <textarea value={undefined} />,
+    )) as HTMLTextAreaElement
+    expect(e.getAttribute('value')).toBe(null)
+    expect(e.value).toBe('')
+  })
+
+  itRenders('a textarea with a value and readOnly', async (render) => {
+    const e = (await render(
+      <textarea value="foo" readOnly={true} />,
+    )) as HTMLTextAreaElement
+    expect(e.getAttribute('value')).toBe(null)
+    expect(e.value).toBe('foo')
+  })
+
+  itRenders('a textarea with a defaultValue', async (render) => {
+    const e = (await render(
+      <textarea defaultValue="foo" />,
+    )) as HTMLTextAreaElement
+    expect(e.getAttribute('value')).toBe(null)
+    expect(e.getAttribute('defaultValue')).toBe(null)
+    expect(e.value).toBe('foo')
+  })
+
+  itRenders('a textarea value overrides defaultValue', async (render) => {
+    const e = (await render(
+      <textarea value="foo" defaultValue="bar" readOnly={true} />,
+    )) as HTMLTextAreaElement
+    expect(e.getAttribute('value')).toBe(null)
+    expect(e.getAttribute('defaultValue')).toBe(null)
+    expect(e.value).toBe('foo')
+  })
+})

--- a/packages/redact/tests/react-integration/fragment.test.tsx
+++ b/packages/redact/tests/react-integration/fragment.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationFragment-test.js`.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / React.Fragment', () => {
+  itRenders('a fragment with one child', async (render) => {
+    const e = await render(
+      <>
+        <div>text1</div>
+      </>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+  })
+
+  itRenders('a fragment with several children', async (render) => {
+    const Header = () => <p>header</p>
+    const Footer = () => (
+      <>
+        <h2>footer</h2>
+        <h3>about</h3>
+      </>
+    )
+    const e = await render(
+      <>
+        <div>text1</div>
+        <span>text2</span>
+        <Header />
+        <Footer />
+      </>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+    expect((parent.childNodes[3] as HTMLElement).tagName).toBe('H2')
+    expect((parent.childNodes[4] as HTMLElement).tagName).toBe('H3')
+  })
+
+  itRenders('a nested fragment', async (render) => {
+    const e = await render(
+      <>
+        <>
+          <div>text1</div>
+        </>
+        <span>text2</span>
+        <>
+          <>
+            <>
+              {null}
+              <p />
+            </>
+            {false}
+          </>
+        </>
+      </>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+  })
+
+  itRenders('an empty fragment', async (render) => {
+    expect(
+      (
+        (await render(
+          <div>
+            <React.Fragment />
+          </div>,
+        )) as HTMLElement
+      ).firstChild,
+    ).toBe(null)
+  })
+})

--- a/packages/redact/tests/react-integration/harness.tsx
+++ b/packages/redact/tests/react-integration/harness.tsx
@@ -1,0 +1,122 @@
+/**
+ * Shim-side port of React's `ReactDOMServerIntegrationTestUtils` — the same
+ * `itRenders(desc, testFn)` matrix React uses to exercise SSR + hydration
+ * across four render strategies. Ported because it's the highest-value
+ * external test corpus that touches zero React internals: each strategy
+ * feeds the same React element through a different public-API path and
+ * asserts on the resulting DOM.
+ *
+ * Strategies:
+ *   - server string render   (`renderToString`)
+ *   - server stream render   (`renderToReadableStream`)
+ *   - client clean render    (`createRoot` into a fresh container)
+ *   - hydrate on server HTML (`renderToString` → `hydrateRoot`)
+ *
+ * Diverges from React's harness in two places:
+ *   - `clientCleanRender` / `hydrateOnServerString` await a microtask tick
+ *     after render/hydrate so passive effects flush before assertions; our
+ *     shim defers useEffect via queueMicrotask, matching real React.
+ *   - The "bad markup" variant is omitted — mismatch recovery has its own
+ *     dedicated tests and the per-case error-count plumbing would clutter
+ *     this file.
+ */
+import { it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString, renderToReadableStream } from 'react-dom/server'
+import { createRoot, hydrateRoot } from 'react-dom/client'
+import type { ReactNode } from 'react'
+
+type RenderFn = (element: ReactNode, expectedErrorCount?: number) => Promise<Node | null>
+
+async function streamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  return out + decoder.decode()
+}
+
+function containerFromMarkup(markup: string): HTMLElement {
+  const container = document.createElement('div')
+  container.innerHTML = markup
+  return container
+}
+
+async function serverRender(element: ReactNode): Promise<Node | null> {
+  const markup = renderToString(element as any)
+  return containerFromMarkup(markup).firstChild
+}
+
+async function streamRender(element: ReactNode): Promise<Node | null> {
+  const stream = await renderToReadableStream(element as any)
+  const markup = await streamToString(stream)
+  await stream.allReady
+  return containerFromMarkup(markup).firstChild
+}
+
+async function clientCleanRender(element: ReactNode): Promise<Node | null> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  try {
+    createRoot(container).render(element as any)
+    await Promise.resolve()
+    return container.firstChild
+  } finally {
+    document.body.removeChild(container)
+  }
+}
+
+async function hydrateOnServerString(element: ReactNode): Promise<Node | null> {
+  const markup = renderToString(element as any)
+  const container = containerFromMarkup(markup)
+  document.body.appendChild(container)
+  try {
+    const serverNode = container.firstChild
+    hydrateRoot(container, element as any)
+    await Promise.resolve()
+    const clientNode = container.firstChild
+    // Server and client nodes should be the same — hydration shouldn't recreate
+    // DOM when markup matches.
+    if (serverNode && clientNode) {
+      expect(clientNode).toBe(serverNode)
+    }
+    return clientNode
+  } finally {
+    document.body.removeChild(container)
+  }
+}
+
+/**
+ * Run `testFn` under all four render strategies. `testFn` receives a `render`
+ * function that returns the first DOM child produced for the given element.
+ */
+export function itRenders(desc: string, testFn: (render: RenderFn) => Promise<void>): void {
+  it(`renders ${desc} with server string render`, () => testFn(serverRender))
+  it(`renders ${desc} with server stream render`, () => testFn(streamRender))
+  it(`renders ${desc} with client clean render`, () => testFn(clientCleanRender))
+  it(`renders ${desc} hydrating on server string`, () => testFn(hydrateOnServerString))
+}
+
+// Exported by identity so tests can discriminate between render strategies.
+// React's own harness does this to branch on "is there a `<!-- -->` between
+// adjacent text nodes?" — server/stream/hydrate preserve that separator,
+// client clean render does not.
+export { serverRender, streamRender, clientCleanRender, hydrateOnServerString, React }
+
+// --- small DOM assertion helpers lifted from React's harness -----------------
+
+export const TEXT_NODE_TYPE = 3
+
+export function expectNode(node: Node | null | undefined, type: number, value: string): void {
+  expect(node).not.toBe(null)
+  expect(node!.nodeType).toBe(type)
+  expect(node!.nodeValue).toMatch(value)
+}
+
+export function expectTextNode(node: Node | null | undefined, text: string): void {
+  expectNode(node, TEXT_NODE_TYPE, text)
+}

--- a/packages/redact/tests/react-integration/hooks.test.tsx
+++ b/packages/redact/tests/react-integration/hooks.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationHooks-test.js`. Covers the
+ * SSR hook surface: useState/useReducer reading initial state, useMemo,
+ * useCallback, useRef, useContext, useDebugValue, useImperativeHandle,
+ * useEffect (must be a noop server-side).
+ *
+ * Skipped from upstream:
+ *   - Render-phase state updates (calling `setCount` during render so the
+ *     component re-runs until state stabilizes). Our SSR dispatcher returns
+ *     a no-op setter, so these tests would all fail until we implement
+ *     state-settling render loops server-side. Tracked separately; the
+ *     loop-until-stable semantic is non-trivial and not currently blocking
+ *     tanstack.com.
+ *   - `itThrowsWhenRendering` cases for misused hooks (inside class
+ *     components, inside other hooks). Those assert specific dev-mode
+ *     error messages we don't produce.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders, serverRender } from './harness'
+
+describe('ReactDOMServerHooks / useState', () => {
+  itRenders('basic render', async (render) => {
+    function Counter() {
+      const [count] = React.useState(0)
+      return <span>Count: {count}</span>
+    }
+    const e = (await render(<Counter />)) as HTMLElement
+    expect(e.textContent).toEqual('Count: 0')
+  })
+
+  itRenders('lazy state initialization', async (render) => {
+    function Counter() {
+      const [count] = React.useState(() => 0)
+      return <span>Count: {count}</span>
+    }
+    const e = (await render(<Counter />)) as HTMLElement
+    expect(e.textContent).toEqual('Count: 0')
+  })
+
+  it('does not trigger re-render when setter is invoked outside current render', async () => {
+    // This mirrors React's SSR behavior: an outside-render setState call is a
+    // no-op server-side (no useEffect), so the initial value renders.
+    function UpdateCount({ setCount, count, children }: any) {
+      if (count < 3) {
+        // Calling setCount outside the body-scope render (via a child that
+        // dispatches sync during parent render) also shouldn't loop.
+        setCount((c: number) => c + 1)
+      }
+      return <span>{children}</span>
+    }
+    function Counter() {
+      const [count, setCount] = React.useState(0)
+      return (
+        <div>
+          <UpdateCount setCount={setCount} count={count}>
+            Count: {count}
+          </UpdateCount>
+        </div>
+      )
+    }
+    const node = (await serverRender(<Counter />)) as HTMLElement
+    expect(node.textContent).toEqual('Count: 0')
+  })
+})
+
+describe('ReactDOMServerHooks / useReducer', () => {
+  itRenders('with initial state', async (render) => {
+    function reducer(state: number, action: string) {
+      return action === 'increment' ? state + 1 : state
+    }
+    function Counter() {
+      const [count] = React.useReducer(reducer, 0)
+      return <span>{count}</span>
+    }
+    const e = (await render(<Counter />)) as HTMLElement
+    expect(e.tagName).toEqual('SPAN')
+    expect(e.textContent).toEqual('0')
+  })
+
+  itRenders('lazy initialization', async (render) => {
+    function reducer(state: number, action: string) {
+      return action === 'increment' ? state + 1 : state
+    }
+    function Counter() {
+      const [count] = React.useReducer(reducer, 0, (c) => c + 1)
+      return <span>{count}</span>
+    }
+    const e = (await render(<Counter />)) as HTMLElement
+    expect(e.textContent).toEqual('1')
+  })
+})
+
+describe('ReactDOMServerHooks / useMemo', () => {
+  itRenders('basic render', async (render) => {
+    function CapitalizedText({ text }: { text: string }) {
+      const capitalized = React.useMemo(() => text.toUpperCase(), [text])
+      return <span>{capitalized}</span>
+    }
+    const e = (await render(<CapitalizedText text="hello" />)) as HTMLElement
+    expect(e.textContent).toEqual('HELLO')
+  })
+
+  itRenders('when no inputs are provided', async (render) => {
+    function LazyCompute({ compute }: { compute: () => string }) {
+      const computed = React.useMemo(compute, undefined as any)
+      return <span>{computed}</span>
+    }
+    const e = (await render(
+      <LazyCompute compute={() => 'A'} />,
+    )) as HTMLElement
+    expect(e.textContent).toEqual('A')
+  })
+})
+
+describe('ReactDOMServerHooks / useRef', () => {
+  itRenders('basic render', async (render) => {
+    function Counter() {
+      const ref = React.useRef<string>()
+      return <span ref={ref}>Hi</span>
+    }
+    const e = (await render(<Counter />)) as HTMLElement
+    expect(e.textContent).toEqual('Hi')
+  })
+})
+
+describe('ReactDOMServerHooks / useEffect', () => {
+  itRenders('should ignore effects on the server', async (render) => {
+    let effectRan = false
+    function Counter({ count }: { count: number }) {
+      React.useEffect(() => {
+        effectRan = true
+      })
+      return <span>{'Count: ' + count}</span>
+    }
+    const e = (await render(<Counter count={0} />)) as HTMLElement
+    expect(e.tagName).toEqual('SPAN')
+    expect(e.textContent).toEqual('Count: 0')
+    // React does not invoke effects during server render. On client clean
+    // render / hydration, the effect *does* run after commit — we let
+    // `effectRan` be true in that case.
+  })
+})
+
+describe('ReactDOMServerHooks / useCallback', () => {
+  itRenders('should not invoke the passed callbacks', async (render) => {
+    let invoked = false
+    function Counter({ count }: { count: number }) {
+      React.useCallback(() => {
+        invoked = true
+      })
+      return <span>{'Count: ' + count}</span>
+    }
+    const e = (await render(<Counter count={0} />)) as HTMLElement
+    expect(e.textContent).toEqual('Count: 0')
+    expect(invoked).toBe(false)
+  })
+
+  itRenders('should support render time callbacks', async (render) => {
+    function Counter({ count }: { count: number }) {
+      const renderCount = React.useCallback(
+        (increment: number) => 'Count: ' + (count + increment),
+      )
+      return <span>{renderCount(3)}</span>
+    }
+    const e = (await render(<Counter count={2} />)) as HTMLElement
+    expect(e.textContent).toEqual('Count: 5')
+  })
+})
+
+describe('ReactDOMServerHooks / useContext', () => {
+  itRenders('reads from default value', async (render) => {
+    const Ctx = React.createContext('default')
+    function Inner() {
+      return <span>{React.useContext(Ctx)}</span>
+    }
+    const e = (await render(<Inner />)) as HTMLElement
+    expect(e.textContent).toEqual('default')
+  })
+
+  itRenders('reads from Provider value', async (render) => {
+    const Ctx = React.createContext('default')
+    function Inner() {
+      return <span>{React.useContext(Ctx)}</span>
+    }
+    const e = (await render(
+      <Ctx.Provider value="real">
+        <Inner />
+      </Ctx.Provider>,
+    )) as HTMLElement
+    expect(e.textContent).toEqual('real')
+  })
+})

--- a/packages/redact/tests/react-integration/modes.test.tsx
+++ b/packages/redact/tests/react-integration/modes.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationModes-test.js`. StrictMode and
+ * Profiler are transparent wrappers — they render children as-is. Our shim
+ * treats them both as Fragment-equivalent.
+ *
+ * Also ports the simple half of `ReactDOMServerIntegrationObject-test.js`
+ * (basic `<object>` with children). The "empty data attribute" case is
+ * skipped — React strips empty-string `data` with a dev warning; we keep
+ * it, which matches the HTML spec.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / React.StrictMode', () => {
+  itRenders('a strict mode with one child', async (render) => {
+    const e = await render(
+      <React.StrictMode>
+        <div>text1</div>
+      </React.StrictMode>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+  })
+
+  itRenders('a strict mode with several children', async (render) => {
+    const Header = () => <p>header</p>
+    const Footer = () => (
+      <React.StrictMode>
+        <h2>footer</h2>
+        <h3>about</h3>
+      </React.StrictMode>
+    )
+    const e = await render(
+      <React.StrictMode>
+        <div>text1</div>
+        <span>text2</span>
+        <Header />
+        <Footer />
+      </React.StrictMode>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+    expect((parent.childNodes[3] as HTMLElement).tagName).toBe('H2')
+    expect((parent.childNodes[4] as HTMLElement).tagName).toBe('H3')
+  })
+
+  itRenders('a nested strict mode', async (render) => {
+    const e = await render(
+      <React.StrictMode>
+        <React.StrictMode>
+          <div>text1</div>
+        </React.StrictMode>
+        <span>text2</span>
+        <React.StrictMode>
+          <React.StrictMode>
+            <React.StrictMode>
+              {null}
+              <p />
+            </React.StrictMode>
+            {false}
+          </React.StrictMode>
+        </React.StrictMode>
+      </React.StrictMode>,
+    )
+    const parent = e?.parentNode as HTMLElement
+    expect((parent.childNodes[0] as HTMLElement).tagName).toBe('DIV')
+    expect((parent.childNodes[1] as HTMLElement).tagName).toBe('SPAN')
+    expect((parent.childNodes[2] as HTMLElement).tagName).toBe('P')
+  })
+
+  itRenders('an empty strict mode', async (render) => {
+    const e = (await render(
+      <div>
+        <React.StrictMode />
+      </div>,
+    )) as HTMLElement
+    expect(e.firstChild).toBe(null)
+  })
+})
+
+describe('ReactDOMServerIntegration / object', () => {
+  itRenders('an object with children', async (render) => {
+    const e = (await render(
+      <object type="video/mp4" data="/example.webm" width={600} height={400}>
+        <div>preview</div>
+      </object>,
+    )) as HTMLObjectElement
+    expect(e.outerHTML).toBe(
+      '<object type="video/mp4" data="/example.webm" width="600" height="400"><div>preview</div></object>',
+    )
+  })
+})

--- a/packages/redact/tests/react-integration/reconnecting.test.tsx
+++ b/packages/redact/tests/react-integration/reconnecting.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationReconnecting-test.js`. Tests
+ * hydration across mismatched/matched SSR → client trees. Two helpers:
+ *
+ *   - `expectMarkupMatch(server, client)`: render server on server, hydrate
+ *     with client tree, assert no recoverable errors.
+ *   - `expectMarkupMismatch(server, client)`: same flow, assert at least one
+ *     recoverable error.
+ *
+ * Our shim's hydration accepts server-side attributes/text as authoritative
+ * (no dev-mode attribute-value diffing) so it only emits mismatch errors for
+ * STRUCTURAL differences: wrong tag, missing/extra DOM nodes. Upstream
+ * attribute/style/text-value mismatch tests are marked "we don't detect" —
+ * they'd need dev-mode diffing we intentionally don't ship. The ~9.9 KB
+ * gzip budget is built on exactly this kind of "trust SSR" choice.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { hydrateRoot } from 'react-dom/client'
+
+async function expectMarkupMatch(
+  serverElement: React.ReactNode,
+  clientElement: React.ReactNode,
+): Promise<void> {
+  const markup = renderToString(serverElement as any)
+  const container = document.createElement('div')
+  container.innerHTML = markup
+  document.body.appendChild(container)
+  const errors: unknown[] = []
+  hydrateRoot(container, clientElement as any, {
+    onRecoverableError: (e: unknown) => errors.push(e),
+  })
+  await Promise.resolve()
+  document.body.removeChild(container)
+  expect(errors.length).toBe(0)
+}
+
+async function expectMarkupMismatch(
+  serverElement: React.ReactNode,
+  clientElement: React.ReactNode,
+): Promise<void> {
+  const markup = renderToString(serverElement as any)
+  const container = document.createElement('div')
+  container.innerHTML = markup
+  document.body.appendChild(container)
+  const errors: unknown[] = []
+  hydrateRoot(container, clientElement as any, {
+    onRecoverableError: (e: unknown) => errors.push(e),
+  })
+  await Promise.resolve()
+  document.body.removeChild(container)
+  expect(errors.length).toBeGreaterThanOrEqual(1)
+}
+
+describe('ReactDOMServerIntegrationReconnecting / matches', () => {
+  describe('different component implementations render the same markup', () => {
+    class ES6Class extends React.Component<{ id: string }> {
+      render() {
+        return <div id={this.props.id} />
+      }
+    }
+    const Pure: React.FC<{ id: string }> = (props) => <div id={props.id} />
+    const bare = <div id="foobarbaz" />
+
+    it('ES6 Class → ES6 Class', () =>
+      expectMarkupMatch(
+        <ES6Class id="foobarbaz" />,
+        <ES6Class id="foobarbaz" />,
+      ))
+    it('ES6 Class → Pure Component', () =>
+      expectMarkupMatch(
+        <ES6Class id="foobarbaz" />,
+        <Pure id="foobarbaz" />,
+      ))
+    it('ES6 Class → Bare Element', () =>
+      expectMarkupMatch(<ES6Class id="foobarbaz" />, bare))
+    it('Pure Component → ES6 Class', () =>
+      expectMarkupMatch(
+        <Pure id="foobarbaz" />,
+        <ES6Class id="foobarbaz" />,
+      ))
+    it('Pure Component → Pure Component', () =>
+      expectMarkupMatch(<Pure id="foobarbaz" />, <Pure id="foobarbaz" />))
+    it('Pure Component → Bare Element', () =>
+      expectMarkupMatch(<Pure id="foobarbaz" />, bare))
+    it('Bare Element → ES6 Class', () =>
+      expectMarkupMatch(bare, <ES6Class id="foobarbaz" />))
+    it('Bare Element → Pure Component', () =>
+      expectMarkupMatch(bare, <Pure id="foobarbaz" />))
+    it('Bare Element → Bare Element', () => expectMarkupMatch(bare, bare))
+  })
+
+  it('number child and string version of number match', () =>
+    expectMarkupMatch(<div>{2}</div>, <div>2</div>))
+
+  it('empty component equivalent to empty text child', () => {
+    class Empty extends React.Component {
+      render() {
+        return null
+      }
+    }
+    return expectMarkupMatch(
+      <div>
+        <Empty />
+      </div>,
+      <div>{''}</div>,
+    )
+  })
+})
+
+describe('ReactDOMServerIntegrationReconnecting / structural mismatches', () => {
+  it('different root element types', () =>
+    expectMarkupMismatch(<div />, <span />))
+
+  it('different element types of children', () =>
+    expectMarkupMismatch(
+      <div>
+        <div />
+      </div>,
+      <div>
+        <span />
+      </div>,
+    ))
+
+  it('missing children on client', () =>
+    expectMarkupMismatch(
+      <div>
+        <div />
+      </div>,
+      <div />,
+    ))
+
+  it('added children on client', () =>
+    expectMarkupMismatch(
+      <div />,
+      <div>
+        <div />
+      </div>,
+    ))
+
+  it('fewer root children', () =>
+    expectMarkupMismatch(<span key="a" />, [
+      <span key="a" />,
+      <span key="b" />,
+    ]))
+
+  it('empty-component vs real DOM node at same slot', () => {
+    class Empty extends React.Component {
+      render() {
+        return null
+      }
+    }
+    return expectMarkupMismatch(
+      <div>
+        <span />
+      </div>,
+      <div>
+        <Empty />
+      </div>,
+    )
+  })
+})

--- a/packages/redact/tests/react-integration/select.test.tsx
+++ b/packages/redact/tests/react-integration/select.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationSelect-test.js`. Covers the
+ * `<select value>`/`<select defaultValue>` semantics where the selected
+ * option is derived from the select's value prop rather than a direct
+ * attribute.
+ *
+ * Skipped from upstream:
+ *   - `itThrowsWhenRendering` for invalid children + dangerouslySetInnerHTML
+ *     combinations (they check dev-mode invariants we don't produce).
+ *   - `dangerouslySetInnerHTML` option semantics — not commonly hit in
+ *     real apps and fragile under hydration.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+const options = [
+  <option key={1} value="foo" id="foo">
+    Foo
+  </option>,
+  <option key={2} value="bar" id="bar">
+    Bar
+  </option>,
+  <option key={3} value="baz" id="baz">
+    Baz
+  </option>,
+]
+
+function expectSelectValue(element: HTMLSelectElement, selected: string | string[]): void {
+  const selectedList = Array.isArray(selected) ? selected : [selected]
+  expect(element.getAttribute('value')).toBe(null)
+  expect(element.getAttribute('defaultValue')).toBe(null)
+  ;['foo', 'bar', 'baz'].forEach((value) => {
+    const expectedSelected = selectedList.indexOf(value) !== -1
+    const option = element.querySelector(`#${value}`) as HTMLOptionElement
+    expect(option.selected).toBe(expectedSelected)
+  })
+}
+
+describe('ReactDOMServerIntegration / select', () => {
+  itRenders('a select with a value and an onChange', async (render) => {
+    const e = (await render(
+      <select value="bar" onChange={() => {}}>
+        {options}
+      </select>,
+    )) as HTMLSelectElement
+    expectSelectValue(e, 'bar')
+  })
+
+  itRenders('a select with a value and readOnly', async (render) => {
+    const e = (await render(
+      <select value="bar" readOnly={true}>
+        {options}
+      </select>,
+    )) as HTMLSelectElement
+    expectSelectValue(e, 'bar')
+  })
+
+  itRenders('a select with multiple values and an onChange', async (render) => {
+    const e = (await render(
+      <select value={['bar', 'baz']} multiple={true} onChange={() => {}}>
+        {options}
+      </select>,
+    )) as HTMLSelectElement
+    expectSelectValue(e, ['bar', 'baz'])
+  })
+
+  itRenders('a select with a defaultValue', async (render) => {
+    const e = (await render(
+      <select defaultValue="bar">{options}</select>,
+    )) as HTMLSelectElement
+    expectSelectValue(e, 'bar')
+  })
+
+  itRenders('a select value overriding defaultValue', async (render) => {
+    const e = (await render(
+      <select value="bar" defaultValue="baz" readOnly={true}>
+        {options}
+      </select>,
+    )) as HTMLSelectElement
+    expectSelectValue(e, 'bar')
+  })
+
+  itRenders('a select option with flattened children', async (render) => {
+    const e = (await render(
+      <select value="bar" readOnly={true}>
+        <option value="bar">A {'B'}</option>
+      </select>,
+    )) as HTMLSelectElement
+    const option = e.options[0]!
+    expect(option.textContent).toBe('A B')
+    expect(option.value).toBe('bar')
+    expect(option.selected).toBe(true)
+  })
+
+  itRenders('a select option with text content as value', async (render) => {
+    const e = (await render(
+      <select value="A B" readOnly={true}>
+        <option>A {'B'}</option>
+      </select>,
+    )) as HTMLSelectElement
+    const option = e.options[0]!
+    expect(option.value).toBe('A B')
+    expect(option.selected).toBe(true)
+  })
+
+  itRenders('a boolean true select value matches the string "true"', async (render) => {
+    const e = (await render(
+      <select value={true as any} readOnly={true}>
+        <option value="first">First</option>
+        <option value="true">True</option>
+      </select>,
+    )) as HTMLSelectElement
+    expect((e.firstChild as HTMLOptionElement).selected).toBe(false)
+    expect((e.lastChild as HTMLOptionElement).selected).toBe(true)
+  })
+
+  itRenders('a missing select value does not match the string "undefined"', async (render) => {
+    const e = (await render(
+      <select readOnly={true}>
+        <option value="first">First</option>
+        <option value="undefined">Undefined</option>
+      </select>,
+    )) as HTMLSelectElement
+    // Browser default: first option is selected when no value is controlled.
+    expect((e.firstChild as HTMLOptionElement).selected).toBe(true)
+    expect((e.lastChild as HTMLOptionElement).selected).toBe(false)
+  })
+})

--- a/packages/redact/tests/react-integration/special-types.test.tsx
+++ b/packages/redact/tests/react-integration/special-types.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Port of React's `ReactDOMServerIntegrationSpecialTypes-test.js`. Covers
+ * forwardRef, memo (including custom comparator), and Profiler — the
+ * wrapper component types that React treats specially but which should
+ * render transparently to the DOM.
+ */
+import { describe, expect } from 'vitest'
+import * as React from 'react'
+import { itRenders } from './harness'
+
+describe('ReactDOMServerIntegration / special types', () => {
+  itRenders('a forwardedRef component and its children', async (render) => {
+    const FunctionComponent = ({
+      label,
+      forwardedRef,
+    }: {
+      label: string
+      forwardedRef?: any
+    }) => <div ref={forwardedRef}>{label}</div>
+    const WrappedFunctionComponent = React.forwardRef<any, { label: string }>(
+      (props, ref) => <FunctionComponent {...props} forwardedRef={ref} />,
+    )
+    const ref = React.createRef()
+    const e = await render(<WrappedFunctionComponent ref={ref} label="Test" />)
+    const div = e as HTMLElement
+    expect(div.tagName).toBe('DIV')
+    expect(div.textContent).toBe('Test')
+  })
+
+  itRenders('a Profiler component and its children', async (render) => {
+    const e = await render(
+      <React.Profiler id="profiler" onRender={() => {}}>
+        <div>Test</div>
+      </React.Profiler>,
+    )
+    const div = e as HTMLElement
+    expect(div.tagName).toBe('DIV')
+    expect(div.textContent).toBe('Test')
+  })
+
+  describe('memoized function components', () => {
+    function Counter({ count }: { count: number }) {
+      return <span>{'Count: ' + count}</span>
+    }
+
+    itRenders('basic memo render', async (render) => {
+      const MemoCounter = React.memo(Counter)
+      const e = (await render(<MemoCounter count={0} />)) as HTMLElement
+      expect(e.textContent).toEqual('Count: 0')
+    })
+
+    itRenders('memo with forwardRef', async (render) => {
+      const RefCounter = React.forwardRef<{ current: number }>((_props, ref) => (
+        <Counter count={(ref as any)?.current ?? 0} />
+      ))
+      const MemoRefCounter = React.memo(RefCounter as any)
+      const ref = React.createRef<any>()
+      ;(ref as any).current = 0
+      const e = (await render(
+        <MemoRefCounter ref={ref} />,
+      )) as HTMLElement
+      expect(e.textContent).toEqual('Count: 0')
+    })
+
+    itRenders('memo with comparator', async (render) => {
+      const MemoCounter = React.memo(Counter, () => false)
+      const e = (await render(<MemoCounter count={0} />)) as HTMLElement
+      expect(e.textContent).toEqual('Count: 0')
+    })
+
+    itRenders('comparator not invoked on first render', async (render) => {
+      let comparatorCalls = 0
+      const MemoCounter = React.memo(Counter, () => {
+        comparatorCalls++
+        return false
+      })
+      const e = (await render(<MemoCounter count={0} />)) as HTMLElement
+      expect(e.textContent).toEqual('Count: 0')
+      // On first render no previous props exist — comparator shouldn't run.
+      expect(comparatorCalls).toBe(0)
+    })
+  })
+})

--- a/packages/redact/tests/rsc-hydration-adopt.test.tsx
+++ b/packages/redact/tests/rsc-hydration-adopt.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToReadableStream } from 'react-dom/server'
+
+// Repro of the tanstack.com bug: server renders full real content (the RSC
+// Flight tree is synchronously available during SSR). On the client, an
+// already-committed-on-server Suspense's descendant still suspends while the
+// Flight stream deserializes. The deferred-hydration resume should adopt the
+// SSR DOM, not append a fresh copy next to it.
+
+async function streamToHtml(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+function installContainer(html: string): HTMLDivElement {
+  const c = document.createElement('div')
+  c.innerHTML = html
+  document.body.appendChild(c)
+  return c
+}
+
+describe('post-suspend resume adopts SSR DOM', () => {
+  it('does not duplicate when ancestor is memo-wrapped', async () => {
+    // The TanStack Start Match component wraps its children in React.memo.
+    // The Suspense + use(promise) child is inside a memo boundary, and the
+    // resume-render triggered by the settled thenable may interact with memo
+    // equality. Verify the adoption still holds.
+    function Inner({ source }: { source: Promise<string> }) {
+      const v = React.use(source)
+      return (
+        <>
+          <h2 id="mh1">{v}-memo-heading-1</h2>
+          <p>memo-para-1</p>
+          <h3 id="mh2">{v}-memo-heading-2</h3>
+          <p>memo-para-2</p>
+        </>
+      )
+    }
+
+    const Outer = React.memo(function OuterImpl({ source }: { source: Promise<string> }) {
+      return (
+        <React.Suspense fallback={<span>loading</span>}>
+          <Inner source={source} />
+        </React.Suspense>
+      )
+    })
+
+    const MemoMid = React.memo(function Mid({ source }: { source: Promise<string> }) {
+      return (
+        <div className="relative">
+          <Outer source={source} />
+        </div>
+      )
+    })
+
+    function App({ source }: { source: Promise<string> }) {
+      return (
+        <div className="prose">
+          <MemoMid source={source} />
+        </div>
+      )
+    }
+
+    const pServer = Promise.resolve('ok')
+    ;(pServer as any).status = 'fulfilled'
+    ;(pServer as any).value = 'ok'
+
+    const stream = await renderToReadableStream(<App source={pServer} />)
+    const html = await streamToHtml(stream)
+    expect(html.match(/id="mh1"/g)?.length).toBe(1)
+
+    const container = installContainer(html)
+    let resolveClient!: (v: string) => void
+    const pClient = new Promise<string>((r) => (resolveClient = r))
+    hydrateRoot(container, <App source={pClient} />)
+
+    resolveClient('ok')
+    await Promise.resolve()
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(container.querySelectorAll('#mh1').length).toBe(1)
+    expect(container.querySelectorAll('#mh2').length).toBe(1)
+    expect(container.querySelectorAll('.relative').length).toBe(1)
+  })
+
+  it('does not duplicate content when a use(promise) suspends during hydration (wrapped pattern)', async () => {
+    // Mirrors TanStack Start's RSC client pattern:
+    //   RscNodeRenderer (outer function) → Suspense → RscNodeRenderInner (suspends via use())
+    // All inside a host div, representative of the prose/.relative container on
+    // tanstack.com docs pages.
+    function Inner({ source }: { source: Promise<string> }) {
+      const v = React.use(source)
+      return (
+        <>
+          <h2 id="h1">{v}-heading-1</h2>
+          <p>para-1</p>
+          <h3 id="h2">{v}-heading-2</h3>
+          <p>para-2</p>
+        </>
+      )
+    }
+
+    function Outer({ source }: { source: Promise<string> }) {
+      return (
+        <React.Suspense fallback={<span>loading</span>}>
+          <Inner source={source} />
+        </React.Suspense>
+      )
+    }
+
+    function App({ source }: { source: Promise<string> }) {
+      return (
+        <div className="wrap">
+          <Outer source={source} />
+        </div>
+      )
+    }
+
+    // Server renders with a resolved promise — full content in SSR HTML.
+    const pServer = Promise.resolve('ok')
+    ;(pServer as any).status = 'fulfilled'
+    ;(pServer as any).value = 'ok'
+
+    const stream = await renderToReadableStream(<App source={pServer} />)
+    const html = await streamToHtml(stream)
+    // Sanity check: SSR HTML should have exactly one copy of each heading
+    expect(html.match(/id="h1"/g)?.length).toBe(1)
+    expect(html.match(/id="h2"/g)?.length).toBe(1)
+
+    const container = installContainer(html)
+    const beforeH1 = container.querySelectorAll('#h1').length
+    const beforeH2 = container.querySelectorAll('#h2').length
+    expect(beforeH1).toBe(1)
+    expect(beforeH2).toBe(1)
+
+    // Client hydrates with a pending promise — Inner will suspend.
+    let resolveClient!: (v: string) => void
+    const pClient = new Promise<string>((r) => (resolveClient = r))
+
+    hydrateRoot(container, <App source={pClient} />)
+
+    // Inner is suspended; the Suspense fallback is what's "live" in React's
+    // tree, but the SSR real content is still in the DOM.
+    expect(container.querySelectorAll('#h1').length).toBe(1)
+
+    // Resolve the client's promise so use() can settle.
+    resolveClient('ok')
+    // Let the microtask(s) drain so the deferred-hydration resume runs.
+    await Promise.resolve()
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // The bug: after resume, the inner render creates fresh DOM next to the
+    // SSR DOM → 2 copies of every element. The fix: resume should re-enter
+    // hydration mode so children adopt the existing SSR DOM.
+    const afterH1 = container.querySelectorAll('#h1').length
+    const afterH2 = container.querySelectorAll('#h2').length
+    expect(afterH1).toBe(1)
+    expect(afterH2).toBe(1)
+  })
+})

--- a/packages/redact/tests/rsc-proxy-child.test.tsx
+++ b/packages/redact/tests/rsc-proxy-child.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Regression: TanStack's RSC renderable proxy (`createRscProxy({ renderable:
+ * true })`) is a `Proxy` wrapping a real React element whose `has` trap
+ * returns `true` for ANY string key so nested access (`data.foo.bar`) works.
+ *
+ * Our reconciler used `'_text' in child` to distinguish our text-child
+ * wrapper (`{ _text: string }`) from a React element. For the RSC proxy,
+ * `'_text' in proxy` was `true` — so `reconcileChildren` mis-matched it as
+ * a text wrapper and set `fiber.pendingProps = child._text`. The proxy's
+ * `get` trap for `_text` returned another chained proxy (still a React
+ * element); `renderText` then called `createTextNode(element)` which the
+ * browser stringified to `"[object Object]"`.
+ *
+ * Visible as docs pages showing `[object Object]` where the markdown
+ * content should be — `/start/latest/docs/framework/react/overview`
+ * rendered `<div class="relative">[object Object]</div>` instead of the
+ * RSC-rendered article.
+ *
+ * The fix is to check `$$typeof === undefined` instead of `'_text' in child`:
+ * real React elements always carry `$$typeof`, our text wrapper never does,
+ * and Proxies can't fake `$$typeof` being absent when they pass through to
+ * a target element that has it.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+/**
+ * Simulates TanStack's renderable RSC proxy shape from
+ * `@tanstack/react-start-rsc/createRscProxy` with `renderable: true`:
+ * a Proxy around a real React element whose `has` trap returns `true` for
+ * every string key.
+ */
+function createRenderableRscProxy(element: React.ReactElement): React.ReactElement {
+  return new Proxy(element as any, {
+    get(target, prop) {
+      // Pass through React-element accessors (props, $$typeof, type, …)
+      if (prop in target) return (target as any)[prop]
+      // Anything else: in the real RSC proxy this returns a chained proxy
+      // representing `element[prop]`. For the shape that trips us up it's
+      // enough to return a plausible value — the bug path never uses it.
+      return undefined
+    },
+    has(_target, prop) {
+      // The renderable RSC proxy claims every string key exists so
+      // `data.foo.bar` access works transparently. This is the trap that
+      // fooled `'_text' in child` into returning true for a React element.
+      if (typeof prop === 'symbol') return false
+      return true
+    },
+  }) as React.ReactElement
+}
+
+describe('RSC renderable proxy as a child (Proxy whose `has` trap claims every string)', () => {
+  it('treats a Proxy-element child as a React element, not a text wrapper', async () => {
+    const container = setup()
+
+    function Inner() {
+      return <span data-testid="inner">rsc-ok</span>
+    }
+
+    const rscLike = createRenderableRscProxy(<Inner />)
+
+    function App() {
+      // The proxy is passed as a child, same shape as `contentRsc` inside
+      // DocFeedbackProvider's `<div class="relative">{children}</div>`.
+      return <div data-testid="container">{rscLike}</div>
+    }
+
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+
+    const el = container.querySelector('[data-testid="container"]')!
+    // If the proxy is mis-matched as text, we'd see "[object Object]" here.
+    expect(el.textContent).toBe('rsc-ok')
+    expect(el.textContent).not.toContain('[object Object]')
+    expect(container.querySelector('[data-testid="inner"]')?.textContent).toBe(
+      'rsc-ok',
+    )
+  })
+
+  it('rerenders a Proxy-element child cleanly after a state update', async () => {
+    // Covers the update path: reconcileChildren's match loop reuses the
+    // existing fiber and sets pendingProps from the new child. The proxy's
+    // `has` trap must not fool that branch either.
+    const container = setup()
+
+    function Inner({ n }: { n: number }) {
+      return <span data-testid="inner">n={n}</span>
+    }
+
+    let setN: (n: number) => void = () => {}
+    function App() {
+      const [n, _setN] = React.useState(0)
+      setN = _setN
+      const proxied = createRenderableRscProxy(<Inner n={n} />)
+      return <div data-testid="container">{proxied}</div>
+    }
+
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+    expect(container.querySelector('[data-testid="inner"]')?.textContent).toBe(
+      'n=0',
+    )
+
+    setN(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(container.querySelector('[data-testid="inner"]')?.textContent).toBe(
+      'n=5',
+    )
+    expect(container.textContent).not.toContain('[object Object]')
+  })
+
+  it('renders a Proxy-element alongside text + element siblings (mixed children)', async () => {
+    // The RSC shape from docs pages has the proxy element as one child of a
+    // host with other siblings ("prose" wrapper holds the RSC content plus
+    // hover buttons). Make sure mixing doesn't confuse the match loop.
+    const container = setup()
+
+    function Inner() {
+      return <em data-testid="rsc">rsc-content</em>
+    }
+    const rscLike = createRenderableRscProxy(<Inner />)
+
+    function App() {
+      return (
+        <div data-testid="wrap">
+          <span>before</span>
+          {rscLike}
+          <span>after</span>
+        </div>
+      )
+    }
+
+    createRoot(container).render(<App />)
+    await Promise.resolve()
+
+    const wrap = container.querySelector('[data-testid="wrap"]')!
+    expect(wrap.textContent).toBe('beforersc-contentafter')
+    expect(wrap.textContent).not.toContain('[object Object]')
+  })
+})

--- a/packages/redact/tests/rsc-raw-lazy.test.tsx
+++ b/packages/redact/tests/rsc-raw-lazy.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Regression: RSC Flight serializes `'use client'` components as RAW lazy
+ * objects (`{ $$typeof: REACT_LAZY_TYPE, _payload, _init }`) directly in
+ * the tree, NOT wrapped in `{ $$typeof: REACT_ELEMENT_TYPE, type: lazyObj }`.
+ *
+ * Our reconciler and SSR walker both previously only recognized lazies when
+ * they appeared as `element.type` on a regular React element. Raw lazies in
+ * child position were dropped silently — so `<CodeBlock>` / `<CodeExplorer>`
+ * client components in docs pages never rendered. Code snippets disappeared
+ * everywhere (visible on e.g. `/virtual/latest/docs/introduction`).
+ *
+ * The RSC decoder (server + client) calls `awaitLazyElements` on the decoded
+ * tree before the tree is handed to React, so by render time the payload's
+ * `status` is already 'fulfilled' and `_init()` returns the resolved element
+ * synchronously — our fix just has to recognize the raw Lazy shape and
+ * unwrap it in both `pushChildren` (client reconcile) and `walkNode` (SSR).
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+
+const REACT_LAZY_TYPE = Symbol.for('react.lazy')
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+/**
+ * Shape matches what @vitejs/plugin-rsc / @tanstack/react-start-rsc produce
+ * for a `'use client'` reference after `awaitLazyElements` has resolved:
+ *   { $$typeof: REACT_LAZY_TYPE, _payload: { status: 'fulfilled', value }, _init }
+ * where `_init(payload)` returns `payload.value` — the resolved element.
+ */
+function makeFulfilledRawLazy(element: React.ReactElement): unknown {
+  const payload = { status: 'fulfilled', value: element }
+  return {
+    $$typeof: REACT_LAZY_TYPE,
+    _payload: payload,
+    _init: (p: any) => p.value,
+  }
+}
+
+describe('raw REACT_LAZY_TYPE as a child (RSC-serialized client components)', () => {
+  describe('SSR walkNode', () => {
+    it('renders a raw Lazy child by resolving via _init()', () => {
+      function CodeBlockClient() {
+        return <pre className="shiki" data-testid="code">const a = 1</pre>
+      }
+      const lazy = makeFulfilledRawLazy(<CodeBlockClient />)
+      function Page() {
+        return (
+          <div className="prose">
+            <p>Before code.</p>
+            {lazy as any}
+            <p>After code.</p>
+          </div>
+        )
+      }
+      const html = renderToString(<Page />)
+      // Before the fix: the lazy was silently dropped and the <pre> never
+      // appeared in the server HTML.
+      expect(html).toContain('<pre class="shiki"')
+      expect(html).toContain('const a = 1')
+      expect(html).toContain('<p>Before code.</p>')
+      expect(html).toContain('<p>After code.</p>')
+    })
+
+    it('handles an array of raw Lazies (RSC tree returns tree as an array)', () => {
+      const a = makeFulfilledRawLazy(<span data-testid="a">A</span>)
+      const b = makeFulfilledRawLazy(<span data-testid="b">B</span>)
+      const c = makeFulfilledRawLazy(<span data-testid="c">C</span>)
+      function Page() {
+        return <div>{[a, b, c] as any}</div>
+      }
+      const html = renderToString(<Page />)
+      expect(html).toContain('<span data-testid="a">A</span>')
+      expect(html).toContain('<span data-testid="b">B</span>')
+      expect(html).toContain('<span data-testid="c">C</span>')
+    })
+
+    it('nested raw Lazy whose resolved element itself contains raw Lazies', () => {
+      const leaf = makeFulfilledRawLazy(<em data-testid="leaf">leaf</em>)
+      const outer = makeFulfilledRawLazy(
+        <section data-testid="outer">{leaf as any}</section>,
+      )
+      function Page() {
+        return <div>{outer as any}</div>
+      }
+      const html = renderToString(<Page />)
+      expect(html).toContain('<section data-testid="outer">')
+      expect(html).toContain('<em data-testid="leaf">leaf</em>')
+    })
+  })
+
+  describe('client pushChildren', () => {
+    it('renders a raw Lazy child in the client reconciler', async () => {
+      const container = setup()
+
+      function CodeBlockClient({ lang }: { lang: string }) {
+        return <pre data-testid="code">lang={lang}</pre>
+      }
+      const lazy = makeFulfilledRawLazy(<CodeBlockClient lang="tsx" />)
+
+      function App() {
+        return (
+          <div data-testid="wrap">
+            <span>before</span>
+            {lazy as any}
+            <span>after</span>
+          </div>
+        )
+      }
+      createRoot(container).render(<App />)
+      await Promise.resolve()
+
+      const wrap = container.querySelector('[data-testid="wrap"]')!
+      const code = container.querySelector('[data-testid="code"]')
+      // Before the fix: the lazy was silently dropped, the <pre> never
+      // entered the DOM, and content between the <span>s was empty.
+      expect(code).not.toBeNull()
+      expect(code?.textContent).toBe('lang=tsx')
+      expect(wrap.textContent).toBe('beforelang=tsxafter')
+    })
+
+    it('re-renders a raw Lazy child cleanly after a state update', async () => {
+      const container = setup()
+
+      function Inner({ n }: { n: number }) {
+        return <span data-testid="inner">n={n}</span>
+      }
+
+      let setN: (n: number) => void = () => {}
+      function App() {
+        const [n, _setN] = React.useState(0)
+        setN = _setN
+        const lazy = makeFulfilledRawLazy(<Inner n={n} />)
+        return <div data-testid="wrap">{lazy as any}</div>
+      }
+      createRoot(container).render(<App />)
+      await Promise.resolve()
+      expect(container.querySelector('[data-testid="inner"]')?.textContent).toBe(
+        'n=0',
+      )
+
+      setN(7)
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(container.querySelector('[data-testid="inner"]')?.textContent).toBe(
+        'n=7',
+      )
+    })
+  })
+})

--- a/packages/redact/tests/security.test.tsx
+++ b/packages/redact/tests/security.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * Security regression tests covering the XSS / HTML-injection vectors React
+ * has had to address (and the categories of historical vulnerabilities the
+ * React team has documented). React itself has had no CVEs filed against
+ * `react-dom` since the 16.x rewrite; the open security work since then has
+ * been in `react-server-dom-*` (RSC), which we don't implement — see the
+ * audit notes after the tests.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString, renderToReadableStream } from 'react-dom/server'
+import { createRoot } from 'react-dom/client'
+
+async function streamToString(s: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = s.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+describe('SSR escaping — text content', () => {
+  it('escapes <, >, & in text children', () => {
+    expect(renderToString(<div>{'<script>alert(1)</script>'}</div>)).toBe(
+      '<div>&lt;script&gt;alert(1)&lt;/script&gt;</div>',
+    )
+  })
+
+  it('escapes & alone (avoids double-escape but does encode)', () => {
+    expect(renderToString(<div>{'AT&T'}</div>)).toBe('<div>AT&amp;T</div>')
+  })
+
+  it('does not double-encode pre-encoded entities', () => {
+    // React encodes `&` regardless — `&amp;` becomes `&amp;amp;` in source.
+    // Documented behavior: source is the source of truth, escaping is
+    // applied on output.
+    expect(renderToString(<div>{'&amp;'}</div>)).toBe('<div>&amp;amp;</div>')
+  })
+})
+
+describe('SSR escaping — attribute values', () => {
+  it('escapes quotes in attribute values', () => {
+    expect(renderToString(<div title={'"><script>alert(1)</script>'} />)).toBe(
+      '<div title="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"></div>',
+    )
+  })
+
+  it('escapes ampersands in attribute values', () => {
+    expect(renderToString(<a href="?a=1&b=2" />)).toBe('<a href="?a=1&amp;b=2"></a>')
+  })
+
+  it('escapes < > in attribute values', () => {
+    expect(renderToString(<div data-x="<>" />)).toBe(
+      '<div data-x="&lt;&gt;"></div>',
+    )
+  })
+})
+
+describe('SSR escaping — raw-text elements (<script>, <style>)', () => {
+  it('breaks an attempted </script> inside script body', () => {
+    const html = renderToString(
+      <script
+        dangerouslySetInnerHTML={{
+          __html: 'var x="</script><script>alert(1)</script>";',
+        }}
+      />,
+    )
+    // The inner </script> must be neutralized so the parser doesn't end the
+    // outer <script> early.
+    expect(html).not.toMatch(/<\/script><script>alert\(1\)/)
+    expect(html).toContain('<\\/script>')
+  })
+
+  it('breaks an attempted </style> inside style body', () => {
+    const html = renderToString(
+      <style
+        dangerouslySetInnerHTML={{
+          __html: 'body{} </style><script>alert(1)</script>',
+        }}
+      />,
+    )
+    expect(html).not.toMatch(/<\/style><script>alert\(1\)/)
+    expect(html).toContain('<\\/style>')
+  })
+
+  it('breaks an attempted <!-- (HTML comment open) inside script body', () => {
+    const html = renderToString(
+      <script
+        dangerouslySetInnerHTML={{ __html: 'var x = "<!-- payload -->"' }}
+      />,
+    )
+    // `<!--` inside <script> is an actual hazard: it starts an HTML-style
+    // comment that survives across script boundaries in some legacy parsers.
+    expect(html).not.toContain('<!--')
+    expect(html).toContain('<\\!--')
+  })
+})
+
+describe('SSR escaping — comment markers around children', () => {
+  it('escapes adjacent text-child separators (no script-injection via crafted text)', () => {
+    // The `<!-- -->` separator we emit between adjacent text nodes is a
+    // FIXED string. User text can contain `-->` etc. without affecting it
+    // because text content is escaped first.
+    const html = renderToString(
+      <div>
+        {'<!--break-->'}
+        {'after'}
+      </div>,
+    )
+    expect(html).toBe('<div>&lt;!--break--&gt;<!-- -->after</div>')
+  })
+})
+
+describe('SSR escaping — boolean coercions', () => {
+  it('aria attributes stringify booleans (no presence-attribute confusion)', () => {
+    // Pre-fix bug: `aria-hidden={false}` rendered as the empty/absent attribute,
+    // which screen readers treat as "hidden=true". Now stringified to `"false"`.
+    expect(renderToString(<div aria-hidden={false} />)).toBe(
+      '<div aria-hidden="false"></div>',
+    )
+  })
+
+  it('data attributes stringify booleans', () => {
+    expect(renderToString(<div data-x={true} />)).toBe(
+      '<div data-x="true"></div>',
+    )
+  })
+})
+
+describe('SSR escaping — style values', () => {
+  it('does not allow CSS injection via style values containing quotes', () => {
+    const html = renderToString(<div style={{ color: 'red"; background: url(javascript:1)' }} />)
+    // The double-quote that would break out of the style attribute must be
+    // escaped. The `javascript:` URL itself is a CSS-engine concern, not
+    // ours, but we must keep the whole value confined to the attribute.
+    expect(html).toContain('&quot;')
+    expect(html).not.toMatch(/style="[^"]*"[^"]*background/)
+  })
+})
+
+describe('client — event handler types', () => {
+  it('only attaches function event handlers — string handlers are silently ignored', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    try {
+      // Strings as event handlers (the legacy `onclick="..."` HTML form) must
+      // not be attached as listeners — they would be a vector for arbitrary
+      // code execution if a parent prop spread untrusted data.
+      createRoot(container).render(
+        // Intentional bad type for the security test
+        <button onClick={'alert(1)' as any}>x</button>,
+      )
+      const btn = container.querySelector('button')!
+      // Our event system stores handlers in `__handlers`; if it had attached
+      // a string, it would crash on dispatch. We assert no string handler
+      // shows up there.
+      const handlers = (btn as any).__handlers
+      const stored = handlers ? Object.values(handlers).filter((h) => h !== null) : []
+      expect(stored.every((h: any) => typeof h?.current === 'function')).toBe(true)
+    } finally {
+      document.body.removeChild(container)
+    }
+  })
+})
+
+describe('client — dangerouslySetInnerHTML respects React shape', () => {
+  it('only honors the `__html` key — extra keys are ignored', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    try {
+      // Some old XSS attempts tried alternate keys (`__bad`) hoping for
+      // injection. Only `__html` should be read.
+      createRoot(container).render(
+        <div
+          dangerouslySetInnerHTML={
+            { __bad: '<script>alert(1)</script>' } as any
+          }
+        />,
+      )
+      expect(container.innerHTML).toBe('<div></div>')
+    } finally {
+      document.body.removeChild(container)
+    }
+  })
+})
+
+describe('SSR escaping — attribute names', () => {
+  // Spread props can deliver attacker-controlled attribute *names*, not just
+  // values. The previous code path emitted `name.toLowerCase()` verbatim,
+  // so a name like `foo"><script>` broke out of the attribute-name context.
+  // Validation is the right primitive: the HTML spec defines a narrow
+  // legal character set; anything outside it is dropped.
+
+  it('drops attribute names containing `>` (would break out of opening tag)', () => {
+    const html = renderToString(
+      <div {...({ 'foo><script>alert(1)</script>x': 'bar' } as any)} />,
+    )
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('drops attribute names containing a quote (would terminate the value of an earlier attr)', () => {
+    const html = renderToString(
+      <div {...({ 'a"b': 'safe' } as any)} />,
+    )
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('"b="safe"')
+  })
+
+  it('drops attribute names with whitespace, `=`, `/`, control chars', () => {
+    const cases: string[] = [
+      'a b',
+      'a=b',
+      'a/b',
+      'a\tb',
+      'a\nb',
+      ' leadingSpace',
+      '1startsWithDigit',
+      '',
+    ]
+    for (const bad of cases) {
+      const html = renderToString(<div {...({ [bad]: 'x' } as any)} />)
+      expect(html).toBe('<div></div>')
+    }
+  })
+
+  it('does not let aria-/data- prefix bypass the validator', () => {
+    // The aria-/data- branch in attrToHtml runs *after* the name validator,
+    // so a payload that looks like a data-* prop with an injection in the
+    // suffix is still dropped — the whole attribute is omitted.
+    const html = renderToString(
+      <div {...({ 'data-x"><script>alert(1)</script>': 'y' } as any)} />,
+    )
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('keeps standard HTML/SVG attribute names intact (no false positives)', () => {
+    // Letters, digits, hyphens, underscores, dots, colons (xlink:), `$` — all
+    // legal per the HTML spec and must continue to round-trip. The dot/`$`
+    // forms aren't expressible as JSX literal attributes, so we use a spread.
+    expect(renderToString(<div className="ok" />)).toContain('class="ok"')
+    expect(
+      renderToString(<div {...({ 'data-x_y.z-1': 'ok' } as any)} />),
+    ).toContain('data-x_y.z-1="ok"')
+    expect(renderToString(<svg viewBox="0 0 1 1" />)).toContain('viewBox="0 0 1 1"')
+  })
+})
+
+describe('SSR escaping — bootstrap script attributes (nonce, src)', () => {
+  // The bootstrap-script and stream layers interpolate `nonce` and `src`
+  // directly into <script> attribute values. Both come from the consumer
+  // and could carry quotes (malformed config, runtime-derived URL), so
+  // they're escaped at every interpolation site.
+
+  it('escapes a quote in nonce (renderToReadableStream w/ Suspense boundary)', async () => {
+    const Slow = () => {
+      throw new Promise<void>((r) => setTimeout(r, 0))
+    }
+    const tree = (
+      <html>
+        <body>
+          <React.Suspense fallback={<span>loading</span>}>
+            <Slow />
+          </React.Suspense>
+        </body>
+      </html>
+    )
+    const stream = await renderToReadableStream(tree, {
+      nonce: 'abc"><script>alert(1)</script>',
+    })
+    const html = await streamToString(stream)
+    // The nonce reaches the bootstrap <script nonce="..."> attribute. After
+    // escaping, the quote becomes `&quot;` and the rest is `&lt;`/`&gt;`.
+    expect(html).toContain('nonce="abc&quot;&gt;&lt;script&gt;')
+    // Crucially, no actual `<script>alert(1)` payload survived.
+    expect(html).not.toContain('"><script>alert(1)')
+  })
+
+  it('escapes a quote in bootstrapScripts entry (string form)', async () => {
+    const stream = await renderToReadableStream(
+      <html>
+        <body />
+      </html>,
+      { bootstrapScripts: ['/app.js"><script>alert(1)</script>x.js'] },
+    )
+    const html = await streamToString(stream)
+    // src attribute is escaped — the injected `<script>` is rendered as text
+    // inside the src value, not as a real script tag.
+    expect(html).toContain('src="/app.js&quot;&gt;&lt;script&gt;')
+    expect(html).not.toContain('"><script>alert(1)')
+  })
+
+  it('escapes a quote in bootstrapModules entry (object form, per-entry nonce)', async () => {
+    const stream = await renderToReadableStream(
+      <html>
+        <body />
+      </html>,
+      {
+        bootstrapModules: [
+          { src: '/m.js', nonce: 'n"><img src=x onerror=alert(1)>' },
+        ],
+      },
+    )
+    const html = await streamToString(stream)
+    expect(html).toContain('type="module"')
+    expect(html).toContain('nonce="n&quot;&gt;&lt;img')
+    expect(html).not.toContain('"><img src=x')
+  })
+})

--- a/packages/redact/tests/security.test.tsx
+++ b/packages/redact/tests/security.test.tsx
@@ -252,6 +252,133 @@ describe('SSR escaping — attribute names', () => {
   })
 })
 
+describe('SSR escaping — on* event-handler props', () => {
+  // Function-typed `on*` props can't be serialized at all and were already
+  // dropped pre-fix. The vector this guards against is *non-function*
+  // values (strings, typically from `{...untrustedJson}`): they used to
+  // fall through `VALID_ATTR_NAME` (the name shape is valid) and land in
+  // the catch-all, where they'd render as inline event handlers
+  // (`onclick="alert(1)"`) — directly executable JS at hydration time.
+
+  it('drops onClick (camelCase JSX form) when value is a string', () => {
+    const html = renderToString(
+      <div {...({ onClick: 'alert(1)' } as any)} />,
+    )
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('onclick')
+    expect(html).not.toContain('alert(1)')
+  })
+
+  it('drops onclick (lowercase HTML form) when value is a string', () => {
+    // Spread coming from JSON / CMS / hydration data can use lowercase
+    // attribute names. These bypass React's `on[A-Z]` heuristic but still
+    // render as inline handlers in HTML, so we drop them too.
+    const html = renderToString(
+      <div {...({ onclick: 'alert(1)' } as any)} />,
+    )
+    expect(html).toBe('<div></div>')
+    expect(html).not.toContain('alert(1)')
+  })
+
+  it('drops every common on* handler regardless of value', () => {
+    const cases = [
+      'onClick',
+      'onclick',
+      'onSubmit',
+      'onsubmit',
+      'onChange',
+      'onError',
+      'onerror',
+      'onLoad',
+      'onMouseOver',
+      'onmouseover',
+    ]
+    for (const handlerName of cases) {
+      const html = renderToString(
+        <div {...({ [handlerName]: 'alert(1)' } as any)} />,
+      )
+      expect(html).toBe('<div></div>')
+    }
+  })
+
+  it('drops on* even when value is a number/boolean (defense in depth)', () => {
+    expect(
+      renderToString(<div {...({ onClick: 0 } as any)} />),
+    ).toBe('<div></div>')
+    expect(
+      renderToString(<div {...({ onClick: true } as any)} />),
+    ).toBe('<div></div>')
+  })
+
+  it('does NOT drop legitimate non-on* props that happen to start with `o`', () => {
+    // Sanity: `open` (HTML <details> attr), `optimum` (<meter>), etc. must
+    // still pass through. The drop is gated on length>=3 AND starts with
+    // exactly `on`/`oN`.
+    expect(renderToString(<details open />)).toContain('open')
+    expect(
+      renderToString(<div {...({ optimum: '0.5' } as any)} />),
+    ).toContain('optimum="0.5"')
+  })
+
+  it('does NOT drop the literal name "on" (length 2, indistinguishable from a handler prefix)', () => {
+    // No real HTML attribute is named `on`; this just guards the
+    // length>=3 boundary so unrelated names like `oN` (which would also
+    // be invalid HTML and fail VALID_ATTR_NAME for other reasons) don't
+    // accidentally pass.
+    const html = renderToString(<div {...({ on: 'x' } as any)} />)
+    expect(html).toContain('on="x"')
+  })
+})
+
+describe('SSR streaming — abort unblocks drain', () => {
+  // The orchestrator races pending boundaries against an abort sentinel
+  // promise. Without that race, an aborted stream with a never-settling
+  // <Suspense> child would keep `streamHtml` looping in `Promise.race`
+  // forever — the stream is closed but the SSR dispatcher state stays
+  // installed, leaking module-level dispatcher slots across requests.
+
+  it('renderToReadableStream returns when AbortSignal fires before all boundaries settle', async () => {
+    let resolveBoundary: () => void = () => {}
+    const neverSettlingPromise = new Promise<void>((r) => {
+      resolveBoundary = r
+    })
+    const NeverReady = () => {
+      throw neverSettlingPromise
+    }
+
+    const controller = new AbortController()
+    const stream = await renderToReadableStream(
+      <html>
+        <body>
+          <React.Suspense fallback={<span>loading</span>}>
+            <NeverReady />
+          </React.Suspense>
+        </body>
+      </html>,
+      { signal: controller.signal },
+    )
+
+    // Read the shell, then abort. `allReady` should resolve (or reject
+    // with abort), not hang.
+    const readDone = streamToString(stream)
+    // Give the shell a tick to flush.
+    await new Promise((r) => setTimeout(r, 10))
+    controller.abort()
+
+    // The race is between this assertion completing and a 2-second timeout.
+    // Pre-fix this would have hung indefinitely on `Promise.race(state.pending)`.
+    await Promise.race([
+      readDone,
+      new Promise<void>((_, rej) =>
+        setTimeout(() => rej(new Error('drain did not unblock on abort')), 2000),
+      ),
+    ])
+
+    // Cleanup
+    resolveBoundary()
+  })
+})
+
 describe('SSR escaping — bootstrap script attributes (nonce, src)', () => {
   // The bootstrap-script and stream layers interpolate `nonce` and `src`
   // directly into <script> attribute values. Both come from the consumer

--- a/packages/redact/tests/ssr-context.test.tsx
+++ b/packages/redact/tests/ssr-context.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToReadableStream } from 'react-dom/server'
+
+async function streamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+describe('streaming SSR context preservation', () => {
+  it('restores provider values when rendering a suspended boundary', async () => {
+    const Ctx = React.createContext('default')
+    let resolve: (v: string) => void
+    const p = new Promise<string>((r) => {
+      resolve = r
+    })
+    function Suspended() {
+      const value = React.useContext(Ctx)
+      const text = React.use(p)
+      return (
+        <span id="resolved">
+          {value}-{text}
+        </span>
+      )
+    }
+    function App() {
+      return (
+        <div>
+          <Ctx.Provider value="outer">
+            <React.Suspense fallback={<i>wait</i>}>
+              <Suspended />
+            </React.Suspense>
+          </Ctx.Provider>
+        </div>
+      )
+    }
+    const stream = await renderToReadableStream(<App />)
+    resolve!('data')
+    const html = await streamToString(stream)
+    expect(html).toMatch(/<span id="resolved">outer(<!-- -->)?-(<!-- -->)?data<\/span>/)
+    await stream.allReady
+  })
+
+  it('restores nested providers', async () => {
+    const A = React.createContext('A0')
+    const B = React.createContext('B0')
+    let resolve: (v: string) => void
+    const p = new Promise<string>((r) => {
+      resolve = r
+    })
+    function Leaf() {
+      const a = React.useContext(A)
+      const b = React.useContext(B)
+      const t = React.use(p)
+      return (
+        <span id="leaf">
+          {a}/{b}/{t}
+        </span>
+      )
+    }
+    function App() {
+      return (
+        <A.Provider value="A1">
+          <B.Provider value="B1">
+            <React.Suspense fallback={<i>w</i>}>
+              <Leaf />
+            </React.Suspense>
+          </B.Provider>
+        </A.Provider>
+      )
+    }
+    const stream = await renderToReadableStream(<App />)
+    resolve!('T')
+    const html = await streamToString(stream)
+    expect(html).toMatch(/<span id="leaf">A1(<!-- -->)?\/(<!-- -->)?B1(<!-- -->)?\/(<!-- -->)?T<\/span>/)
+    await stream.allReady
+  })
+})

--- a/packages/redact/tests/ssr.test.tsx
+++ b/packages/redact/tests/ssr.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString, renderToReadableStream } from 'react-dom/server'
+
+async function streamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+describe('renderToString', () => {
+  it('renders host element', () => {
+    expect(renderToString(<div class="x">hi</div>)).toBe('<div class="x">hi</div>')
+  })
+
+  it('renders function component', () => {
+    function Hello({ name }: { name: string }) {
+      return <span>Hello, {name}!</span>
+    }
+    // Adjacent text children are separated by `<!-- -->` markers to preserve
+    // React-tree boundaries across the browser's text-node merging.
+    expect(renderToString(<Hello name="Tanner" />)).toBe(
+      '<span>Hello, <!-- -->Tanner<!-- -->!</span>',
+    )
+  })
+
+  it('escapes text and attrs', () => {
+    expect(renderToString(<div title={'<a&b"c'}>{'<a&b'}</div>)).toBe(
+      '<div title="&lt;a&amp;b&quot;c">&lt;a&amp;b</div>',
+    )
+  })
+
+  it('renders boolean attrs', () => {
+    const html = renderToString(<input type="checkbox" checked disabled />)
+    expect(html).toContain('checked=""')
+    expect(html).toContain('disabled=""')
+  })
+
+  it('renders void elements self-closing', () => {
+    expect(renderToString(<img src="/a.png" alt="a" />)).toBe('<img src="/a.png" alt="a"/>')
+  })
+
+  it('renders context provider value', () => {
+    const Ctx = React.createContext('default')
+    function Reader() {
+      return <span>{React.useContext(Ctx)}</span>
+    }
+    const html = renderToString(
+      <Ctx.Provider value="real">
+        <Reader />
+      </Ctx.Provider>,
+    )
+    expect(html).toBe('<span>real</span>')
+  })
+
+  it('renders class component', () => {
+    class C extends React.Component<{ x: number }, { y: number }> {
+      state = { y: this.props.x * 2 }
+      render() {
+        return <span>{this.state.y}</span>
+      }
+    }
+    expect(renderToString(<C x={3} />)).toBe('<span>6</span>')
+  })
+
+  it('renders style objects', () => {
+    const html = renderToString(<div style={{ color: 'red', marginTop: 4 }} />)
+    expect(html).toBe('<div style="color:red;margin-top:4px;"></div>')
+  })
+
+  it('skips event handlers', () => {
+    expect(renderToString(<button onClick={() => {}}>x</button>)).toBe('<button>x</button>')
+  })
+
+  it('renders dangerouslySetInnerHTML', () => {
+    expect(
+      renderToString(
+        <div dangerouslySetInnerHTML={{ __html: '<em>raw</em>' }} />,
+      ),
+    ).toBe('<div><em>raw</em></div>')
+  })
+
+  it('renders Fragment and arrays', () => {
+    const html = renderToString(
+      <>
+        <span>a</span>
+        {['b', 'c'].map((x) => (
+          <span key={x}>{x}</span>
+        ))}
+      </>,
+    )
+    expect(html).toBe('<span>a</span><span>b</span><span>c</span>')
+  })
+
+  it('Suspense renders fallback when child suspends', () => {
+    const promise = new Promise<string>(() => {})
+    function Inner() {
+      return <span>{React.use(promise)}</span>
+    }
+    const html = renderToString(
+      <React.Suspense fallback={<i>load</i>}>
+        <Inner />
+      </React.Suspense>,
+    )
+    // Fallback is emitted inside the boundary marker
+    expect(html).toContain('<i>load</i>')
+  })
+})
+
+describe('renderToReadableStream', () => {
+  it('streams shell with no suspense', async () => {
+    const stream = await renderToReadableStream(<div>hello</div>)
+    const out = await streamToString(stream)
+    expect(out).toContain('<div>hello</div>')
+    await stream.allReady
+  })
+
+  it('streams fallback then resolved content', async () => {
+    let resolve: (v: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    function Inner() {
+      return <span id="real">{React.use(promise)}</span>
+    }
+    const stream = await renderToReadableStream(
+      <div>
+        before
+        <React.Suspense fallback={<i id="fb">load</i>}>
+          <Inner />
+        </React.Suspense>
+        after
+      </div>,
+    )
+    resolve!('done')
+    const out = await streamToString(stream)
+    expect(out).toContain('<i id="fb">load</i>')
+    expect(out).toContain('<span id="real">done</span>')
+    expect(out).toContain('$RC(')
+    await stream.allReady
+  })
+})

--- a/packages/redact/tests/streaming-hydration.test.tsx
+++ b/packages/redact/tests/streaming-hydration.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { renderToReadableStream, BOUNDARY_REVEAL_RUNTIME } from 'react-dom/server'
+
+async function streamToHtml(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+function installContainer(html: string): HTMLDivElement {
+  const c = document.createElement('div')
+  c.innerHTML = html
+  document.body.appendChild(c)
+  return c
+}
+
+function executeScriptsIn(container: HTMLElement): void {
+  // jsdom/happy-dom don't auto-execute <script> when innerHTML is set. We
+  // manually eval each non-src <script> so our $RC / $RH runtime and reveal
+  // calls run as they would in a browser.
+  const scripts = Array.from(container.querySelectorAll('script'))
+  for (const s of scripts) {
+    if (s.src) continue
+    const code = s.textContent ?? ''
+    try {
+      // eslint-disable-next-line no-new-func
+      new Function(code)()
+    } catch {}
+  }
+}
+
+describe('streaming hydration', () => {
+  it('hydrates a resolved boundary against the streamed real content', async () => {
+    let resolveData!: (v: string) => void
+    const pServer = new Promise<string>((r) => (resolveData = r))
+
+    function Inner({ source }: { source: Promise<string> }) {
+      const v = React.use(source)
+      return <span id="x">{v}</span>
+    }
+
+    function App({ source }: { source: Promise<string> }) {
+      const [n, setN] = React.useState(0)
+      return (
+        <div>
+          <React.Suspense fallback={<i>load</i>}>
+            <Inner source={source} />
+          </React.Suspense>
+          <button id="b" onClick={() => setN(n + 1)}>
+            {n}
+          </button>
+        </div>
+      )
+    }
+
+    const stream = await renderToReadableStream(<App source={pServer} />)
+    resolveData('hi')
+    const html = await streamToHtml(stream)
+    expect(html).toContain('<span id="x">hi</span>')
+
+    const container = installContainer(html)
+    // Execute the inline runtime + any $RC(...) reveal scripts that were in the output
+    executeScriptsIn(container)
+
+    // Client already has a resolved thenable (status: fulfilled after one tick)
+    // Use an already-settled promise to avoid re-suspending on the client.
+    const pClient = Promise.resolve('hi')
+    ;(pClient as any).status = 'fulfilled'
+    ;(pClient as any).value = 'hi'
+
+    hydrateRoot(container, <App source={pClient} />)
+
+    // Clicking the button should update state — proves hydration attached handlers
+    const btn = container.querySelector('#b') as HTMLButtonElement
+    expect(btn.textContent).toBe('0')
+    flushSync(() => btn.click())
+    expect(btn.textContent).toBe('1')
+    // Real content is still there
+    expect(container.querySelector('#x')?.textContent).toBe('hi')
+  })
+
+  it('re-hydrates a pending boundary when the server reveal fires', async () => {
+    // Server stream pauses, client hydrates seeing fallback, then $RC runs,
+    // client must re-hydrate real content against the revealed DOM.
+    let resolveData!: (v: string) => void
+    const pServer = new Promise<string>((r) => (resolveData = r))
+
+    function Inner({ source }: { source: Promise<string> }) {
+      const v = React.use(source)
+      return <span id="real">{v}</span>
+    }
+    function App({ source }: { source: Promise<string> }) {
+      return (
+        <div>
+          <React.Suspense fallback={<i id="fb">load</i>}>
+            <Inner source={source} />
+          </React.Suspense>
+        </div>
+      )
+    }
+
+    const stream = await renderToReadableStream(<App source={pServer} />)
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+
+    // Read chunks until we see the inline runtime (marks end of shell)
+    let shellHtml = ''
+    while (!shellHtml.includes('$RC=function')) {
+      const { value, done } = await reader.read()
+      if (done) break
+      shellHtml += decoder.decode(value, { stream: true })
+    }
+    expect(shellHtml).toContain('<i id="fb">load</i>')
+
+    const container = installContainer(shellHtml)
+    executeScriptsIn(container)
+
+    // Hydrate while server is still pending — client also suspends since
+    // its promise isn't resolved yet. Client renders fallback over server fallback.
+    const pClient = new Promise<string>(() => {})
+    hydrateRoot(container, <App source={pClient} />)
+
+    // Now simulate server resolving + emit next chunks
+    resolveData('ok')
+    // Drain remaining server chunks
+    const rest: string[] = []
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      rest.push(decoder.decode(value, { stream: true }))
+    }
+    rest.push(decoder.decode())
+    const restHtml = rest.join('')
+
+    // Append remaining chunks (template + reveal script) and execute them
+    const wrap = document.createElement('div')
+    wrap.innerHTML = restHtml
+    while (wrap.firstChild) container.appendChild(wrap.firstChild)
+    executeScriptsIn(container)
+
+    // After $RC ran, our $RH callback should have re-hydrated real children.
+    // Real content should be visible (assuming the client also now has data).
+    // In this test the client pClient is still pending, so we just assert
+    // the DOM has the real server content swapped in.
+    expect(container.querySelector('#real')?.textContent).toBe('ok')
+    await stream.allReady
+  })
+})

--- a/packages/redact/tests/suspense.test.tsx
+++ b/packages/redact/tests/suspense.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+async function flush(n = 10) {
+  for (let i = 0; i < n; i++) await Promise.resolve()
+}
+
+describe('Suspense + use()', () => {
+  it('renders fallback then real content', async () => {
+    const container = setup()
+    let resolve: (v: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    function Inner() {
+      const v = React.use(promise)
+      return <span>{v}</span>
+    }
+    function App() {
+      return (
+        <React.Suspense fallback={<span>loading</span>}>
+          <Inner />
+        </React.Suspense>
+      )
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<span>loading</span>')
+    resolve!('done')
+    await flush()
+    expect(container.innerHTML).toBe('<span>done</span>')
+  })
+
+  it('lazy component suspends', async () => {
+    const container = setup()
+    let resolveMod: (v: { default: () => any }) => void
+    const LazyOne = React.lazy(
+      () =>
+        new Promise<{ default: () => any }>((r) => {
+          resolveMod = r
+        }),
+    )
+    function App() {
+      return (
+        <React.Suspense fallback={<i>load</i>}>
+          <LazyOne />
+        </React.Suspense>
+      )
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<i>load</i>')
+    resolveMod!({ default: () => <b>ok</b> })
+    await flush()
+    expect(container.innerHTML).toBe('<b>ok</b>')
+  })
+
+  // Regression: a lazy-loaded component that on mount immediately updates its
+  // own state via useEffect must re-render with the new state. On tanstack.com
+  // this is `ParentSize`: mounts with {0,0}, measures the container in a
+  // useEffect, calls setSize({real w, real h}). The chart only renders when
+  // size.width > 0. If the post-effect setState re-render doesn't fire, the
+  // chart never appears.
+  it('lazy component whose useEffect setState triggers re-render', async () => {
+    const container = setup()
+    let resolveMod: (v: { default: () => any }) => void
+    const promise = new Promise<{ default: () => any }>((r) => {
+      resolveMod = r
+    })
+    const Lazy = React.lazy(() => promise)
+
+    function Measured() {
+      const [size, setSize] = React.useState({ w: 0 })
+      React.useEffect(() => {
+        setSize({ w: 42 })
+      }, [])
+      return <span>{size.w}</span>
+    }
+
+    function App() {
+      return (
+        <React.Suspense fallback={<i>load</i>}>
+          <Lazy />
+        </React.Suspense>
+      )
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<i>load</i>')
+    resolveMod!({ default: Measured })
+    await flush(30)
+    expect(container.innerHTML).toBe('<span>42</span>')
+  })
+
+  // Regression: a lazy inside a React.memo ancestor whose props haven't
+  // changed gets its post-resolution update dropped. Our flushPending used to
+  // filter out dirty fibers with dirty ancestors to avoid redundant work, but
+  // when the ancestor is a Memo that bails on equal props, the ancestor's
+  // render never cascades to the descendant and the scheduled update is lost
+  // forever. Fix: keep all dirty fibers in the flush queue (sorted by depth)
+  // and let rerenderFiber's own dirty-check dedupe. Mirrors tanstack.com's
+  // /stats/npm where the Suspense sits under a `React.memo(Match)` — the
+  // chart's `state.suspended=false` from the resolution handler never
+  // triggered a re-render, and the fallback stayed on screen forever.
+  it('lazy resolution under a React.memo ancestor still re-renders', async () => {
+    const container = setup()
+    let resolveMod: (v: { default: () => any }) => void
+    const Lazy = React.lazy(
+      () =>
+        new Promise<{ default: () => any }>((r) => {
+          resolveMod = r
+        }),
+    )
+    const Memoed = React.memo(function Memoed({ stable }: { stable: number }) {
+      return (
+        <React.Suspense fallback={<i>load</i>}>
+          <Lazy />
+        </React.Suspense>
+      )
+    })
+    let bump: () => void = () => {}
+    function App() {
+      const [_, setN] = React.useState(0)
+      bump = () => setN((n) => n + 1)
+      // `stable` never changes across re-renders → Memo's shallowEqual returns
+      // true and renderMemo early-exits, which was silently dropping dirty
+      // descendants' pending renders.
+      return <Memoed stable={1} />
+    }
+    createRoot(container).render(<App />)
+    expect(container.innerHTML).toBe('<i>load</i>')
+    // Kick a parent render so Memo encounters equal props (no-op cascade).
+    bump()
+    await flush()
+    resolveMod!({ default: () => <b>ok</b> })
+    await flush(30)
+    expect(container.innerHTML).toBe('<b>ok</b>')
+  })
+
+  // Regression: same post-effect setState pattern, but the state-using
+  // component is nested several levels below the lazy boundary. This mirrors
+  // tanstack.com more closely — Lazy → NPMStatsChart → ParentSize.
+  it('nested component inside lazy updates state via useEffect', async () => {
+    const container = setup()
+    let resolveMod: (v: { default: () => any }) => void
+    const promise = new Promise<{ default: () => any }>((r) => {
+      resolveMod = r
+    })
+    const Lazy = React.lazy(() => promise)
+
+    function Inner() {
+      const [w, setW] = React.useState(0)
+      React.useEffect(() => {
+        setW(42)
+      }, [])
+      return <span>{w}</span>
+    }
+    function Outer() {
+      return (
+        <div>
+          <Inner />
+        </div>
+      )
+    }
+    function App() {
+      return (
+        <React.Suspense fallback={<i>load</i>}>
+          <Lazy />
+        </React.Suspense>
+      )
+    }
+    createRoot(container).render(<App />)
+    resolveMod!({ default: Outer })
+    await flush(30)
+    expect(container.innerHTML).toBe('<div><span>42</span></div>')
+  })
+})

--- a/packages/redact/tests/synthetic-event-shape.test.tsx
+++ b/packages/redact/tests/synthetic-event-shape.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Event handlers receive an event that exposes `.nativeEvent`.
+ *
+ * React wraps events in a SyntheticEvent whose `.nativeEvent` property
+ * points to the raw underlying Event. Many libraries rely on this shape:
+ *
+ *   - react-instantsearch's SearchBox reads `event.nativeEvent.isComposing`
+ *     to decide whether to call refine() — without the alias it throws a
+ *     TypeError inside the onChange handler, the call is swallowed, and
+ *     no search ever runs.
+ *   - Several UI kits (DnD libraries, floating-ui integrations) read
+ *     `event.nativeEvent.shiftKey` / `.metaKey` for keyboard modifier
+ *     routing.
+ *
+ * The shim doesn't build a full SyntheticEvent layer — it hands handlers
+ * the raw DOM Event, but aliases `e.nativeEvent = e` so these access
+ * patterns don't throw. This test locks that contract down.
+ */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+function setup() {
+  const c = document.createElement('div')
+  document.body.appendChild(c)
+  return c
+}
+
+describe('event handlers — SyntheticEvent shape', () => {
+  it('onChange event exposes .nativeEvent', () => {
+    const container = setup()
+    let captured: any = null
+    function App() {
+      const [v, setV] = React.useState('')
+      return (
+        <input
+          id="i"
+          value={v}
+          onChange={(e: any) => {
+            captured = e
+            setV(e.target.value)
+          }}
+        />
+      )
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#i') as HTMLInputElement
+    flushSync(() => {
+      input.value = 'a'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(captured).not.toBeNull()
+    expect(captured.nativeEvent).toBeDefined()
+    // `event.nativeEvent.isComposing` must not throw (react-instantsearch
+    // relies on this); the value may be false on a synthetic dispatch.
+    expect(() => captured.nativeEvent.isComposing).not.toThrow()
+  })
+
+  it('onClick event exposes .nativeEvent', () => {
+    const container = setup()
+    let captured: any = null
+    function App() {
+      return <button onClick={(e: any) => (captured = e)}>go</button>
+    }
+    createRoot(container).render(<App />)
+    const btn = container.querySelector('button') as HTMLButtonElement
+    flushSync(() => btn.click())
+    expect(captured).not.toBeNull()
+    expect(captured.nativeEvent).toBeDefined()
+    expect(() => captured.nativeEvent.shiftKey).not.toThrow()
+  })
+
+  it('onKeyDown event exposes .nativeEvent', () => {
+    const container = setup()
+    let captured: any = null
+    function App() {
+      return <input id="k" onKeyDown={(e: any) => (captured = e)} />
+    }
+    createRoot(container).render(<App />)
+    const input = container.querySelector('#k') as HTMLInputElement
+    flushSync(() =>
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }),
+      ),
+    )
+    expect(captured).not.toBeNull()
+    expect(captured.nativeEvent).toBeDefined()
+    expect(captured.nativeEvent.metaKey).toBe(true)
+  })
+})

--- a/packages/redact/tests/tsconfig.json
+++ b/packages/redact/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "@ss/redact"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/redact/tests/use-effect-coalesced-renders.test.tsx
+++ b/packages/redact/tests/use-effect-coalesced-renders.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+
+// Regression: when two renders happen back-to-back before the passive
+// microtask drains, each render's useEffect should still cleanly tear down
+// the prior side-effect and install the current one. Moving cleanup
+// execution from dispatch-time to effect-run-time prevents coalesced renders
+// from leaking side-effects (tanstack.com's NPM stats chart was appending a
+// fresh Plot SVG every toggle without removing the previous one).
+
+describe('useEffect cleanup under coalesced renders', () => {
+  it('does not leak side-effects when two deps-changing renders coalesce before passive drain', async () => {
+    const appended: Array<HTMLSpanElement> = []
+
+    function Side({ label }: { label: string }) {
+      const containerRef = React.useRef<HTMLDivElement>(null)
+      React.useEffect(() => {
+        if (!containerRef.current) return
+        const span = document.createElement('span')
+        span.dataset.label = label
+        containerRef.current.appendChild(span)
+        appended.push(span)
+        return () => {
+          span.remove()
+        }
+      }, [label])
+      return <div ref={containerRef} data-host="1" />
+    }
+
+    function App({ label }: { label: string }) {
+      return <Side label={label} />
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    // Initial mount — microtask drains so create runs and appends span #1.
+    root.render(<App label="a" />)
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelectorAll('[data-host="1"] > span').length).toBe(1)
+
+    // Two deps-changing renders back-to-back, synchronously — both schedule
+    // effects before the passive microtask fires. Prior to the fix, the
+    // cleanup ran once during the B dispatch, then C dispatch found
+    // hook.cleanup already null (B's effect hadn't run yet), so both B's
+    // and C's effects added spans with no cleanup between them → two spans.
+    root.render(<App label="b" />)
+    root.render(<App label="c" />)
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Only one live side-effect at any settled state.
+    expect(container.querySelectorAll('[data-host="1"] > span').length).toBe(1)
+  })
+
+  it('still cleans up on unmount (no double-call when cleanup already ran)', async () => {
+    let cleanupCalls = 0
+
+    function Side({ label }: { label: string }) {
+      React.useEffect(() => {
+        return () => {
+          cleanupCalls += 1
+        }
+      }, [label])
+      return null
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    root.render(<Side label="a" />)
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+
+    root.render(<Side label="b" />)
+    root.render(<Side label="c" />)
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // First cleanup (a→b) + second cleanup (b→c) should both run.
+    expect(cleanupCalls).toBe(2)
+
+    root.unmount()
+    // Unmount should run the last live cleanup once (c's).
+    expect(cleanupCalls).toBe(3)
+  })
+})

--- a/packages/redact/tests/vitest.config.ts
+++ b/packages/redact/tests/vitest.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
+
+// __dirname here is `packages/redact/tests`, so `..` gets us to the redact
+// package root and `src/...` reaches the canonical TS source. We point both
+// the `@ss/redact/*` and `react`/`react-dom` shapes at the same source files
+// so tests exercise the actual implementation, not the built dist/.
+const r = (p: string) => resolve(__dirname, '..', p)
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    include: ['**/*.test.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@ss/redact/jsx-runtime': r('src/react/jsx-runtime.ts'),
+      '@ss/redact/jsx-dev-runtime': r('src/react/jsx-runtime.ts'),
+      '@ss/redact/compiler-runtime': r('src/react/compiler-runtime.ts'),
+      '@ss/redact/dom-client': r('src/dom/client.ts'),
+      '@ss/redact/dom-test-utils': r('src/dom/test-utils.ts'),
+      '@ss/redact/dom': r('src/dom/index.ts'),
+      '@ss/redact/server': r('src/server/index.ts'),
+      '@ss/redact/scheduler': r('src/scheduler/index.ts'),
+      '@ss/redact/vite': r('src/vite/index.ts'),
+      '@ss/redact': r('src/react/index.ts'),
+      // React-shape aliases — what consumers will actually import
+      'react/jsx-runtime': r('src/react/jsx-runtime.ts'),
+      'react/jsx-dev-runtime': r('src/react/jsx-runtime.ts'),
+      'react/compiler-runtime': r('src/react/compiler-runtime.ts'),
+      react: r('src/react/index.ts'),
+      'react-dom/client': r('src/dom/client.ts'),
+      'react-dom/server': r('src/server/index.ts'),
+      'react-dom/test-utils': r('src/dom/test-utils.ts'),
+      'react-dom': r('src/dom/index.ts'),
+      scheduler: r('src/scheduler/index.ts'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: '@ss/redact',
+  },
+})

--- a/packages/redact/tsconfig.json
+++ b/packages/redact/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@ss/redact"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## First-paint JS — preview (`@ss/redact`) vs production (vanilla React)

### Preview — `@ss/redact`
| Chunk | raw | gzip | br |
|---|---:|---:|---:|
| `index-MmSRWcLX.js` | 372.7 KB | 101.1 KB | 103.2 KB |
| `routes-Cxa-tpbo.js` | 72.8 KB | 24.5 KB | 25.7 KB |
| `link-ClPyco1r.js` | 56.8 KB | 19.6 KB | 20.4 KB |
| `canonical-CZVYjyxZ.js` | 43.3 KB | 14.4 KB | 14.9 KB |
| **Total preload** | **545.6 KB** | **159.6 KB** | **164.2 KB** |

### Production — vanilla React (`sponsorsearch.co.uk`)
| Chunk | raw | gzip | br |
|---|---:|---:|---:|
| `index-CvS0zZmT.js` | 636.3 KB | 187.0 KB | 190.1 KB |
| `index-Bcwa-P1L.js` | 75.1 KB | 25.3 KB | 26.4 KB |
| **Total preload** | **711.5 KB** | **212.3 KB** | **216.5 KB** |

### Deltas
| Metric | Production | Preview | Delta |
|---|---:|---:|---:|
| Largest chunk raw | 636.3 KB | 372.7 KB | **−263.6 KB / −41.4%** |
| Largest chunk gzip | 187.0 KB | 101.1 KB | **−85.9 KB / −45.9%** |
| Total first-paint raw | 711.5 KB | 545.6 KB | **−165.9 KB / −23.3%** |
| Total first-paint gzip | 212.3 KB | 159.6 KB | **−52.7 KB / −24.8%** |
| Total first-paint brotli | 216.5 KB | 164.2 KB | **−52.4 KB / −24.2%** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added @ss/redact — a React-compatible runtime with client rendering, hydration, streaming SSR, and suspense reveal support.
  * Integrated a Vite plugin to opt-in/out reconciler features (nano/full presets) and register the runtime with build tooling.
  * Exposed React-compatible DOM, server, and JSX runtimes plus testing helpers.

* **Chores**
  * Bumped Vite to ^8.0.3 and @vitejs/plugin-react to ^6.0.1.
  * Added extensive test suites for rendering, hydration, streaming, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->