### PR TITLE
feat: strip legal/suffix noise from external search URLs

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -18,7 +18,13 @@ import GovUkLogo from '../components/GovUkLogo';
 import LinkedInLogo from '../components/LinkedInLogo';
 import { NameHistory } from '../components/NameHistory';
 import { StatusBadge } from '../components/StatusBadge';
-import { formatAddress, formatDate, formatLocation, titleCase } from '../utils';
+import {
+  companySearchName,
+  formatAddress,
+  formatDate,
+  formatLocation,
+  titleCase,
+} from '../utils';
 import { buildCanonical } from '../utils/canonical';
 import { buildCompanyJsonLd, ratingPhrase } from '../utils/jsonld';
 
@@ -224,6 +230,8 @@ function CompanyDetail() {
   const displayName = profile?.company_name
     ? titleCase(profile.company_name)
     : hmrcName;
+  // Noise-stripped query so external searches land on the right company.
+  const searchQuery = encodeURIComponent(companySearchName(displayName));
   const currentKey = normalizeName(
     profile?.company_name ?? sponsor.organisationName,
   );
@@ -435,7 +443,7 @@ function CompanyDetail() {
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>
                 <a
-                  href={`https://www.google.com/search?q=${encodeURIComponent(displayName)}`}
+                  href={`https://www.google.com/search?q=${searchQuery}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Search Google for ${displayName}`}
@@ -446,7 +454,7 @@ function CompanyDetail() {
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>
                 <a
-                  href={`https://www.linkedin.com/search/results/companies/?keywords=${encodeURIComponent(displayName)}`}
+                  href={`https://www.linkedin.com/search/results/companies/?keywords=${searchQuery}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Search LinkedIn for ${displayName}`}

--- a/apps/web/src/utils.test.ts
+++ b/apps/web/src/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+
+import { companySearchName } from './utils.ts';
+
+describe('companySearchName', () => {
+  test('strips trailing legal suffixes', () => {
+    expect(companySearchName('Acme Ltd')).toBe('Acme');
+    expect(companySearchName('Acme Limited')).toBe('Acme');
+    expect(companySearchName('Globex PLC')).toBe('Globex');
+    expect(companySearchName('Initech LLP')).toBe('Initech');
+    expect(companySearchName('Acme, Inc')).toBe('Acme');
+    expect(companySearchName('Acme Holdings Ltd.')).toBe('Acme Holdings');
+  });
+
+  test('strips parenthetical qualifiers like (UK)', () => {
+    expect(companySearchName('Acme (UK) Ltd')).toBe('Acme');
+    expect(companySearchName('Acme (UK) Limited')).toBe('Acme');
+    expect(companySearchName('Acme (Holdings) PLC')).toBe('Acme');
+  });
+
+  test('strips a dangling "& Co" once the suffix is gone', () => {
+    expect(companySearchName('Smith & Co Ltd')).toBe('Smith');
+    expect(companySearchName('Smith and Co Limited')).toBe('Smith');
+  });
+
+  test('drops a "t/a" trading-as tail', () => {
+    expect(companySearchName('Foo Ltd t/a Bar')).toBe('Foo');
+    expect(companySearchName('Foo Limited trading as Bar')).toBe('Foo');
+  });
+
+  test('keeps meaningful name words (Group, Holdings, leading UK)', () => {
+    expect(companySearchName('Acme Group Limited')).toBe('Acme Group');
+    expect(companySearchName('UK Power Networks Limited')).toBe(
+      'UK Power Networks',
+    );
+    expect(companySearchName('Marks & Spencer Group Plc')).toBe(
+      'Marks & Spencer Group',
+    );
+  });
+
+  test('collapses whitespace and tidies punctuation', () => {
+    expect(companySearchName('  Acme   Ltd  ')).toBe('Acme');
+  });
+
+  test('falls back to the original when cleaning would empty it', () => {
+    expect(companySearchName('Limited')).toBe('Limited');
+    expect(companySearchName('Acme')).toBe('Acme');
+  });
+});

--- a/apps/web/src/utils.ts
+++ b/apps/web/src/utils.ts
@@ -101,6 +101,40 @@ export function formatLocation(
   return parts.join(', ');
 }
 
+// Trailing legal-entity suffixes stripped from a company name before searching.
+const SEARCH_SUFFIXES =
+  /[\s,]+(?:limited|ltd|plc|llp|llc|lp|cic|cio|inc|incorporated|corp|corporation|unlimited)\.?\s*$/i;
+
+/**
+ * Reduce a registered company name to a search-friendly query for external
+ * platforms (Google, LinkedIn). Drops parenthetical qualifiers like `(UK)`,
+ * any `t/a` ("trading as") tail, and trailing legal-entity suffixes (Ltd,
+ * Limited, PLC, LLP, …) — all noise that pushes the platform onto the wrong
+ * result. Falls back to the trimmed original if cleaning would empty it.
+ */
+export function companySearchName(name: string): string {
+  const original = name.trim();
+  let s = original
+    .replace(/\([^)]*\)/g, ' ') // "(UK)", "(Holdings)", …
+    .replace(/\b(?:t\/a|trading as)\b.*$/i, ' ') // legal name precedes "t/a …"
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Peel trailing suffixes repeatedly (e.g. "Foo & Co Ltd." -> "Foo & Co").
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(SEARCH_SUFFIXES, '').trim();
+  } while (s !== prev);
+
+  s = s
+    .replace(/[\s,]+(?:&|and)\s+co\.?\s*$/i, '') // dangling "& Co"
+    .replace(/[\s,&-]+$/, '') // leftover trailing punctuation
+    .trim();
+
+  return s || original;
+}
+
 /**
  * Format an ISO date string as a UK long-form date (`5 April 2026`). Returns
  * an empty string for missing or unparseable input.


### PR DESCRIPTION
## Problem

The **Google** and **LinkedIn** "See more on" links searched the raw company name. Noise like `(UK)`, `Ltd`, `Limited` (and other legal-entity suffixes) frequently sent the platform to the wrong result.

## Fix

New pure helper `companySearchName(name)` in `apps/web/src/utils.ts`, applied to both URLs before encoding:

- Drops **parenthetical qualifiers** — `(UK)`, `(Holdings)`, …
- Drops a **`t/a` / "trading as"** tail (the legal name precedes it).
- Peels **trailing legal-entity suffixes** (case-insensitive, repeatable, tolerant of `.`/`,`): `Limited, Ltd, PLC, LLP, LLC, LP, CIC, CIO, Inc, Incorporated, Corp, Corporation, Unlimited`.
- Removes a dangling **`& Co`** once the suffix is gone.
- **Keeps meaningful words** — `Group`, `Holdings`, and a *leading* `UK` (e.g. `UK Power Networks`) are preserved; only parenthetical/trailing noise is removed.
- **Falls back** to the trimmed original if cleaning would empty the string.

Both buttons share one cleaned query; the `aria-label` still uses the full display name. No visual change.

## Verification

- Unit tests added (`apps/web/src/utils.test.ts`) — 7 cases, all passing.
- Verified live on a real `…Ltd` company; rendered hrefs:
  - `…/search?q=Gujjar%20Logistics%20Service` (was `…Gujjar%20Logistics%20Service%20Ltd`)
  - `…/companies/?keywords=Gujjar%20Logistics%20Service`
- Lint + TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)