### PR TITLE
feat: remove the color aspect when you target an interactive element …

### DIFF
--- a/apps/web/src/components/UnionJackCursor.module.css
+++ b/apps/web/src/components/UnionJackCursor.module.css
@@ -27,11 +27,9 @@
   will-change: transform;
 }
 
-/* Hover: grow and fade from grayscale to full colour — a "you can click this"
-   cue. The resting state stays grayscale. */
+/* Hover: grow "you can click this" cue. The resting state stays grayscale. */
 .lensHover {
   transform: translate(-50%, -50%) scale(1.4);
-  filter: grayscale(0);
 }
 
 /* I-beam shown over editable text fields: centred on the pointer like the lens,


### PR DESCRIPTION
…as it's distracting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cursor lens hover effect to scale only, removing the prior color filter transition that would brighten on interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->