### PR TITLE
feat: flip brand logos on hover so they don't blend into the pill

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -447,9 +447,9 @@ function CompanyDetail() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Search Google for ${displayName}`}
-                  className="glass inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#4285f4]! hover:text-white dark:text-white"
+                  className="glass brand-link brand-link-google inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#4285f4]! hover:text-white dark:text-white"
                 >
-                  <GoogleLogo className="h-5 w-auto" />
+                  <GoogleLogo className="brand-mark h-5 w-auto" />
                   <span>Google</span>
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>
@@ -458,9 +458,9 @@ function CompanyDetail() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Search LinkedIn for ${displayName}`}
-                  className="glass inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#0a66c2]! hover:text-white dark:text-white"
+                  className="glass brand-link brand-link-linkedin inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#0a66c2]! hover:text-white dark:text-white"
                 >
-                  <LinkedInLogo className="h-5 w-auto" />
+                  <LinkedInLogo className="brand-mark h-5 w-auto" />
                   <span>LinkedIn</span>
                   <ExternalLink size={14} aria-hidden="true" />
                 </a>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -301,6 +301,25 @@ a {
   box-shadow: var(--shadow-card-full);
 }
 
+/* Brand link logo flip: on hover the pill turns the brand colour, so recolour
+   the company SVG mark (`.brand-mark`) to a contrasting fill so it doesn't blend
+   in. Scoped to `.brand-mark` so the external-link icon is left untouched. */
+.brand-link .brand-mark path,
+.brand-link .brand-mark rect {
+  transition: fill 0.3s ease;
+}
+/* Google "G": flip the multi-colour mark to solid white on the blue hover. */
+.brand-link-google:hover .brand-mark path {
+  fill: #fff;
+}
+/* LinkedIn: swap square/glyph so a white square stays visible on the blue hover. */
+.brand-link-linkedin:hover .brand-mark rect {
+  fill: #fff;
+}
+.brand-link-linkedin:hover .brand-mark path {
+  fill: #0a66c2;
+}
+
 .heading-card {
   letter-spacing: -0.4px;
 }


### PR DESCRIPTION
## Problem

Each "See more on" pill turns its brand colour on hover. That made the brand logos blend into the background:
- Google's "G" — its blue segment merged into the blue hover bg.
- LinkedIn's mark — the blue square vanished into the blue hover bg, leaving only the "in".

## Fix

Recolour the **company SVG marks on hover** (no background changes):
- **Google** G → solid white.
- **LinkedIn** → white square + `#0a66c2` "in" (a flip), so a white square stays visible on the blue.
- **GOV.UK** — unchanged; its logo is already `currentColor` (white on hover).

Implemented as small rules in `styles.css` (alongside `.glass`), with a fill transition to match the existing 300ms hover.

### Scoped to the brand mark only
The recolour targets a new `.brand-mark` class on the logos, so the **external-link "↗" icons are left untouched** — they keep their `currentColor` stroke (white on hover), fill `none`. Verified live:

| | brand mark (hover) | external-link icon (hover) |
|---|---|---|
| Google | G fill `#fff` | fill `none`, stroke `#fff` ✓ |
| LinkedIn | square `#fff`, "in" `#0a66c2` | fill `none`, stroke `#fff` ✓ |

Backgrounds (GOV.UK `#1d70b8`, Google `#4285f4`, LinkedIn `#0a66c2`) are all unchanged. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual styling of external link buttons for Google and LinkedIn across the platform
  * Added interactive hover animations with smooth color transitions to brand link buttons for improved visual feedback
  * Enhanced user experience with better visual polish and interactivity on branded external links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->