### PR TITLE
fix: keep the page gradient continuous into the footer (Windows + iOS)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,7 +54,7 @@
   --bg-page-edge: #f4f4f8;
   --shimmer-base: var(--sea-ink-faint);
   --shimmer-peak: var(--sea-ink);
-  --bg-wash: rgba(0, 114, 245, 0.05);
+  --bg-wash: rgba(0, 114, 245, 0.1);
 }
 
 .dark {
@@ -104,7 +104,7 @@
   --bg-page-edge: #0a0a0a;
   --shimmer-base: var(--sea-ink-soft);
   --shimmer-peak: var(--sea-ink);
-  --bg-wash: rgba(99, 102, 241, 0.07);
+  --bg-wash: rgba(99, 102, 241, 0.09);
 }
 
 html,
@@ -121,17 +121,20 @@ html {
    * own opaque bg. Uses --bg-page-edge so the gutter colour stays theme-aware. */
   scrollbar-gutter: stable;
   background-color: var(--bg-page-edge);
-  /* Viewport-fixed wash that lifts the bottom edge so the page gradient flows
-   * continuously into the footer instead of collapsing to the flat edge colour.
-   * Lives on the root (behind everything) so it sits under the body glows and
-   * the grid/dots pseudo-elements. */
-  background-image: radial-gradient(
-    ellipse 100% 45% at 50% 100%,
+}
+
+/* Fixed bottom colour wash so the page gradient reaches the footer at short viewport heights; a pseudo-element (vs background-attachment:fixed) avoids a Windows scrollbar-gutter seam + per-frame repaint. */
+html::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background: radial-gradient(
+    ellipse 110% 55% at 50% 100%,
     var(--bg-wash),
     transparent
   );
-  background-attachment: fixed;
-  background-repeat: no-repeat;
 }
 
 body {
@@ -186,11 +189,10 @@ body::after {
     linear-gradient(var(--grid-line) 1px, transparent 1px),
     linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
   background-size: 60px 60px;
-  mask-image: radial-gradient(
-    ellipse 70% 50% at 50% 30%,
-    black,
-    transparent 70%
-  );
+  /* vignette + additive bottom floor (composites by default add) so a faint grid still reaches the footer at short viewport heights; the floor rotates 26deg with the grid */
+  mask-image:
+    radial-gradient(ellipse 70% 50% at 50% 30%, black, transparent 70%),
+    linear-gradient(to bottom, transparent 45%, rgba(0, 0, 0, 0.4) 100%);
 }
 
 a:where(:not([class*='no-underline'])) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -119,22 +119,13 @@ html {
    * lives here (rather than on body) so that body remains transparent and the
    * `body::after` grid pseudo-element (z-index: -1) isn't hidden behind body's
    * own opaque bg. Uses --bg-page-edge so the gutter colour stays theme-aware. */
+  /* height:100% (with body's min-height:100% below) makes the body fill the
+     viewport when content is short, so its glow background reaches the bottom
+     edge instead of the bare --bg-page-edge showing as a border. Percentage,
+     not vh/dvh — avoids the iOS dynamic-viewport quirks. */
+  height: 100%;
   scrollbar-gutter: stable;
   background-color: var(--bg-page-edge);
-}
-
-/* Decorative glows + a bottom colour wash on a fixed full-viewport layer, so they always cover the viewport (incl. when the page is shorter than the window) without depending on body height — avoids both the clipped-glow block and the iOS 100dvh issues. Sits behind the dots/grid pseudo-elements and body content. */
-html::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
-  background:
-    radial-gradient(ellipse 80% 50% at 50% -20%, var(--glow-a), transparent),
-    radial-gradient(ellipse 60% 40% at 100% 50%, var(--glow-b), transparent),
-    radial-gradient(ellipse 50% 50% at 0% 80%, var(--glow-c), transparent),
-    radial-gradient(ellipse 110% 55% at 50% 100%, var(--bg-wash), transparent);
 }
 
 body {
@@ -142,6 +133,14 @@ body {
   color: var(--sea-ink);
   font-family: var(--font-sans);
   font-feature-settings: 'liga' 1;
+  /* Glows + bottom colour wash on the body (not a fixed/root layer): the body
+     covers the document including iOS's under-toolbar area, so the footer never
+     drops to the bare black --bg-page-edge there. */
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -20%, var(--glow-a), transparent),
+    radial-gradient(ellipse 60% 40% at 100% 50%, var(--glow-b), transparent),
+    radial-gradient(ellipse 50% 50% at 0% 80%, var(--glow-c), transparent),
+    radial-gradient(ellipse 110% 55% at 50% 100%, var(--bg-wash), transparent);
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,7 +54,7 @@
   --bg-page-edge: #f4f4f8;
   --shimmer-base: var(--sea-ink-faint);
   --shimmer-peak: var(--sea-ink);
-  --bg-wash: rgba(0, 114, 245, 0.1);
+  --bg-wash: rgba(0, 114, 245, 0.14);
 }
 
 .dark {
@@ -104,7 +104,7 @@
   --bg-page-edge: #0a0a0a;
   --shimmer-base: var(--sea-ink-soft);
   --shimmer-peak: var(--sea-ink);
-  --bg-wash: rgba(99, 102, 241, 0.09);
+  --bg-wash: rgba(99, 102, 241, 0.11);
 }
 
 html,
