### PR TITLE
fix: reduce from 7 to 2 days as rogue packages are yanked our in hours

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
-# Refuse to install package versions younger than 2 days. Mitigates supply-chain
+# Refuse to install package versions younger than 3 days. Mitigates supply-chain
 # attacks where compromised releases are typically caught and yanked within hours.
-minimumReleaseAge = 172800
+minimumReleaseAge = 259200

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
-# Refuse to install package versions younger than 7 days. Mitigates supply-chain
-# attacks where compromised releases are typically caught and yanked within days.
-minimumReleaseAge = 604800
+# Refuse to install package versions younger than 2 days. Mitigates supply-chain
+# attacks where compromised releases are typically caught and yanked within hours.
+minimumReleaseAge = 172800


### PR DESCRIPTION
The 7 day drift is too far off and meaningless looking at how fast rogue packages are shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the minimum release age for package installation from 7 days to 3 days.
  * Updated accompanying inline comment to reflect the new threshold, allowing newer package versions to be installed sooner.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/103)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->