### PR TITLE
feat: switch the mapping mechanism

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@mcp-b/global": "^2.2.0",
     "@ss/db": "workspace:*",
-    "virtual-text-layout": "0.2.1",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "0.10.2",
     "@tanstack/react-query": "^5.96.2",
@@ -50,11 +49,14 @@
     "csv-parse": "^6.2.1",
     "dotenv": "^17.4.0",
     "drizzle-orm": "^0.45.2",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.545.0",
     "nitro": "^3.0.260311-beta",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-leaflet": "^5.0.0",
     "tailwindcss": "^4.1.18",
+    "virtual-text-layout": "0.2.1",
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
@@ -63,6 +65,7 @@
     "@tanstack/devtools-vite": "0.6.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.1.4",

--- a/apps/web/src/components/AddressMap.tsx
+++ b/apps/web/src/components/AddressMap.tsx
@@ -1,29 +1,18 @@
+import { ClientOnly } from '@tanstack/react-router';
+import { lazy, Suspense } from 'react';
 import type { Geocoded } from '../api/geocode';
 
-const BBOX_HALF_EXTENT_METERS = 50;
+const LeafletMap = lazy(() => import('./LeafletMap'));
 
-/** Build a tight bbox around `lat`/`lon` for the OSM embed iframe — half-extent in metres controls zoom (smaller = more zoomed in). */
-function tightBbox(lat: number, lon: number): string {
-  const latDelta = BBOX_HALF_EXTENT_METERS / 111_000;
-  const lonDelta =
-    BBOX_HALF_EXTENT_METERS / (111_000 * Math.cos((lat * Math.PI) / 180));
-  return [lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta].join(
-    ',',
-  );
-}
-
-/** Embeds an OpenStreetMap iframe centered on `geo` with a marker. Geo is resolved upstream by the route loader so this component renders synchronously. */
+/** Renders a Leaflet map of `geo` on the client only. The Leaflet bundle is code-split via `React.lazy`, and `<ClientOnly>` keeps it out of the SSR render (Leaflet can't run on the server). */
 export function AddressMap({ geo }: { geo: Geocoded }) {
-  const iframeSrc = `https://www.openstreetmap.org/export/embed.html?bbox=${tightBbox(geo.lat, geo.lon)}&layer=mapnik&marker=${geo.lat},${geo.lon}`;
-
   return (
     <div className="relative h-64 w-full bg-(--sea-ink-soft)/10">
-      <iframe
-        title="Map of registered address"
-        src={iframeSrc}
-        className="absolute inset-0 h-full w-full border-0 transition-[filter] duration-200 pointer-fine:saturate-0 pointer-fine:hover:saturate-100 pointer-fine:dark:invert pointer-fine:dark:hue-rotate-180 pointer-fine:dark:hover:invert-0 pointer-fine:dark:hover:hue-rotate-0"
-        loading="lazy"
-      />
+      <ClientOnly>
+        <Suspense>
+          <LeafletMap geo={geo} />
+        </Suspense>
+      </ClientOnly>
     </div>
   );
 }

--- a/apps/web/src/components/LeafletMap.css
+++ b/apps/web/src/components/LeafletMap.css
@@ -1,0 +1,16 @@
+/* Re-skin leaflet's attribution pill to match the page background. Leaflet's own `.leaflet-container .leaflet-control-attribution` rule has higher specificity AND loads later in the lazy chunk, so we need !important to override both bg and link color. */
+.leaflet-control-attribution {
+  /* biome-ignore lint: override leaflet's white-ish background which clashes with the dark tile theme */
+  background: var(--bg-base) !important;
+  color: var(--sea-ink-soft);
+}
+.leaflet-control-attribution a {
+  /* biome-ignore lint: override leaflet's blue link colour to match site branding */
+  color: var(--gray-400) !important;
+}
+
+/* Leaflet's container defaults to background:#ddd, which flashes a light grey panel while tiles load — jarring on dark theme. */
+.leaflet-container {
+  /* biome-ignore lint: override leaflet's default container background which flashes light during tile load */
+  background: var(--surface) !important;
+}

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -3,7 +3,15 @@ import 'leaflet/dist/leaflet.css';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MapContainer, Marker, TileLayer } from 'react-leaflet';
 import type { Geocoded } from '../api/geocode';
