### PR TITLE
feat: move map tiles call to the server

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,6 +6,7 @@ const ALLOWED_PREFIXES = [
   '/privacy', // privacy policy
   '/_server', // TanStack server functions
   '/api/revalidate', // Nitro cache revalidation endpoint
+  '/api/tiles/', // Nitro Stadia Maps tile proxy
 ];
 
 const STATIC_EXTENSIONS = new Set([

--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -12,8 +12,10 @@
  *  - y:     tile y (0 <= y < 2^z), optional @2x retina suffix
  *
  * Access control — three cheap layers, ordered cheapest-first:
- *  - Referer must match prod domain (browsers send this automatically;
- *    skipped on non-prod NODE_ENV so localhost works).
+ *  - Referer's parsed hostname must match the prod custom domain OR a
+ *    Vercel deployment URL anchored on both the project prefix and the
+ *    team suffix (only this team can deploy under that suffix). Skipped
+ *    on non-prod NODE_ENV so localhost works.
  *  - Sec-Fetch-Site, when present, must be same-origin (browser-computed,
  *    cannot be set by in-browser JS — blocks cross-site embed attempts).
  *  - Zoom + tile-coord bounds reject world-scrape patterns (z=0..4).
@@ -25,17 +27,35 @@ import { defineEventHandler } from 'h3';
 import { TILE_MAX_ZOOM, TILE_MIN_ZOOM } from '#/utils/tileBounds';
 
 const ALLOWED_THEMES = new Set(['alidade_smooth', 'alidade_smooth_dark']);
-const ALLOWED_REFERERS = [
-  'https://sponsorsearch.co.uk',
-  'https://www.sponsorsearch.co.uk',
-];
+const ALLOWED_HOSTS = new Set([
+  'sponsorsearch.co.uk',
+  'www.sponsorsearch.co.uk',
+]);
+const VERCEL_TEAM_SUFFIX = '-nikil-kuruvillas-projects.vercel.app';
+const VERCEL_PROJECT_PREFIX = 'learn-tanstack-start-';
+
+/** Returns true when the Referer's parsed hostname matches the prod custom domain or a Vercel deployment URL anchored on both this team's suffix and this project's prefix. */
+function isAllowedReferer(referer: string): boolean {
+  if (!referer) return false;
+  try {
+    const url = new URL(referer);
+    if (url.protocol !== 'https:') return false;
+    if (ALLOWED_HOSTS.has(url.hostname)) return true;
+    return (
+      url.hostname.startsWith(VERCEL_PROJECT_PREFIX) &&
+      url.hostname.endsWith(VERCEL_TEAM_SUFFIX)
+    );
+  } catch {
+    return false;
+  }
+}
 
 export default defineEventHandler(async (event) => {
   const isProd = process.env.NODE_ENV === 'production';
 
   if (isProd) {
     const referer = event.req.headers.get('referer') ?? '';
-    if (!ALLOWED_REFERERS.some((r) => referer.startsWith(r))) {
+    if (!isAllowedReferer(referer)) {
       return new Response(null, { status: 403 });
     }
   }

--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -101,14 +101,25 @@ export default defineEventHandler(async (event) => {
     return new Response(null, { status: 500 });
   }
 
-  const upstream = await fetch(
-    `https://tiles.stadiamaps.com/tiles/${theme}/${z}/${x}/${y}.png?api_key=${apiKey}`,
-    {
-      headers: {
-        'User-Agent': 'SponsorSearch/1.0 (+https://sponsorsearch.co.uk)',
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `https://tiles.stadiamaps.com/tiles/${theme}/${z}/${x}/${y}.png?api_key=${apiKey}`,
+      {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'SponsorSearch/1.0 (+https://sponsorsearch.co.uk)',
+        },
       },
-    },
-  );
+    );
+  } catch (err) {
+    console.error('[tiles] upstream fetch failed:', err);
+    return new Response(null, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!upstream.ok) {
     return new Response(null, { status: upstream.status });
@@ -118,7 +129,8 @@ export default defineEventHandler(async (event) => {
     status: 200,
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control': 'public, max-age=3600, s-maxage=31536000, immutable',
+      'Cache-Control':
+        'public, max-age=3600, s-maxage=31536000, immutable, stale-if-error=86400',
     },
   });
 });

--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -1,0 +1,104 @@
+/**
+ * GET /api/tiles/:theme/:z/:x/:y
+ *
+ * Proxies Stadia Maps tile requests so we can front them with the Vercel
+ * edge cache (s-maxage=1y, immutable) — first viewer per region pays Stadia,
+ * everyone else hits the CDN. STADIA_API_KEY stays server-only.
+ *
+ * URL params:
+ *  - theme: alidade_smooth | alidade_smooth_dark
+ *  - z:     zoom (5-19)
+ *  - x:     tile x (0 <= x < 2^z)
+ *  - y:     tile y (0 <= y < 2^z), optional @2x retina suffix
+ *
+ * Access control — three cheap layers, ordered cheapest-first:
+ *  - Referer must match prod domain (browsers send this automatically;
+ *    skipped on non-prod NODE_ENV so localhost works).
+ *  - Sec-Fetch-Site, when present, must be same-origin (browser-computed,
+ *    cannot be set by in-browser JS — blocks cross-site embed attempts).
+ *  - Zoom + tile-coord bounds reject world-scrape patterns (z=0..4).
+ *
+ * Env vars:
+ *  - STADIA_API_KEY — server-only Stadia API key.
+ */
+import { defineEventHandler } from 'h3';
+import { TILE_MAX_ZOOM, TILE_MIN_ZOOM } from '#/utils/tileBounds';
+
+const ALLOWED_THEMES = new Set(['alidade_smooth', 'alidade_smooth_dark']);
+const ALLOWED_REFERERS = [
+  'https://sponsorsearch.co.uk',
+  'https://www.sponsorsearch.co.uk',
+];
+
+export default defineEventHandler(async (event) => {
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (isProd) {
+    const referer = event.req.headers.get('referer') ?? '';
+    if (!ALLOWED_REFERERS.some((r) => referer.startsWith(r))) {
+      return new Response(null, { status: 403 });
+    }
+  }
+
+  const fetchSite = event.req.headers.get('sec-fetch-site');
+  if (fetchSite && fetchSite !== 'same-origin') {
+    return new Response(null, { status: 403 });
+  }
+
+  const params = event.context.params ?? {};
+  const theme = params.theme as string | undefined;
+  const z = params.z as string | undefined;
+  const x = params.x as string | undefined;
+  const y = params.y as string | undefined;
+
+  if (!theme || !z || !x || !y) {
+    return new Response(null, { status: 400 });
+  }
+
+  if (!ALLOWED_THEMES.has(theme)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const zn = Number(z);
+  if (!Number.isInteger(zn) || zn < TILE_MIN_ZOOM || zn > TILE_MAX_ZOOM) {
+    return new Response(null, { status: 400 });
+  }
+
+  const yMatch = y.match(/^(\d+)(@2x)?$/);
+  const xn = Number(x);
+  if (!yMatch || !Number.isInteger(xn) || xn < 0) {
+    return new Response(null, { status: 400 });
+  }
+  const yNum = Number(yMatch[1]);
+  const worldSize = 2 ** zn;
+  if (xn >= worldSize || yNum < 0 || yNum >= worldSize) {
+    return new Response(null, { status: 400 });
+  }
+
+  const apiKey = process.env.STADIA_API_KEY;
+  if (!apiKey) {
+    console.error('[tiles] STADIA_API_KEY not set');
+    return new Response(null, { status: 500 });
+  }
+
+  const upstream = await fetch(
+    `https://tiles.stadiamaps.com/tiles/${theme}/${z}/${x}/${y}.png?api_key=${apiKey}`,
+    {
+      headers: {
+        'User-Agent': 'SponsorSearch/1.0 (+https://sponsorsearch.co.uk)',
+      },
+    },
+  );
+
+  if (!upstream.ok) {
+    return new Response(null, { status: upstream.status });
+  }
+
+  return new Response(await upstream.arrayBuffer(), {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=3600, s-maxage=31536000, immutable',
+    },
+  });
+});

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -9,13 +9,12 @@ import {
 } from 'react-leaflet';
 import type { Geocoded } from '../api/geocode';
 import { useIsDark } from '../hooks/useIsDark';
+import { TILE_MAX_ZOOM, TILE_MIN_ZOOM } from '../utils/tileBounds';
 import './LeafletMap.css';
 import UnionJackLens from './UnionJackLens';
 
-const LIGHT_TILES =
-  'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png';
-const DARK_TILES =
-  'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png';
+const LIGHT_TILES = '/api/tiles/alidade_smooth/{z}/{x}/{y}{r}';
+const DARK_TILES = '/api/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}';
 const TILE_ATTRIBUTION =
   '&copy; <a target="_blank" href="https://leafletjs.com">Leaflet</a> &copy; <a target="_blank" href="https://stadiamaps.com/">Stadia Maps</a> &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>';
 
@@ -53,6 +52,8 @@ export default function LeafletMap({ geo }: { geo: Geocoded }) {
     <MapContainer
       center={position}
       zoom={16}
+      minZoom={TILE_MIN_ZOOM}
+      maxZoom={TILE_MAX_ZOOM}
       scrollWheelZoom={false}
       attributionControl={false}
       className="absolute inset-0 isolate h-full w-full"

--- a/apps/web/src/utils/tileBounds.ts
+++ b/apps/web/src/utils/tileBounds.ts
@@ -1,0 +1,3 @@
+/** Shared zoom bounds for the Stadia tile proxy and the Leaflet map UI — kept in one file so the server-side validation and the client-side controls cannot drift apart. */
+export const TILE_MIN_ZOOM = 5;
+export const TILE_MAX_ZOOM = 19;


### PR DESCRIPTION
- move the map tiles call to the server so it can be cached.
- the previous implementation directly hit the stadia map tile from the client, hence missing out on stadia map cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Map tile imagery now loads through the application's internal proxy instead of directly from external providers, improving performance and security while reducing external service dependencies.
* Map zooming functionality is now constrained to levels 5-19, providing a more responsive and optimized user experience across different scales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->