### PR TITLE
fix: remove stale-if-error as it doesn't HIT

### DIFF
--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -130,7 +130,7 @@ export default defineEventHandler(async (event) => {
     headers: {
       'Content-Type': 'image/png',
       'Cache-Control':
-        'public, max-age=3600, s-maxage=31536000, immutable, stale-if-error=86400',
+        'public, max-age=3600, s-maxage=31536000, immutable, stale-while-revalidate=86400',
     },
   });
 });

--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -129,8 +129,6 @@ export default defineEventHandler(async (event) => {
     status: 200,
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control':
-        'public, max-age=3600, s-maxage=31536000, stale-while-revalidate=86400',
     },
   });
 });

--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -130,7 +130,7 @@ export default defineEventHandler(async (event) => {
     headers: {
       'Content-Type': 'image/png',
       'Cache-Control':
-        'public, max-age=3600, s-maxage=31536000, immutable, stale-while-revalidate=86400',
+        'public, max-age=3600, s-maxage=31536000, stale-while-revalidate=86400',
     },
   });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -44,6 +44,12 @@ const config = defineConfig({
             'Cache-Control': 's-maxage=2592000, stale-while-revalidate=604800',
           },
         },
+        '/api/tiles/**': {
+          headers: {
+            'Cache-Control':
+              'public, max-age=3600, s-maxage=31536000, stale-while-revalidate=86400',
+          },
+        },
       },
     }),
     viteReact(),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -46,8 +46,7 @@ const config = defineConfig({
         },
         '/api/tiles/**': {
           headers: {
-            'Cache-Control':
-              'public, max-age=3600, s-maxage=31536000, stale-while-revalidate=86400',
+            'Cache-Control': 's-maxage=31536000, stale-while-revalidate=86400',
           },
         },
       },


### PR DESCRIPTION
- the stale-if-error maybe causing cache MISS all the time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tile caching behavior to enhance content availability and performance during background updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->