### PR TITLE
feat: grayscale brand icons that colourise on hover

### DIFF
--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -434,7 +434,7 @@ function CompanyDetail() {
                   href={`https://find-and-update.company-information.service.gov.uk/company/${profile.company_number}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="glass inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#1d70b8]! hover:text-white dark:text-white"
+                  className="glass inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[box-shadow]! duration-300! dark:text-white"
                 >
                   {flagState.govukBranded ? (
                     <GovUkLogo className="h-5 w-auto" />
@@ -449,7 +449,7 @@ function CompanyDetail() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Search Google for ${displayName}`}
-                className="glass brand-link brand-link-google inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#4285f4]! hover:text-white dark:text-white"
+                className="glass brand-link inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[box-shadow]! duration-300! dark:text-white"
               >
                 <GoogleLogo className="brand-mark h-5 w-auto" />
                 <span>Google</span>
@@ -460,7 +460,7 @@ function CompanyDetail() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Search LinkedIn for ${displayName}`}
-                className="glass brand-link brand-link-linkedin inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[color,background-color,box-shadow]! duration-300! hover:bg-[#0a66c2]! hover:text-white dark:text-white"
+                className="glass brand-link inline-flex w-fit items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-black no-underline transition-[box-shadow]! duration-300! dark:text-white"
               >
                 <LinkedInLogo className="brand-mark h-5 w-auto" />
                 <span>LinkedIn</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -301,23 +301,14 @@ a {
   box-shadow: var(--shadow-card-full);
 }
 
-/* Brand link logo flip: on hover the pill turns the brand colour, so recolour
-   the company SVG mark (`.brand-mark`) to a contrasting fill so it doesn't blend
-   in. Scoped to `.brand-mark` so the external-link icon is left untouched. */
-.brand-link .brand-mark path,
-.brand-link .brand-mark rect {
-  transition: fill 0.3s ease;
+/* Brand mark rests in grayscale and reveals its full brand colour on hover.
+   Scoped to `.brand-mark` so the external-link icon is left untouched. */
+.brand-link .brand-mark {
+  filter: grayscale(1);
+  transition: filter 0.3s ease;
 }
-/* Google "G": flip the multi-colour mark to solid white on the blue hover. */
-.brand-link-google:hover .brand-mark path {
-  fill: #fff;
-}
-/* LinkedIn: swap square/glyph so a white square stays visible on the blue hover. */
-.brand-link-linkedin:hover .brand-mark rect {
-  fill: #fff;
-}
-.brand-link-linkedin:hover .brand-mark path {
-  fill: #0a66c2;
+.brand-link:hover .brand-mark {
+  filter: grayscale(0);
 }
 
 .heading-card {


### PR DESCRIPTION
## What

Reworks the "See more on" hover treatment:

- **Brand icons rest in grayscale** and **reveal full brand colour on hover** (`filter: grayscale(1)` → `grayscale(0)`, 300ms), scoped to `.brand-mark` so the external-link icons are untouched.
- **Removed the per-button hover background colours** (GOV.UK `#1d70b8`, Google `#4285f4`, LinkedIn `#0a66c2`) and the white-text flip. The pills now keep only the shared `glass` background + its hover shadow.
- GOV.UK is a monochrome wordmark (`currentColor`), so the grayscale toggle is a no-op there — it just loses its coloured hover background like the others.
- Tidied the buttons' transition to `transition-[box-shadow]` (colour/background no longer animate) and dropped the now-unused `brand-link-google`/`brand-link-linkedin` modifier classes.

## Verification (live, computed values)

| State | Google / LinkedIn mark `filter` | button background |
|---|---|---|
| Rest | `grayscale(1)` | glass `rgba(255,255,255,.5)` |
| Hover | `grayscale(0)` | glass `rgba(255,255,255,.5)` (no brand colour) |

Screenshots confirm: grayscale at rest, the hovered icon colourises while siblings stay grey, and no pill changes background colour. Lint + TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- Updated external-link button styling to provide a more unified visual appearance and consistent hover behavior across GOV.UK, Google, and LinkedIn links
- Refined the hover effects and visual animations for brand marks, delivering improved transition smoothness and overall visual polish
- Enhanced styling consistency across all interactive elements in the company details experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->