### PR TITLE
fix: more vertical gap between wrapped "See more on" buttons

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -428,7 +428,7 @@ function CompanyDetail() {
               <h3 className="mb-2 text-[10px] font-medium tracking-wider text-(--sea-ink-soft) uppercase">
                 See more on
               </h3>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-x-2 gap-y-3">
                 <a
                   href={`https://find-and-update.company-information.service.gov.uk/company/${profile.company_number}`}
                   target="_blank"

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -428,7 +428,7 @@ function CompanyDetail() {
               <h3 className="mb-2 text-[10px] font-medium tracking-wider text-(--sea-ink-soft) uppercase">
                 See more on
               </h3>
-              <div className="flex flex-wrap gap-x-2 gap-y-3">
+              <div className="flex flex-wrap gap-x-2 gap-y-4">
                 <a
                   href={`https://find-and-update.company-information.service.gov.uk/company/${profile.company_number}`}
                   target="_blank"


### PR DESCRIPTION
## Problem

On mobile the GOV.UK / Google / LinkedIn pills in the "See more on" section wrap to multiple rows, but the container used a single `gap-2` (8px) for both axes — so wrapped rows sat only 8px apart, close enough to mis-tap.

## Fix

Split the gap: `gap-2` → `gap-x-2 gap-y-3` — horizontal gap stays 8px, the row (vertical) gap grows to 12px for comfortable tap spacing. Desktop renders a single row, so this only affects the wrapped mobile layout.

Verified at 390px — clearer separation between the rows; horizontal spacing unchanged. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)