### PR TITLE
fix: block cross-site tile CDN bypass via Vary: Sec-Fetch-Site

### DIFF
--- a/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
+++ b/apps/web/server/api/tiles/[theme]/[z]/[x]/[y].get.ts
@@ -16,8 +16,13 @@
  *    Vercel deployment URL anchored on both the project prefix and the
  *    team suffix (only this team can deploy under that suffix). Skipped
  *    on non-prod NODE_ENV so localhost works.
- *  - Sec-Fetch-Site, when present, must be same-origin (browser-computed,
- *    cannot be set by in-browser JS — blocks cross-site embed attempts).
+ *  - Sec-Fetch-Site must be same-origin (browser-computed Fetch Metadata
+ *    header, unspoofable from page JS — blocks cross-site embed attempts).
+ *    The 200 response also sets `Vary: Sec-Fetch-Site` so Vercel's edge
+ *    cache partitions entries by this value — cross-site browser fetches
+ *    look up a different cache key from same-origin ones, so they can
+ *    never hit a same-origin-warmed cache entry and always fall through
+ *    to the function's 403.
  *  - Zoom + tile-coord bounds reject world-scrape patterns (z=0..4).
  *
  * Env vars:
@@ -61,7 +66,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const fetchSite = event.req.headers.get('sec-fetch-site');
-  if (fetchSite && fetchSite !== 'same-origin') {
+  if (fetchSite !== 'same-origin') {
     return new Response(null, { status: 403 });
   }
 
@@ -129,6 +134,7 @@ export default defineEventHandler(async (event) => {
     status: 200,
     headers: {
       'Content-Type': 'image/png',
+      Vary: 'Sec-Fetch-Site',
     },
   });
 });


### PR DESCRIPTION
## Summary

- The tile handler's `Referer` and `Sec-Fetch-Site` checks only fire on cache MISS. Once a tile is cached with `s-maxage=1y`, any browser embedding the URL cross-site gets the cached PNG — bypassing access control entirely. Discovered while debugging Vercel logs and confirmed by reproducing the bypass with `curl` + Referer warming + direct browser load.
- Add `Vary: Sec-Fetch-Site` on the 200 response so Vercel's edge partitions cache entries by the browser-computed origin context (`Sec-Fetch-Site` is a Fetch Metadata header that page JS cannot override). Cross-site fetches look up a different cache key, miss, and fall through to the function's 403.
- Tighten the function's `Sec-Fetch-Site` check from "if present, must be same-origin" to "must be same-origin" — was previously allowing requests with the header missing entirely to pass through.

## Test plan

- [x] Deploy to preview, load https://learn-tanstack-start-*-nikil-kuruvillas-projects.vercel.app and confirm map tiles still render (same-origin path is unbroken).
- [ ] On the preview, curl with `Referer: <preview-url>` + `Sec-Fetch-Site: same-origin` → expect 200 with `Vary: Sec-Fetch-Site` in response headers.
- [ ] On the preview, curl without `Sec-Fetch-Site` header → expect 403 (was 200 before this change).
- [ ] Warm a tile via curl with same-origin spoofed headers, then attempt to load it from a different origin (e.g. an HTML file with `<img>`) → browser sends `Sec-Fetch-Site: cross-site`, CDN looks up a different cache key, function returns 403.
- [ ] After merging to prod, sanity-check https://sponsorsearch.co.uk/ map tiles still load and verify `vary: Sec-Fetch-Site` is present on cache HIT responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tile API requests now enforce stricter same-origin header validation, rejecting non-matching origin requests.
  * Cache responses now support origin-aware partitioning to optimize efficiency across different request origins.

* **Documentation**
  * Updated access control documentation describing origin validation and cache partitioning mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->