### PR TITLE
feat: add a custom cursor for sponsor search

### DIFF
--- a/apps/web/src/components/IBeam.module.css
+++ b/apps/web/src/components/IBeam.module.css
@@ -1,0 +1,11 @@
+/* Dual-layer I-beam: a dark inner body with a fixed light outer rim (both themes).
+   The light rim is near-invisible on light surfaces — where the dark body carries
+   it — but provides the needed outline on any dark surface, including dark-by-
+   default UI shown in light mode (e.g. the TanStack devtools). */
+.rim {
+  stroke: #ededed;
+}
+
+.core {
+  stroke: #1f1f1f;
+}

--- a/apps/web/src/components/IBeam.tsx
+++ b/apps/web/src/components/IBeam.tsx
@@ -1,8 +1,11 @@
+import styles from './IBeam.module.css';
+
 /**
- * Grayscale, outlined I-beam cursor shown over editable text fields (paired with
- * the Union-Jack badge in `UnionJackCursor`). Theme-aware: an ink-coloured body
- * over a surface-coloured rim, so the outline stays visible in both light and
- * dark mode. Sized to fill its wrapper; centred on the pointer by the caller.
+ * I-beam cursor shown over editable text fields (paired with the Union-Jack
+ * badge in `UnionJackCursor`). A dark inner body with a fixed light outer rim, so
+ * it reads as a dual layer and stays visible on dark surfaces (incl. dark-by-
+ * default UI shown in light mode). Sized to fill its wrapper; centred on the
+ * pointer by the caller.
  */
 export default function IBeam() {
   return (
@@ -13,19 +16,18 @@ export default function IBeam() {
       style={{ display: 'block', width: '100%', height: '100%' }}
       aria-hidden="true"
     >
-      {/* Rim drawn first (wider, behind); body on top. `stroke` is set via CSS,
-          not the attribute, because only the property accepts var(). */}
+      {/* Outer rim drawn first (wider, behind); dark inner body on top. */}
       <path
         d="M4 3 H10 M7 3 V19 M4 19 H10"
-        style={{ stroke: 'var(--surface)' }}
+        className={styles.rim}
         strokeWidth="3.6"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M4 3 H10 M7 3 V19 M4 19 H10"
-        style={{ stroke: 'var(--sea-ink)' }}
-        strokeWidth="2.4"
+        className={styles.core}
+        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/apps/web/src/components/IBeam.tsx
+++ b/apps/web/src/components/IBeam.tsx
@@ -1,0 +1,34 @@
+/**
+ * Grayscale, outlined I-beam cursor shown over editable text fields (paired with
+ * the Union-Jack badge in `UnionJackCursor`). Theme-aware: an ink-coloured body
+ * over a surface-coloured rim, so the outline stays visible in both light and
+ * dark mode. Sized to fill its wrapper; centred on the pointer by the caller.
+ */
+export default function IBeam() {
+  return (
+    <svg
+      viewBox="0 0 14 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: 'block', width: '100%', height: '100%' }}
+      aria-hidden="true"
+    >
+      {/* Rim drawn first (wider, behind); body on top. `stroke` is set via CSS,
+          not the attribute, because only the property accepts var(). */}
+      <path
+        d="M4 3 H10 M7 3 V19 M4 19 H10"
+        style={{ stroke: 'var(--surface)' }}
+        strokeWidth="3.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 3 H10 M7 3 V19 M4 19 H10"
+        style={{ stroke: 'var(--sea-ink)' }}
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -30,12 +30,25 @@
 }
 
 /* I-beam shown over editable text fields: centred on the pointer like the lens,
-   but no grayscale filter (already monochrome) and no grow. */
+   but no grayscale filter (already monochrome) and no grow. Positioning context
+   for the Union-Jack badge that sits beside it. */
 .caret {
+  position: relative;
   width: 14px;
   height: 22px;
   transform: translate(-50%, -50%);
   transform-origin: center;
+}
+
+/* Small grayscale Union-Jack badge to the right of the I-beam. */
+.caretFlag {
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  width: 14px;
+  height: 14px;
+  transform: translateY(-50%);
+  filter: grayscale(1);
 }
 
 /* Hide the native pointer everywhere while the custom cursor is active. Stays

--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -21,8 +21,7 @@
   transform: translate(-50%, -50%) scale(1);
   transform-origin: center;
   transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
-  filter: grayscale(1) drop-shadow(0 0 1px rgba(255, 255, 255, 0.5))
-    drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+  filter: grayscale(1);
   will-change: transform;
 }
 

--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -1,0 +1,46 @@
+/* Position layer: translated instantly to the pointer via JS (no transition). */
+.layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2147483647;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease;
+  will-change: transform;
+}
+
+.layerVisible {
+  opacity: 1;
+}
+
+/* Scale layer: centred on the pointer; only the grow/shrink is transitioned. */
+.lens {
+  width: 20px;
+  height: 20px;
+  transform: translate(-50%, -50%) scale(1);
+  transform-origin: center;
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  filter: grayscale(1) drop-shadow(0 0 1px rgba(255, 255, 255, 0.5))
+    drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+  will-change: transform;
+}
+
+.lensHover {
+  transform: translate(-50%, -50%) scale(1.4);
+}
+
+/* Hide the native pointer everywhere while the custom cursor is active. Stays
+   hidden during View Transitions too: the follower is lifted into its own
+   `uj-cursor` transition group (see transitions.css) so the lens renders on top
+   of the page flip instead of being buried under the root snapshot. */
+:global(html.uj-cursor-active),
+:global(html.uj-cursor-active *) {
+  cursor: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lens {
+    transition-duration: 0ms;
+  }
+}

--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -29,6 +29,15 @@
   transform: translate(-50%, -50%) scale(1.4);
 }
 
+/* I-beam shown over editable text fields: centred on the pointer like the lens,
+   but no grayscale filter (already monochrome) and no grow. */
+.caret {
+  width: 14px;
+  height: 22px;
+  transform: translate(-50%, -50%);
+  transform-origin: center;
+}
+
 /* Hide the native pointer everywhere while the custom cursor is active. Stays
    hidden during View Transitions too: the follower is lifted into its own
    `uj-cursor` transition group (see transitions.css) so the lens renders on top

--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -20,13 +20,18 @@
   height: 20px;
   transform: translate(-50%, -50%) scale(1);
   transform-origin: center;
-  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition:
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    filter 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
   filter: grayscale(1);
   will-change: transform;
 }
 
+/* Hover: grow and fade from grayscale to full colour — a "you can click this"
+   cue. The resting state stays grayscale. */
 .lensHover {
   transform: translate(-50%, -50%) scale(1.4);
+  filter: grayscale(0);
 }
 
 /* I-beam shown over editable text fields: centred on the pointer like the lens,

--- a/apps/web/src/components/UnionJackCursor.tsx
+++ b/apps/web/src/components/UnionJackCursor.tsx
@@ -16,6 +16,7 @@ export default function UnionJackCursor() {
   const posRef = useRef<HTMLDivElement>(null);
   const hoverRef = useRef(false);
   const shownRef = useRef(false);
+  const visibleRef = useRef(false);
   const [enabled, setEnabled] = useState(false);
   const [hovering, setHovering] = useState(false);
   const [visible, setVisible] = useState(false);
@@ -37,14 +38,27 @@ export default function UnionJackCursor() {
       }
     };
 
+    // Toggle follower opacity via a ref so the closures read fresh state.
+    const show = () => {
+      if (!visibleRef.current) {
+        visibleRef.current = true;
+        setVisible(true);
+      }
+    };
+    const hide = () => {
+      if (visibleRef.current) {
+        visibleRef.current = false;
+        setVisible(false);
+      }
+    };
+
     const onMove = (e: PointerEvent) => {
       nextX = e.clientX;
       nextY = e.clientY;
       if (!raf) raf = requestAnimationFrame(flush);
-      if (!shownRef.current) {
-        shownRef.current = true;
-        setVisible(true);
-      }
+      // Reveal on every move (not just the first) so it recovers after a blur.
+      shownRef.current = true;
+      show();
       const over = !!(e.target as Element | null)?.closest?.(
         INTERACTIVE_SELECTOR,
       );
@@ -54,15 +68,18 @@ export default function UnionJackCursor() {
       }
     };
 
-    const onLeave = () => setVisible(false);
+    // Hide on blur/leave, re-show on focus/enter — recovers after Cmd/Alt-Tab,
+    // where Safari fires no mouseenter (pointer already inside on refocus).
+    const onLeave = () => hide();
     const onEnter = () => {
-      if (shownRef.current) setVisible(true);
+      if (shownRef.current) show();
     };
 
     document.addEventListener('pointermove', onMove, { passive: true });
     document.documentElement.addEventListener('mouseleave', onLeave);
     document.documentElement.addEventListener('mouseenter', onEnter);
     window.addEventListener('blur', onLeave);
+    window.addEventListener('focus', onEnter);
 
     return () => {
       if (raf) cancelAnimationFrame(raf);
@@ -70,6 +87,7 @@ export default function UnionJackCursor() {
       document.documentElement.removeEventListener('mouseleave', onLeave);
       document.documentElement.removeEventListener('mouseenter', onEnter);
       window.removeEventListener('blur', onLeave);
+      window.removeEventListener('focus', onEnter);
       document.documentElement.classList.remove('uj-cursor-active');
     };
   }, []);

--- a/apps/web/src/components/UnionJackCursor.tsx
+++ b/apps/web/src/components/UnionJackCursor.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+import UnionJackLens from './UnionJackLens';
+
+import styles from './UnionJackCursor.module.css';
+
+const INTERACTIVE_SELECTOR =
+  'a, button, [role="button"], input, select, textarea, label, summary, [data-cursor-grow]';
+
+/**
+ * Replaces the native mouse pointer with a grayscale Union-Jack lens that
+ * follows the cursor and grows smoothly when hovering interactive elements.
+ * Mouse-only (`pointer: fine`) and client-only — touch devices keep the default.
+ */
+export default function UnionJackCursor() {
+  const posRef = useRef<HTMLDivElement>(null);
+  const hoverRef = useRef(false);
+  const shownRef = useRef(false);
+  const [enabled, setEnabled] = useState(false);
+  const [hovering, setHovering] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!window.matchMedia('(pointer: fine)').matches) return;
+    setEnabled(true);
+    document.documentElement.classList.add('uj-cursor-active');
+
+    let raf = 0;
+    let nextX = 0;
+    let nextY = 0;
+
+    // Coalesce moves into one transform write per frame.
+    const flush = () => {
+      raf = 0;
+      if (posRef.current) {
+        posRef.current.style.transform = `translate3d(${nextX}px, ${nextY}px, 0)`;
+      }
+    };
+
+    const onMove = (e: PointerEvent) => {
+      nextX = e.clientX;
+      nextY = e.clientY;
+      if (!raf) raf = requestAnimationFrame(flush);
+      if (!shownRef.current) {
+        shownRef.current = true;
+        setVisible(true);
+      }
+      const over = !!(e.target as Element | null)?.closest?.(
+        INTERACTIVE_SELECTOR,
+      );
+      if (over !== hoverRef.current) {
+        hoverRef.current = over;
+        setHovering(over);
+      }
+    };
+
+    const onLeave = () => setVisible(false);
+    const onEnter = () => {
+      if (shownRef.current) setVisible(true);
+    };
+
+    document.addEventListener('pointermove', onMove, { passive: true });
+    document.documentElement.addEventListener('mouseleave', onLeave);
+    document.documentElement.addEventListener('mouseenter', onEnter);
+    window.addEventListener('blur', onLeave);
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      document.removeEventListener('pointermove', onMove);
+      document.documentElement.removeEventListener('mouseleave', onLeave);
+      document.documentElement.removeEventListener('mouseenter', onEnter);
+      window.removeEventListener('blur', onLeave);
+      document.documentElement.classList.remove('uj-cursor-active');
+    };
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      ref={posRef}
+      aria-hidden="true"
+      data-uj-cursor
+      className={`${styles.layer} ${visible ? styles.layerVisible : ''}`}
+    >
+      <div className={`${styles.lens} ${hovering ? styles.lensHover : ''}`}>
+        <UnionJackLens
+          style={{ display: 'block', width: '100%', height: '100%' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/UnionJackCursor.tsx
+++ b/apps/web/src/components/UnionJackCursor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
+import IBeam from './IBeam';
 import UnionJackLens from './UnionJackLens';
 
 import styles from './UnionJackCursor.module.css';
@@ -31,34 +32,6 @@ function isTextField(target: EventTarget | null): boolean {
     return !NON_TEXT_INPUT_TYPES.has(field.type);
   }
   return false;
-}
-
-/** Grayscale, outlined I-beam shown in place of the lens over editable fields. */
-function IBeam() {
-  return (
-    <svg
-      viewBox="0 0 14 22"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      style={{ display: 'block', width: '100%', height: '100%' }}
-      aria-hidden="true"
-    >
-      <path
-        d="M4 3 H10 M7 3 V19 M4 19 H10"
-        stroke="#fff"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M4 3 H10 M7 3 V19 M4 19 H10"
-        stroke="#1f1f1f"
-        strokeWidth="1.3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
 }
 
 /**
@@ -173,7 +146,14 @@ export default function UnionJackCursor() {
         }
       >
         {textMode ? (
-          <IBeam />
+          <>
+            <IBeam />
+            <span className={styles.caretFlag}>
+              <UnionJackLens
+                style={{ display: 'block', width: '100%', height: '100%' }}
+              />
+            </span>
+          </>
         ) : (
           <UnionJackLens
             style={{ display: 'block', width: '100%', height: '100%' }}

--- a/apps/web/src/components/UnionJackCursor.tsx
+++ b/apps/web/src/components/UnionJackCursor.tsx
@@ -7,18 +7,76 @@ import styles from './UnionJackCursor.module.css';
 const INTERACTIVE_SELECTOR =
   'a, button, [role="button"], input, select, textarea, label, summary, [data-cursor-grow]';
 
+// Input types that are NOT text-editable; every other type (incl. none) is.
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'submit',
+  'reset',
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'file',
+  'image',
+  'hidden',
+]);
+
+/** True when the pointer is over an editable text field (input/textarea/contenteditable). */
+function isTextField(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target instanceof HTMLElement && target.isContentEditable) return true;
+  const field = target.closest('input, textarea');
+  if (field instanceof HTMLTextAreaElement) return true;
+  if (field instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has(field.type);
+  }
+  return false;
+}
+
+/** Grayscale, outlined I-beam shown in place of the lens over editable fields. */
+function IBeam() {
+  return (
+    <svg
+      viewBox="0 0 14 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: 'block', width: '100%', height: '100%' }}
+      aria-hidden="true"
+    >
+      <path
+        d="M4 3 H10 M7 3 V19 M4 19 H10"
+        stroke="#fff"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 3 H10 M7 3 V19 M4 19 H10"
+        stroke="#1f1f1f"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 /**
  * Replaces the native mouse pointer with a grayscale Union-Jack lens that
  * follows the cursor and grows smoothly when hovering interactive elements.
+ * Over editable text fields it swaps to a custom I-beam so the "editable"
+ * affordance the native cursor used to give isn't lost.
  * Mouse-only (`pointer: fine`) and client-only — touch devices keep the default.
  */
 export default function UnionJackCursor() {
   const posRef = useRef<HTMLDivElement>(null);
   const hoverRef = useRef(false);
+  const textRef = useRef(false);
   const shownRef = useRef(false);
   const visibleRef = useRef(false);
   const [enabled, setEnabled] = useState(false);
   const [hovering, setHovering] = useState(false);
+  const [textMode, setTextMode] = useState(false);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -59,9 +117,15 @@ export default function UnionJackCursor() {
       // Reveal on every move (not just the first) so it recovers after a blur.
       shownRef.current = true;
       show();
-      const over = !!(e.target as Element | null)?.closest?.(
-        INTERACTIVE_SELECTOR,
-      );
+      const target = e.target;
+      // Text fields show the I-beam; they take precedence over the grow.
+      const text = isTextField(target);
+      if (text !== textRef.current) {
+        textRef.current = text;
+        setTextMode(text);
+      }
+      const over =
+        !text && !!(target as Element | null)?.closest?.(INTERACTIVE_SELECTOR);
       if (over !== hoverRef.current) {
         hoverRef.current = over;
         setHovering(over);
@@ -101,10 +165,20 @@ export default function UnionJackCursor() {
       data-uj-cursor
       className={`${styles.layer} ${visible ? styles.layerVisible : ''}`}
     >
-      <div className={`${styles.lens} ${hovering ? styles.lensHover : ''}`}>
-        <UnionJackLens
-          style={{ display: 'block', width: '100%', height: '100%' }}
-        />
+      <div
+        className={
+          textMode
+            ? styles.caret
+            : `${styles.lens} ${hovering ? styles.lensHover : ''}`
+        }
+      >
+        {textMode ? (
+          <IBeam />
+        ) : (
+          <UnionJackLens
+            style={{ display: 'block', width: '100%', height: '100%' }}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/UnionJackCursor.tsx
+++ b/apps/web/src/components/UnionJackCursor.tsx
@@ -36,9 +36,9 @@ function isTextField(target: EventTarget | null): boolean {
 
 /**
  * Replaces the native mouse pointer with a grayscale Union-Jack lens that
- * follows the cursor and grows smoothly when hovering interactive elements.
- * Over editable text fields it swaps to a custom I-beam so the "editable"
- * affordance the native cursor used to give isn't lost.
+ * follows the cursor and, over interactive elements, grows and turns full
+ * colour as a click affordance. Over editable text fields it swaps to a custom
+ * I-beam so the "editable" affordance the native cursor used to give isn't lost.
  * Mouse-only (`pointer: fine`) and client-only — touch devices keep the default.
  */
 export default function UnionJackCursor() {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -131,7 +131,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: BROWSER_INIT_SCRIPT }} />
         <HeadContent />
       </head>
-      <body className="font-sans wrap-anywhere antialiased selection:bg-[rgba(0,114,245,0.16)]">
+      <body className="font-sans wrap-anywhere antialiased">
         <QueryClientProvider client={queryClient}>
           <McpTools />
           <NavigationProgress />

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,6 +20,7 @@ import Header from '../components/Header';
 import { McpTools } from '../components/McpTools';
 import NavigationProgress from '../components/NavigationProgress';
 import RouteError from '../components/RouteError';
+import UnionJackCursor from '../components/UnionJackCursor';
 import { BROWSER_INIT_SCRIPT } from '../scripts/browser-init';
 import { SEARCH_INIT_SCRIPT } from '../scripts/search-input-init';
 import { THEME_INIT_SCRIPT } from '../scripts/theme-init';
@@ -138,6 +139,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           {children}
           <Footer />
         </QueryClientProvider>
+        <UnionJackCursor />
         <TanStackDevtools
           config={{
             position: 'bottom-right',

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -135,6 +135,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Brand-red text selection, theme-aware via --logo-red. Translucent so the
+   selected text stays readable on the red tint. */
+::selection {
+  background-color: color-mix(in srgb, var(--logo-red) 22%, transparent);
+}
+
 body::before {
   content: '';
   position: fixed;

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -96,6 +96,37 @@ body::after {
   opacity: 0.25;
 }
 
+/*
+ * Keep the grayscale Union-Jack cursor (`UnionJackCursor`) visible during page
+ * flips. As a plain fixed div it would be buried under the `root` snapshot the
+ * moment the transition starts — and the native pointer is hidden via
+ * `uj-cursor-active`, so the mouse would vanish for the whole flip. Naming the
+ * follower lifts it into its own group that paints above `root`; `animation:
+ * none` holds the lens static (frozen at its capture position) for the ~300ms
+ * flip, then the live follower resumes. Mirrors the `bg-grid` pattern above.
+ */
+[data-uj-cursor] {
+  view-transition-name: uj-cursor;
+}
+
+::view-transition-group(uj-cursor),
+::view-transition-old(uj-cursor),
+::view-transition-new(uj-cursor) {
+  animation: none;
+}
+
+/* Pin the lens to base scale while a flip is active so a pre-click hover
+   enlargement isn't frozen into the snapshot. Without this, clicking a card
+   (lens scaled up on hover) captures the big lens, which then hangs on top as
+   a frozen ring around the resting (base-scale) cursor on the new page.
+   `:active-view-transition` is evaluated at capture time — same mechanism the
+   `.page-flip-details` rule below relies on. `transition: none` makes the
+   reset instant so the captured frame is base scale, not mid-animation. */
+html:active-view-transition [data-uj-cursor] > div {
+  transform: translate(-50%, -50%) scale(1) !important;
+  transition: none !important;
+}
+
 /* Shares the `active-card` name with the clicked card on the listing so
    the browser pairs them as a single shared element — the card morphs
    into the details wrapper on forward. The surrounding listing is

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -115,6 +115,32 @@ body::after {
   animation: none;
 }
 
+/* Safari strands `cursor: none` across a View Transition: WebKit only repaints
+   the cursor on a real pointer event (bug 14344), so after a flip swaps the
+   element under a stationary pointer the cursor sticks as the native arrow until
+   the next mouse move. A constant, transparent image cursor is invisible AND
+   never changes value between elements, so there's nothing for WebKit to repaint
+   stale — this removes the post-flip lingering. Safari-only; Chrome/Firefox keep
+   `none` from UnionJackCursor.module.css. The fallback keyword covers a rejected
+   url. The data URI must be a fully-transparent RGBA PNG — a grayscale/indexed
+   blob can carry a non-zero sample that Safari renders as a visible dot.
+
+   Scope note: this fixes the LINGER, not the ~300ms flip itself. Safari ignores
+   `cursor` on the ::view-transition overlay pseudos entirely (verified: neither
+   the root nor the leaf snapshots honor it), so the native arrow is briefly
+   visible *during* the animation and self-clears when it ends. That blink is an
+   accepted limitation — removing it would mean not running a view transition on
+   Safari at all. Don't re-attempt an overlay `cursor` rule; it's a no-op here. */
+html[data-browser='safari'] {
+  --uj-blank-cursor: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAEklEQVR42mNgGAWjYBSMAggAAAQQAAGvRYgsAAAAAElFTkSuQmCC')
+    0 0;
+}
+
+html[data-browser='safari'].uj-cursor-active,
+html[data-browser='safari'].uj-cursor-active * {
+  cursor: var(--uj-blank-cursor), none !important;
+}
+
 /* Pin the lens to base scale while a flip is active so a pre-click hover
    enlargement isn't frozen into the snapshot. Without this, clicking a card
    (lens scaled up on hover) captures the big lens, which then hangs on top as

--- a/apps/web/src/transitions.css
+++ b/apps/web/src/transitions.css
@@ -141,15 +141,17 @@ html[data-browser='safari'].uj-cursor-active * {
   cursor: var(--uj-blank-cursor), none !important;
 }
 
-/* Pin the lens to base scale while a flip is active so a pre-click hover
-   enlargement isn't frozen into the snapshot. Without this, clicking a card
-   (lens scaled up on hover) captures the big lens, which then hangs on top as
-   a frozen ring around the resting (base-scale) cursor on the new page.
-   `:active-view-transition` is evaluated at capture time — same mechanism the
-   `.page-flip-details` rule below relies on. `transition: none` makes the
-   reset instant so the captured frame is base scale, not mid-animation. */
+/* Pin the lens to its resting look (base scale + grayscale) while a flip is
+   active so a pre-click hover state isn't frozen into the snapshot. Without
+   this, clicking a card (lens scaled up and full-colour on hover) captures the
+   big colour lens, which then hangs on top as a frozen ring around the resting
+   cursor on the new page. `:active-view-transition` is evaluated at capture
+   time — same mechanism the `.page-flip-details` rule below relies on.
+   `transition: none` makes the reset instant so the captured frame is the
+   resting look, not mid-animation. */
 html:active-view-transition [data-uj-cursor] > div {
   transform: translate(-50%, -50%) scale(1) !important;
+  filter: grayscale(1) !important;
   transition: none !important;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global custom Union‑Jack cursor with centered lens, caret/text I‑beam mode plus badge, hides native cursor when active, activates only for fine pointers, and respects reduced‑motion.
  * Brand‑red translucent text selection color.

* **Bug Fixes**
  * Improved behavior across page transitions and Safari to prevent cursor sticking or frozen enlarged lens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->