+import { useIsDark } from '../hooks/useIsDark';
 import UnionJackLens from './UnionJackLens';
+
+const LIGHT_TILES =
+  'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png';
+const DARK_TILES =
+  'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png';
+const TILE_ATTRIBUTION =
+  '&copy; <a target="_blank" href="https://stadiamaps.com/">Stadia Maps</a> &copy; <a target="_blank" href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>';
 
 const ICON_W = 32;
 const ICON_H = 42;
@@ -25,25 +33,26 @@ const lensSvg = renderToStaticMarkup(
 );
 
 const unionJackIcon = L.divIcon({
-  html: `<div style="--logo-navy:var(--logo-red);position:relative;width:${ICON_W}px;height:${ICON_H}px;">${teardropSvg}${lensSvg}</div>`,
+  html: `<div style="--logo-navy:var(--surface);position:relative;width:${ICON_W}px;height:${ICON_H}px;">${teardropSvg}${lensSvg}</div>`,
   className: '',
   iconSize: [ICON_W, ICON_H],
   iconAnchor: [ICON_W / 2, ICON_H],
 });
 
-/** OSM-tiled Leaflet map centered on `geo` with a custom Union-Jack-pin marker (teardrop body + the shared `UnionJackLens` overlaid as the head). Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
+/** Leaflet map centered on `geo` with a custom Union-Jack-pin marker (teardrop body + the shared `UnionJackLens` overlaid as the head). Tile theme switches with the page's light/dark mode via CartoDB Positron / Dark Matter. Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
 export default function LeafletMap({ geo }: { geo: Geocoded }) {
   const position: [number, number] = [geo.lat, geo.lon];
+  const isDark = useIsDark();
   return (
     <MapContainer
       center={position}
       zoom={17}
       scrollWheelZoom={false}
-      className="absolute inset-0 h-full w-full transition-[filter] duration-200 pointer-fine:saturate-0 pointer-fine:hover:saturate-100 pointer-fine:dark:invert pointer-fine:dark:hue-rotate-180 pointer-fine:dark:hover:invert-0 pointer-fine:dark:hover:hue-rotate-0"
+      className="absolute inset-0 h-full w-full"
     >
       <TileLayer
-        attribution='&copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution={TILE_ATTRIBUTION}
+        url={isDark ? DARK_TILES : LIGHT_TILES}
       />
       <Marker position={position} icon={unionJackIcon} />
     </MapContainer>

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -42,7 +42,7 @@ export default function LeafletMap({ geo }: { geo: Geocoded }) {
       className="absolute inset-0 h-full w-full transition-[filter] duration-200 pointer-fine:saturate-0 pointer-fine:hover:saturate-100 pointer-fine:dark:invert pointer-fine:dark:hue-rotate-180 pointer-fine:dark:hover:invert-0 pointer-fine:dark:hover:hue-rotate-0"
     >
       <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        attribution='&copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       <Marker position={position} icon={unionJackIcon} />

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { MapContainer, Marker, TileLayer } from 'react-leaflet';
 import type { Geocoded } from '../api/geocode';
 import { useIsDark } from '../hooks/useIsDark';
+import './LeafletMap.css';
 import UnionJackLens from './UnionJackLens';
 
 const LIGHT_TILES =
@@ -48,7 +49,7 @@ export default function LeafletMap({ geo }: { geo: Geocoded }) {
       center={position}
       zoom={16}
       scrollWheelZoom={false}
-      className="absolute inset-0 h-full w-full"
+      className="absolute inset-0 isolate h-full w-full"
     >
       <TileLayer
         attribution={TILE_ATTRIBUTION}

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -33,7 +33,7 @@ const lensSvg = renderToStaticMarkup(
 );
 
 const unionJackIcon = L.divIcon({
-  html: `<div style="--logo-navy:var(--surface);position:relative;width:${ICON_W}px;height:${ICON_H}px;">${teardropSvg}${lensSvg}</div>`,
+  html: `<div style="--logo-navy:var(--surface);position:relative;width:${ICON_W}px;height:${ICON_H}px;filter:drop-shadow(0 2px 4px rgba(0,0,0,0.4));">${teardropSvg}${lensSvg}</div>`,
   className: '',
   iconSize: [ICON_W, ICON_H],
   iconAnchor: [ICON_W / 2, ICON_H],
@@ -46,7 +46,7 @@ export default function LeafletMap({ geo }: { geo: Geocoded }) {
   return (
     <MapContainer
       center={position}
-      zoom={17}
+      zoom={16}
       scrollWheelZoom={false}
       className="absolute inset-0 h-full w-full"
     >

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -1,0 +1,36 @@
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+import { MapContainer, Marker, TileLayer } from 'react-leaflet';
+import type { Geocoded } from '../api/geocode';
+
+const defaultIcon = L.icon({
+  iconUrl,
+  iconRetinaUrl,
+  shadowUrl,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+/** OSM-tiled Leaflet map centered on `geo`. Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
+export default function LeafletMap({ geo }: { geo: Geocoded }) {
+  const position: [number, number] = [geo.lat, geo.lon];
+  return (
+    <MapContainer
+      center={position}
+      zoom={16}
+      scrollWheelZoom={false}
+      className="absolute inset-0 h-full w-full transition-[filter] duration-200 pointer-fine:saturate-0 pointer-fine:hover:saturate-100 pointer-fine:dark:invert pointer-fine:dark:hue-rotate-180 pointer-fine:dark:hover:invert-0 pointer-fine:dark:hover:hue-rotate-0"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={position} icon={defaultIcon} />
+    </MapContainer>
+  );
+}

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -1,28 +1,43 @@
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import iconUrl from 'leaflet/dist/images/marker-icon.png';
-import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
-import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { MapContainer, Marker, TileLayer } from 'react-leaflet';
 import type { Geocoded } from '../api/geocode';
+import UnionJackLens from './UnionJackLens';
 
-const defaultIcon = L.icon({
-  iconUrl,
-  iconRetinaUrl,
-  shadowUrl,
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41],
+const ICON_W = 32;
+const ICON_H = 42;
+
+const teardropSvg = `<svg viewBox="0 0 100 130" xmlns="http://www.w3.org/2000/svg" style="position:absolute;top:0;left:0;width:${ICON_W}px;height:${ICON_H}px;">
+  <path d="M50 2 C23 2 2 23 2 50 C2 70 25 95 50 128 C75 95 98 70 98 50 C98 23 77 2 50 2 Z" fill="var(--logo-navy)" />
+</svg>`;
+
+const lensSvg = renderToStaticMarkup(
+  <UnionJackLens
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: ICON_W,
+      height: ICON_W,
+    }}
+  />,
+);
+
+const unionJackIcon = L.divIcon({
+  html: `<div style="--logo-navy:var(--logo-red);position:relative;width:${ICON_W}px;height:${ICON_H}px;">${teardropSvg}${lensSvg}</div>`,
+  className: '',
+  iconSize: [ICON_W, ICON_H],
+  iconAnchor: [ICON_W / 2, ICON_H],
 });
 
-/** OSM-tiled Leaflet map centered on `geo`. Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
+/** OSM-tiled Leaflet map centered on `geo` with a custom Union-Jack-pin marker (teardrop body + the shared `UnionJackLens` overlaid as the head). Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
 export default function LeafletMap({ geo }: { geo: Geocoded }) {
   const position: [number, number] = [geo.lat, geo.lon];
   return (
     <MapContainer
       center={position}
-      zoom={16}
+      zoom={17}
       scrollWheelZoom={false}
       className="absolute inset-0 h-full w-full transition-[filter] duration-200 pointer-fine:saturate-0 pointer-fine:hover:saturate-100 pointer-fine:dark:invert pointer-fine:dark:hue-rotate-180 pointer-fine:dark:hover:invert-0 pointer-fine:dark:hover:hue-rotate-0"
     >
@@ -30,7 +45,7 @@ export default function LeafletMap({ geo }: { geo: Geocoded }) {
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <Marker position={position} icon={defaultIcon} />
+      <Marker position={position} icon={unionJackIcon} />
     </MapContainer>
   );
 }

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -39,7 +39,7 @@ const unionJackIcon = L.divIcon({
   iconAnchor: [ICON_W / 2, ICON_H],
 });
 
-/** Leaflet map centered on `geo` with a custom Union-Jack-pin marker (teardrop body + the shared `UnionJackLens` overlaid as the head). Tile theme switches with the page's light/dark mode via CartoDB Positron / Dark Matter. Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
+/** Leaflet map centered on `geo` with a custom Union-Jack-pin marker (teardrop body + the shared `UnionJackLens` overlaid as the head). Tile theme switches with the page's light/dark mode via Stadia Maps `alidade_smooth` / `alidade_smooth_dark`. Loaded client-side only via the `AddressMap` lazy import — Leaflet touches `window`/`document` at import time and can't run on the SSR server. */
 export default function LeafletMap({ geo }: { geo: Geocoded }) {
   const position: [number, number] = [geo.lat, geo.lon];
   const isDark = useIsDark();

--- a/apps/web/src/hooks/useIsDark.ts
+++ b/apps/web/src/hooks/useIsDark.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/** Watch `<html class="dark">` for theme changes and return whether dark mode is currently active. Reads the initial value synchronously from the DOM so there's no light→dark flash on first paint — only safe to call from client-only components (e.g. inside `<ClientOnly>` or a `lazy()` boundary). */
+export function useIsDark() {
+  const [isDark, setIsDark] = useState(
+    () =>
+      typeof document !== 'undefined' &&
+      document.documentElement.classList.contains('dark'),
+  );
+  useEffect(() => {
+    const el = document.documentElement;
+    const update = () => setIsDark(el.classList.contains('dark'));
+    const observer = new MutationObserver(update);
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+  return isDark;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -298,6 +298,17 @@ a {
   letter-spacing: -0.4px;
 }
 
+/* Re-skin leaflet's attribution pill to match the page background. Leaflet's own `.leaflet-container .leaflet-control-attribution` rule has higher specificity AND loads later (lazy chunk), so we need !important to override both bg and link color. */
+.leaflet-control-attribution {
+  /* biome-ignore lint: override leaflet's white-ish background which clashes with the dark tile theme */
+  background: var(--bg-base) !important;
+  color: var(--sea-ink-soft);
+}
+.leaflet-control-attribution a {
+  /* biome-ignore lint: override leaflet's blue link colour to match site branding */
+  color: var(--gray-400) !important;
+}
+
 /*
  * Pre-hydration gate for the search input.
  *

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -298,17 +298,6 @@ a {
   letter-spacing: -0.4px;
 }
 
-/* Re-skin leaflet's attribution pill to match the page background. Leaflet's own `.leaflet-container .leaflet-control-attribution` rule has higher specificity AND loads later (lazy chunk), so we need !important to override both bg and link color. */
-.leaflet-control-attribution {
-  /* biome-ignore lint: override leaflet's white-ish background which clashes with the dark tile theme */
-  background: var(--bg-base) !important;
-  color: var(--sea-ink-soft);
-}
-.leaflet-control-attribution a {
-  /* biome-ignore lint: override leaflet's blue link colour to match site branding */
-  color: var(--gray-400) !important;
-}
-
 /*
  * Pre-hydration gate for the search input.
  *

--- a/bun.lock
+++ b/bun.lock
@@ -43,10 +43,12 @@
         "csv-parse": "^6.2.1",
         "dotenv": "^17.4.0",
         "drizzle-orm": "^0.45.2",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.545.0",
         "nitro": "^3.0.260311-beta",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-leaflet": "^5.0.0",
         "tailwindcss": "^4.1.18",
         "virtual-text-layout": "0.2.1",
         "zod-to-json-schema": "^3.25.2",
@@ -57,6 +59,7 @@
         "@tanstack/devtools-vite": "0.6.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.1.4",
@@ -324,6 +327,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
+    "@react-leaflet/core": ["@react-leaflet/core@3.0.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
@@ -563,6 +568,10 @@
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/leaflet": ["@types/leaflet@1.9.21", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -890,6 +899,8 @@
 
     "launch-editor": ["launch-editor@2.13.2", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg=="],
 
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -1031,6 +1042,8 @@
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-leaflet": ["react-leaflet@5.0.0", "", { "dependencies": { "@react-leaflet/core": "^3.0.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced static address iframe with an interactive, client-only Leaflet map: lazy-loaded for faster initial render, centered on the address with a custom marker, and tiles that switch to match light/dark theme.
* **Style**
  * Updated map attribution styling so attribution pill and links match the app’s theme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/107)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->