### PR TITLE
feat: add LinkedIn search button to company details

### DIFF
--- a/apps/web/src/components/LinkedInLogo.tsx
+++ b/apps/web/src/components/LinkedInLogo.tsx
@@ -1,0 +1,24 @@
+/**
+ * LinkedIn "in" mark used as the visual label for outbound links to LinkedIn.
+ * Brand blue square with a white glyph (the white stays visible on a blue hover);
+ * sized via `className`.
+ */
+export default function LinkedInLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      focusable="false"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-label="LinkedIn"
+      className={className}
+    >
+      <title>LinkedIn</title>
+      <rect width="24" height="24" rx="4" fill="#0A66C2" />
+      <path
+        fill="#fff"
+        d="M7.12 20.45H3.56V9h3.56v11.45zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.86 0-2.14 1.45-2.14 2.94v5.67H9.34V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29z"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -15,6 +15,7 @@ import { getHmrcBySlug, hmrcBySlugIdQueryOptions } from '../api/hmrc';
 import { AddressMap } from '../components/AddressMap';
 import GoogleLogo from '../components/GoogleLogo';
 import GovUkLogo from '../components/GovUkLogo';
+import LinkedInLogo from '../components/LinkedInLogo';
 import { NameHistory } from '../components/NameHistory';
 import { StatusBadge } from '../components/StatusBadge';
 import { formatAddress, formatDate, formatLocation, titleCase } from '../utils';
@@ -442,6 +443,17 @@ function CompanyDetail() {
                 >
                   <GoogleLogo className="h-5 w-auto" />
                   <span>Google</span>
+                  <ExternalLink size={14} aria-hidden="true" />
+                </a>
+                <a
+                  href={`https://www.linkedin.com/search/results/companies/?keywords=${encodeURIComponent(displayName)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Search LinkedIn for ${displayName}`}
+                  className="glass inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#0a66c2]! hover:text-white dark:text-white"
+                >
+                  <LinkedInLogo className="h-5 w-auto" />
+                  <span>LinkedIn</span>
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>
               </div>


### PR DESCRIPTION
## What

Adds a **LinkedIn** button to the "See more on" section of the company details page, beside the existing **GOV.UK** and **Google** buttons.

- New `LinkedInLogo` component — the LinkedIn "in" mark (brand-blue square + white glyph; the white stays visible on the blue hover, mirroring how the Google "G" survives its blue hover).
- Links to `https://www.linkedin.com/search/results/companies/?keywords=<company name>` (`displayName`, URL-encoded), opens in a new tab with `rel="noopener noreferrer"`, `aria-label="Search LinkedIn for <name>"`.
- No layout change needed — the buttons already use a wrapping flex row (`flex flex-wrap gap-2`), so the new pill **wraps to the next line automatically** when there isn't horizontal room.

## Verification

Lint + TypeScript clean. Rendered locally (zero console errors):

- **Desktop (~1280px):** GOV.UK · Google · LinkedIn in one row.
- **Mobile (~390px):** wraps — GOV.UK + Google on row one, LinkedIn on row two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LinkedIn logo component for external links
  * Added LinkedIn link button to company pages that directs to LinkedIn companies search

<!-- end of auto-generated comment: release notes by coderabbit.ai -->