@@ -189,10 +189,12 @@ body::after {
     linear-gradient(var(--grid-line) 1px, transparent 1px),
     linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
   background-size: 60px 60px;
-  /* vignette + additive bottom floor (composites by default add) so a faint grid still reaches the footer at short viewport heights; the floor rotates 26deg with the grid */
-  mask-image:
-    radial-gradient(ellipse 70% 50% at 50% 30%, black, transparent 70%),
-    linear-gradient(to bottom, transparent 45%, rgba(0, 0, 0, 0.4) 100%);
+  /* soft full-viewport vignette that never fully fades (floor), so the grid stays visible through the footer regardless of where it lands in the viewport */
+  mask-image: radial-gradient(
+    ellipse 90% 75% at 50% 38%,
+    black,
+    rgba(0, 0, 0, 0.55) 90%
+  );
 }
 
 a:where(:not([class*='no-underline'])) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -123,31 +123,25 @@ html {
   background-color: var(--bg-page-edge);
 }
 
-/* Fixed bottom colour wash so the page gradient reaches the footer at short viewport heights; a pseudo-element (vs background-attachment:fixed) avoids a Windows scrollbar-gutter seam + per-frame repaint. */
+/* Decorative glows + a bottom colour wash on a fixed full-viewport layer, so they always cover the viewport (incl. when the page is shorter than the window) without depending on body height — avoids both the clipped-glow block and the iOS 100dvh issues. Sits behind the dots/grid pseudo-elements and body content. */
 html::before {
   content: '';
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: -1;
-  background: radial-gradient(
-    ellipse 110% 55% at 50% 100%,
-    var(--bg-wash),
-    transparent
-  );
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -20%, var(--glow-a), transparent),
+    radial-gradient(ellipse 60% 40% at 100% 50%, var(--glow-b), transparent),
+    radial-gradient(ellipse 50% 50% at 0% 80%, var(--glow-c), transparent),
+    radial-gradient(ellipse 110% 55% at 50% 100%, var(--bg-wash), transparent);
 }
 
 body {
   margin: 0;
-  /* Fill the viewport even when content is short, so the glow background isn't clipped at the body's bottom edge (which showed as a hard-edged block on short windows). */
-  min-height: 100dvh;
   color: var(--sea-ink);
   font-family: var(--font-sans);
   font-feature-settings: 'liga' 1;
-  background-image:
-    radial-gradient(ellipse 80% 50% at 50% -20%, var(--glow-a), transparent),
-    radial-gradient(ellipse 60% 40% at 100% 50%, var(--glow-b), transparent),
-    radial-gradient(ellipse 50% 50% at 0% 80%, var(--glow-c), transparent);
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -139,6 +139,8 @@ html::before {
 
 body {
   margin: 0;
+  /* Fill the viewport even when content is short, so the glow background isn't clipped at the body's bottom edge (which showed as a hard-edged block on short windows). */
+  min-height: 100dvh;
   color: var(--sea-ink);
   font-family: var(--font-sans);
   font-feature-settings: 'liga' 1;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,6 +54,7 @@
   --bg-page-edge: #f4f4f8;
   --shimmer-base: var(--sea-ink-faint);
   --shimmer-peak: var(--sea-ink);
+  --bg-wash: rgba(0, 114, 245, 0.05);
 }
 
 .dark {
@@ -103,6 +104,7 @@
   --bg-page-edge: #0a0a0a;
   --shimmer-base: var(--sea-ink-soft);
   --shimmer-peak: var(--sea-ink);
+  --bg-wash: rgba(99, 102, 241, 0.07);
 }
 
 html,
@@ -119,6 +121,17 @@ html {
    * own opaque bg. Uses --bg-page-edge so the gutter colour stays theme-aware. */
   scrollbar-gutter: stable;
   background-color: var(--bg-page-edge);
+  /* Viewport-fixed wash that lifts the bottom edge so the page gradient flows
+   * continuously into the footer instead of collapsing to the flat edge colour.
+   * Lives on the root (behind everything) so it sits under the body glows and
+   * the grid/dots pseudo-elements. */
+  background-image: radial-gradient(
+    ellipse 100% 45% at 50% 100%,
+    var(--bg-wash),
+    transparent
+  );
+  background-attachment: fixed;
+  background-repeat: no-repeat;
 }
 
 body {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -191,11 +191,10 @@ body::after {
     linear-gradient(var(--grid-line) 1px, transparent 1px),
     linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
   background-size: 60px 60px;
-  /* soft full-viewport vignette that never fully fades (floor), so the grid stays visible through the footer regardless of where it lands in the viewport */
   mask-image: radial-gradient(
-    ellipse 90% 75% at 50% 38%,
+    ellipse 70% 50% at 50% 30%,
     black,
-    rgba(0, 0, 0, 0.55) 90%
+    transparent 70%
   );
 }
 


### PR DESCRIPTION
## Symptom

The bottom of the page / footer rendered differently from the content above it, across a few forms — all of which traced to the same root:
- **Windows desktop:** footer read as a flat colour band / a hard-edged "block" in the bottom-left.
- **iOS Safari:** a **black band clipping the footer copyright**.
- Never reproduced on macOS desktop or in headless Chrome.

## Root cause — viewport height + where the background is painted

1. **Decoration faded before the footer on short windows.** The glow/grid background fades toward the bottom; on short windows (1366×768 Windows laptops, iOS) the footer lands in the faded zone and dropped to the flat `--bg-page-edge`. Macs are taller, so it rarely showed → looked "Windows-only".
2. **The body didn't fill the viewport.** `<body>` was only as tall as its content (the `min-height: 100%` chain never resolved, since `<html>`'s height was `auto`), so on a window taller than the content the bare `<html>` colour showed as a border, and the body-painted glow was clipped into a block.
3. **iOS black band:** an intermediate attempt moved the glows onto a fixed `html::before` layer, but a fixed/root layer does **not** paint into iOS Safari's under-toolbar / safe-area region (the body does). So the footer there fell back to the bare black `--bg-page-edge`.

## Fix

- **Glows + a bottom colour wash live on `<body>`** (not a fixed/root layer). The body covers the whole document, including iOS's under-toolbar area, so the footer stays on the gradient everywhere.
- **`html { height: 100% }` + `body { min-height: 100% }`** makes the body fill the viewport when content is short, so the glow reaches the bottom edge instead of the flat colour showing as a border/block. **Percentage, not `vh`/`dvh`** — `dvh` + the iOS toolbar + `viewport-fit=cover` was what produced the black band.

The diagonal grid vignette is unchanged from `main`. Net change: the `--bg-wash` tokens, one extra gradient layer on `body`, and `html { height: 100% }`.

## Verification

- **Real iOS Safari** (driven via webcam + HMR): footer flows on the gradient into the Safari toolbar, no black band.
- **Desktop Chrome** (headless, 954×911 short window): body fills the viewport, no border/block, footer continuous; both themes.
- `bun lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)