### PR TITLE
fix: firefox bug

### DIFF
--- a/apps/web/src/components/HeroText.module.css
+++ b/apps/web/src/components/HeroText.module.css
@@ -104,9 +104,11 @@
   }
 }
 
-/* "K" suffix tracks the number's size/weight. */
+/* "K+" suffix tracks the number's size/weight. nowrap so Firefox doesn't treat
+   the "+" as a break opportunity and drop it to the next line. */
 .suffix {
   display: inline-block;
+  white-space: nowrap;
 }
 
 /* Muted supporting label below the stat. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping in the hero section where the "+" character was breaking onto a separate line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->