### PR TITLE
feat: show "114K+" in the empty-state hero

### DIFF
--- a/apps/web/src/components/HeroText.tsx
+++ b/apps/web/src/components/HeroText.tsx
@@ -4,19 +4,19 @@ import styles from './HeroText.module.css';
 
 /**
  * Empty-state landing hero — a big, confident stat (Grok / Colossus style): the
- * live sponsor count abbreviated as "<n>K" in high-contrast type over a muted
+ * live sponsor count abbreviated as "<n>K+" in high-contrast type over a muted
  * supporting label. The number is the petrol-pump <Odometer>, rolling up to the
  * live count. Rendered only while the search input is empty, so its entrance
  * animation runs on mount and unmounts the moment the user types. Theme-aware
  * via --sea-ink tokens; honours reduced-motion.
  */
 // Conservative floor (in thousands) shown if the live count is unavailable (cold
-// client nav or a failed fetch). The real figure is above this, so "<n>K" stays true.
+// client nav or a failed fetch). The real figure is above this, so "<n>K+" stays true.
 const FALLBACK_THOUSANDS = 100;
 
 export default function HeroText({ count }: { count?: number }) {
-  // Whole thousands, floored, so "<n>K" is always a truthful lower bound of the
-  // live count (e.g. 114,145 → "114K").
+  // Whole thousands, floored, so "<n>K+" is always a truthful lower bound of the
+  // live count (e.g. 114,145 → "114K+").
   const thousands =
     count && count >= 1000 ? Math.floor(count / 1000) : FALLBACK_THOUSANDS;
   return (
@@ -27,7 +27,7 @@ export default function HeroText({ count }: { count?: number }) {
       <span className={styles.streaks} aria-hidden="true" />
       <span className={styles.figure} aria-hidden="true">
         <Odometer value={thousands} durationMs={1600} delayMs={900} />
-        <span className={styles.suffix}>K</span>
+        <span className={styles.suffix}>K+</span>
       </span>
 
       <span className={styles.subline} aria-hidden="true">


### PR DESCRIPTION
Adds a trailing **`+`** after the abbreviated hero count, so it reads **`114K+`** instead of `114K`.

The figure is floored to whole thousands (`Math.floor(count / 1000)`), so the real count is always higher than what's shown — the `+` makes that explicit. The `aria-label` already reads "114,000+ licensed UK visa sponsors", so this just brings the visible glyph in line with it.

One-line change to the suffix span (`K` → `K+`); comments updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)