### PR TITLE
fix: equalise "See more on" button gaps on mobile only

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -428,7 +428,7 @@ function CompanyDetail() {
               <h3 className="mb-2 text-[10px] font-medium tracking-wider text-(--sea-ink-soft) uppercase">
                 See more on
               </h3>
-              <div className="flex flex-wrap gap-x-2 gap-y-4">
+              <div className="flex flex-wrap gap-4 sm:gap-x-2">
                 <a
                   href={`https://find-and-update.company-information.service.gov.uk/company/${profile.company_number}`}
                   target="_blank"


### PR DESCRIPTION
## What

On mobile the wrapped GOV.UK / Google / LinkedIn pills had an asymmetric gap — 8px horizontal, 16px vertical. Make the **mobile** spacing uniform while leaving **desktop** unchanged.

`gap-x-2 gap-y-4` → `gap-4 sm:gap-x-2`:
- **Mobile (< 640px):** `gap-4` → 16px on both axes (symmetric).
- **Desktop (≥ 640px):** `sm:gap-x-2` overrides the horizontal back to 8px; the row stays one line so vertical is moot. Unchanged from current.

## Verification

- Mobile (390px): horizontal gap now matches the row gap (both 16px).
- Desktop (1280px): single row, 8px horizontal — unchanged.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)