### PR TITLE
perf: stream geocode client-side instead of blocking the loader

### DIFF
--- a/apps/web/src/components/AddressMap.tsx
+++ b/apps/web/src/components/AddressMap.tsx
@@ -35,7 +35,7 @@ export function AddressMap({
   companyName?: string;
 }) {
   return (
-    <ClientOnly>
+    <ClientOnly fallback={placeholder}>
       <Suspense fallback={placeholder}>
         <GeocodedMap address={address} companyName={companyName} />
       </Suspense>

--- a/apps/web/src/components/AddressMap.tsx
+++ b/apps/web/src/components/AddressMap.tsx
@@ -1,24 +1,44 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { ClientOnly } from '@tanstack/react-router';
 import { lazy, Suspense } from 'react';
-import type { Geocoded } from '../api/geocode';
+import { geocodeQueryOptions } from '../api/geocode';
 
 const LeafletMap = lazy(() => import('./LeafletMap'));
 
-/** Renders a Leaflet map of `geo` on the client only. The Leaflet bundle is code-split via `React.lazy`, and `<ClientOnly>` keeps it out of the SSR render (Leaflet can't run on the server). */
-export function AddressMap({
-  geo,
+const placeholder = (
+  <div className="relative h-64 w-full bg-(--sea-ink-soft)/10" />
+);
+
+/** Geocodes `address` client-side and renders a Leaflet map. Suspends on the geocode query so the route loader doesn't block on Nominatim (~600ms). Returns nothing if geocoding fails so the placeholder collapses. */
+function GeocodedMap({
+  address,
   companyName,
 }: {
-  geo: Geocoded;
+  address: string;
+  companyName?: string;
+}) {
+  const { data: geo } = useSuspenseQuery(geocodeQueryOptions(address));
+  if (!geo) return null;
+  return (
+    <div className="relative h-64 w-full bg-(--sea-ink-soft)/10">
+      <LeafletMap geo={geo} companyName={companyName} />
+    </div>
+  );
+}
+
+/** Client-only map for `address`. Streams in after the rest of the page renders — Leaflet can't SSR and Nominatim is too slow to block on. */
+export function AddressMap({
+  address,
+  companyName,
+}: {
+  address: string;
   companyName?: string;
 }) {
   return (
-    <div className="relative h-64 w-full bg-(--sea-ink-soft)/10">
-      <ClientOnly>
-        <Suspense>
-          <LeafletMap geo={geo} companyName={companyName} />
-        </Suspense>
-      </ClientOnly>
-    </div>
+    <ClientOnly>
+      <Suspense fallback={placeholder}>
+        <GeocodedMap address={address} companyName={companyName} />
+      </Suspense>
+    </ClientOnly>
   );
 }

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -10,7 +10,6 @@ import { ExternalLink, MapPin } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { companyProfileQueryOptions } from '../api/companiesHouse';
 import { flagStateQueryOptions } from '../api/flags';
-import { geocodeQueryOptions } from '../api/geocode';
 import { getHmrcBySlug, hmrcBySlugIdQueryOptions } from '../api/hmrc';
 import { AddressMap } from '../components/AddressMap';
 import GovUkLogo from '../components/GovUkLogo';
@@ -55,17 +54,9 @@ export const Route = createFileRoute('/company/$id/$slug')({
       companyProfileQueryOptions(sponsor.organisationName),
     );
 
-    const address = profile?.registered_office_address
-      ? formatAddress(profile.registered_office_address)
-      : '';
-    const [geo, flagState] = await Promise.all([
-      address
-        ? queryClient.ensureQueryData(geocodeQueryOptions(address))
-        : null,
-      queryClient.ensureQueryData(flagStateQueryOptions),
-    ]);
+    const flagState = await queryClient.ensureQueryData(flagStateQueryOptions);
 
-    return { sponsor, profile, geo, flagState };
+    return { sponsor, profile, flagState };
   },
   head: ({ match }) => {
     const loaderData = match.loaderData as
@@ -164,7 +155,7 @@ export const Route = createFileRoute('/company/$id/$slug')({
  * Preserves the `search` param so the back-link returns to the same query.
  */
 function CompanyDetail() {
-  const { sponsor, profile, geo, flagState } = Route.useLoaderData();
+  const { sponsor, profile, flagState } = Route.useLoaderData();
   const { search } = Route.useSearch();
   const navigate = useNavigate();
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -333,14 +324,14 @@ function CompanyDetail() {
                         {formatAddress(profile.registered_office_address)}
                         <ExternalLink size={12} className="shrink-0" />
                       </a>
-                      {geo && (
-                        <div className="-mx-6 -mb-6 mt-3 overflow-hidden rounded-b-lg">
-                          <AddressMap
-                            geo={geo}
-                            companyName={titleCase(sponsor.organisationName)}
-                          />
-                        </div>
-                      )}
+                      <div className="-mx-6 -mb-6 mt-3 overflow-hidden rounded-b-lg">
+                        <AddressMap
+                          address={formatAddress(
+                            profile.registered_office_address,
+                          )}
+                          companyName={titleCase(sponsor.organisationName)}
+                        />
+                      </div>
                     </dd>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- Nominatim is the slow leg of the company-detail loader (~600ms per request, per production traces) and its only consumer is `AddressMap`, which is `ClientOnly` because Leaflet can't SSR. The loader was blocking the entire HTML response on a value the server couldn't even render.
- Moved the geocode query out of the route loader and into `AddressMap` via `useSuspenseQuery`, inside the existing `ClientOnly` + `Suspense` boundary. The page HTML now streams immediately; the map appears once the geocode resolves.
- Reused the existing tinted `h-64` box as the Suspense fallback — same visual as before, just briefly empty. On geocode failure the component returns `null` so the wrapper collapses (same as the prior `{geo && ...}` gate).

## Test plan

- [x] `bun lint:fix && bun lint` clean
- [x] Loaded a company detail page locally — page renders without waiting on Nominatim, map streams in shortly after
- [x] Spot-check a company whose postcode does not geocode — confirm the map area collapses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated address map display to perform geocoding client-side with visual loading indicators during map initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikilok/learn-tanstack-start/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->