### PR TITLE
fix: bug fix that caused the input field to hide out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,12 @@ with `!important` (needed to beat React's inline opacity). This lets React defau
   defeats the safety-net poll's `!getItem(...)` guard — hiding the input forever
   on a non-restoring full load (empty/short/zero-result home, where `ready` never
   becomes true so the restore effect never consumes the key). Two guards keep the
-  key meaning a real scroll: the `HmrcCard` click writer only persists when
-  `scrollY > 0` (else `removeItem`), and `search-input-init.ts` stamps only when
-  the saved value `parseInt`s to `> 0`.
+  key meaning a real scroll: the `HmrcCard` click + `HmrcResults` `pagehide`
+  writers only persist when `scrollY >= 1` (click else `removeItem`), and
+  `search-input-init.ts` stamps only when the saved value `parseInt`s to `>= 1`.
+  Use `>= 1`, not `> 0`: writers and reader must agree, and a sub-pixel scroll
+  (e.g. `0.6`, HiDPI/zoom) floors to `0` on read — persisting it would stamp the
+  hide with nothing the reader (or restore) will honor.
 - **`HmrcResults` discards a stranded key on non-restoring mounts**: a `useEffect`
   keyed on `[search, isLoading, results.length]` `removeItem`s `hmrc-scroll-y`
   unless `search.length >= 3 && (isLoading || results.length > 0)`. This closes the
@@ -37,13 +40,26 @@ with `!important` (needed to beat React's inline opacity). This lets React defau
   do NOT widen it to drop the `isLoading ||` disjunct or add `ready` to its deps.
 - **Attribute is cleared on `isStuck=true` via `useLayoutEffect`**: by then React's
   inline `opacity:0` is in place, so dropping the CSS gate is safe.
+- **The safety-net poll clears on "restore done AND not pill", NOT `scrollY === 0`**:
+  the restore can settle at a few px — a small saved scroll, or a large one that
+  *clamps* because the `scrollTo` rAF raced the virtual list's height — leaving the
+  sentinel in view (input mode, not pill) where `isStuck` never goes true. The old
+  `scrollY === 0` guard never matched there, stranding the input hidden (visible
+  symptom: results page, no input, no pill, "scroll to recover"). The poll now waits
+  for `hmrc-scroll-y` to be consumed, then reads the sentinel: in view → not pill →
+  clear; scrolled out → leave it for the `isStuck` clearer (so the input never
+  flashes at a scrolled position). Gating the rect read on `!getItem(...)` keeps it
+  post-restore and accurate.
 
 ### Anti-patterns (past bugs)
 
 - **`useLayoutEffect` to set opacity directly**: no-op on server → first SSR paint
   shows the input before JS hides it.
-- **Synchronous `getBoundingClientRect` in `useSearchPill`**: sentinel is briefly
-  in-viewport on back-nav before scroll restores, so the read lies.
+- **Synchronous `getBoundingClientRect` in `useSearchPill` — only safe when gated on
+  `!hmrc-scroll-y`**: sentinel is briefly in-viewport on back-nav *before* scroll
+  restores, so an ungated read lies. The safety-net poll may read it because it only
+  does so once the key is gone (restore complete) — the read is then post-restore and
+  accurate. Do NOT add an ungated rect read elsewhere.
 - **Diverging server/client initial state for `ready`**: hydration mismatch → React
   reconciles to client and overwrites server HTML, producing a worse flash. The
   pre-hydration attribute is the only correct way to encode client-only first-paint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,21 @@ with `!important` (needed to beat React's inline opacity). This lets React defau
 - **Safety-net cleanup must NOT remove `hmrc-scroll-y`**: `HmrcResults` owns key
   consumption, and its `ready` gate (data + fonts + width) can take many frames.
   Clearing the key here races scroll-restore on back-nav.
+- **`hmrc-scroll-y` means "restore to Y > 0", never "0"**: a saved `"0"` is a
+  truthy string, so it stamps the hide attribute (`search-input-init.ts`) AND
+  defeats the safety-net poll's `!getItem(...)` guard — hiding the input forever
+  on a non-restoring full load (empty/short/zero-result home, where `ready` never
+  becomes true so the restore effect never consumes the key). Two guards keep the
+  key meaning a real scroll: the `HmrcCard` click writer only persists when
+  `scrollY > 0` (else `removeItem`), and `search-input-init.ts` stamps only when
+  the saved value `parseInt`s to `> 0`.
+- **`HmrcResults` discards a stranded key on non-restoring mounts**: a `useEffect`
+  keyed on `[search, isLoading, results.length]` `removeItem`s `hmrc-scroll-y`
+  unless `search.length >= 3 && (isLoading || results.length > 0)`. This closes the
+  permanent-hide where *any* truthy stale value lands on the empty/short/zero-result
+  home with no consumer. Its guard is shaped to preserve the key through a genuine
+  pending restore (loading, or rows present), so it never races the restore effect —
+  do NOT widen it to drop the `isLoading ||` disjunct or add `ready` to its deps.
 - **Attribute is cleared on `isStuck=true` via `useLayoutEffect`**: by then React's
   inline `opacity:0` is in place, so dropping the CSS gate is safe.
 

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -47,7 +47,13 @@ export default function HmrcCard({
         ...(isActive ? { viewTransitionName: 'active-card' } : {}),
       }}
       onClick={() => {
-        sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
+        // Persist scroll only when scrolled — a "0" is truthy and would strand
+        // the pre-hydration hide with no consumer to clear it (see CLAUDE.md).
+        if (window.scrollY > 0) {
+          sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
+        } else {
+          sessionStorage.removeItem('hmrc-scroll-y');
+        }
         sessionStorage.setItem('hmrc-active-id', row.slugId);
         sessionStorage.setItem(
           'hmrc-highlight',

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -47,9 +47,10 @@ export default function HmrcCard({
         ...(isActive ? { viewTransitionName: 'active-card' } : {}),
       }}
       onClick={() => {
-        // Persist scroll only when scrolled — a "0" is truthy and would strand
-        // the pre-hydration hide with no consumer to clear it (see CLAUDE.md).
-        if (window.scrollY > 0) {
+        // Persist only a real (>=1px) scroll; a "0"/sub-pixel value is truthy but
+        // floors to 0 on read, so it would strand the pre-hydration hide with no
+        // consumer to clear it. Threshold matches the reader's `parseInt > 0`.
+        if (window.scrollY >= 1) {
           sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
         } else {
           sessionStorage.removeItem('hmrc-scroll-y');

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -146,6 +146,16 @@ export default function HmrcResults({ search }: { search: string }) {
     }
   }, [ready]);
 
+  // Discard a stranded scroll key on any mount that cannot restore (empty/short
+  // query or zero rows) so the next full load's pre-hydration script can't hide
+  // the input with no consumer left to clear it. The guard keeps the key alive
+  // through a genuine pending restore (search>=3 while loading or with rows), so
+  // the restore effect above stays its sole consumer and the back-nav race holds.
+  useEffect(() => {
+    const canRestore = search.length >= 3 && (isLoading || results.length > 0);
+    if (!canRestore) sessionStorage.removeItem('hmrc-scroll-y');
+  }, [search, isLoading, results.length]);
+
   useEffect(() => {
     const lastItem = virtualItems[virtualItems.length - 1];
     if (!lastItem) return;

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -151,10 +151,11 @@ export default function HmrcResults({ search }: { search: string }) {
   // the input with no consumer left to clear it. The guard keeps the key alive
   // through a genuine pending restore (search>=3 while loading or with rows), so
   // the restore effect above stays its sole consumer and the back-nav race holds.
+  const hasRows = results.length > 0;
   useEffect(() => {
-    const canRestore = search.length >= 3 && (isLoading || results.length > 0);
+    const canRestore = search.length >= 3 && (isLoading || hasRows);
     if (!canRestore) sessionStorage.removeItem('hmrc-scroll-y');
-  }, [search, isLoading, results.length]);
+  }, [search, isLoading, hasRows]);
 
   useEffect(() => {
     const lastItem = virtualItems[virtualItems.length - 1];
@@ -171,7 +172,8 @@ export default function HmrcResults({ search }: { search: string }) {
   useEffect(() => {
     if (results.length === 0) return;
     const onPageHide = () => {
-      if (window.scrollY > 0) {
+      // Match the reader's `parseInt > 0` gate — sub-pixel scroll floors to 0.
+      if (window.scrollY >= 1) {
         sessionStorage.setItem('hmrc-scroll-y', String(window.scrollY));
       }
     };

--- a/apps/web/src/hooks/useSearchPill.ts
+++ b/apps/web/src/hooks/useSearchPill.ts
@@ -104,20 +104,26 @@ export function useSearchPill(
     if (isStuck) clearHideAttribute();
   }, [isStuck]);
 
-  // Safety net: if the inline script set the attribute but we end up at the
-  // top of the page with nothing to restore, drop it. Polls every animation
-  // frame and terminates only when one of three conditions is met:
-  //   1. The attribute has been removed by another path (e.g., `isStuck=true`
-  //      via the useLayoutEffect above).
-  //   2. `scrollY === 0` and `hmrc-scroll-y` has been consumed by HmrcResults.
+  // Safety net: drop the attribute once the restore is done UNLESS we've landed
+  // in pill mode. Polls every animation frame and terminates when one of:
+  //   1. The attribute was removed by another path (e.g. `isStuck=true` above).
+  //   2. `hmrc-scroll-y` is consumed AND the sentinel is in view (not pill) — so
+  //      the input is the correct final state and we clear.
   //   3. The component unmounts (cancelled flag stops the next tick).
   //
-  // A naive timeout cutoff isn't safe — HmrcResults' scroll-restore is gated
-  // on the virtualizer's font/width readiness, which can take an indefinite
-  // number of frames on slow loads. Anything shorter than "wait until the
-  // restore actually happens" leaves a race window where the attribute
-  // persists with no remaining clearer. rAF auto-pauses on background tabs,
-  // so an open-ended poll has no idle cost when the user isn't looking.
+  // We can't gate on `scrollY === 0`: a small or clamped restore (the rAF can
+  // race the virtual list's height and settle at a few px) leaves the sentinel
+  // in view — input mode, not pill — where `isStuck` never goes true and the old
+  // `scrollY === 0` guard never matched, stranding the input hidden. Reading the
+  // sentinel only after the key is gone keeps the rect post-restore and accurate
+  // (not the pre-restore lie warned about elsewhere). If the sentinel is scrolled
+  // out we leave the attribute for the `isStuck` useLayoutEffect, so the input
+  // never flashes at a scrolled position.
+  //
+  // A naive timeout cutoff isn't safe — HmrcResults' scroll-restore is gated on
+  // the virtualizer's font/width readiness, which can take an indefinite number
+  // of frames on slow loads. rAF auto-pauses on background tabs, so an open-ended
+  // poll has no idle cost when the user isn't looking.
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (!document.documentElement.hasAttribute('data-hide-search-input')) {
@@ -129,9 +135,15 @@ export function useSearchPill(
       if (!document.documentElement.hasAttribute('data-hide-search-input')) {
         return;
       }
-      if (window.scrollY === 0 && !sessionStorage.getItem('hmrc-scroll-y')) {
-        clearHideAttribute();
-        return;
+      if (!sessionStorage.getItem('hmrc-scroll-y')) {
+        const sentinel = sentinelRef.current;
+        const stuck = sentinel
+          ? sentinel.getBoundingClientRect().bottom < 0
+          : false;
+        if (!stuck) {
+          clearHideAttribute();
+          return;
+        }
       }
       requestAnimationFrame(tick);
     };
@@ -139,7 +151,7 @@ export function useSearchPill(
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [sentinelRef]);
 
   // Only activate pill mode when scrolled past the sentinel
   useSearchShortcut(inputRef, () => {

--- a/apps/web/src/scripts/search-input-init.ts
+++ b/apps/web/src/scripts/search-input-init.ts
@@ -11,7 +11,7 @@
 export const SEARCH_INIT_SCRIPT = `(() => {
   try {
     const y = window.sessionStorage.getItem('hmrc-scroll-y');
-    if ((y && parseInt(y, 10) > 0) || window.scrollY > 0) {
+    if ((y && parseInt(y, 10) >= 1) || window.scrollY >= 1) {
       document.documentElement.dataset.hideSearchInput = '';
     }
   } catch (_e) {}

--- a/apps/web/src/scripts/search-input-init.ts
+++ b/apps/web/src/scripts/search-input-init.ts
@@ -1,13 +1,17 @@
 /**
  * Blocking pre-hydration inline script that stamps `data-hide-search-input`
  * on `<html>` when the page is loading scrolled (either `window.scrollY > 0`
- * or a saved `hmrc-scroll-y` key). Paired with a CSS rule in `styles.css`
- * that gates the search input's opacity off this attribute to prevent a
- * first-paint flash before pill mode kicks in.
+ * or a saved `hmrc-scroll-y` that parses to a positive integer). Paired with a
+ * CSS rule in `styles.css` that gates the search input's opacity off this
+ * attribute to prevent a first-paint flash before pill mode kicks in. A
+ * non-positive saved value (e.g. "0") means nothing to restore, so it must not
+ * stamp the attribute — "0" is truthy and would otherwise hide the input
+ * forever (see CLAUDE.md).
  */
 export const SEARCH_INIT_SCRIPT = `(() => {
   try {
-    if (window.sessionStorage.getItem('hmrc-scroll-y') || window.scrollY > 0) {
+    var y = window.sessionStorage.getItem('hmrc-scroll-y');
+    if ((y && parseInt(y, 10) > 0) || window.scrollY > 0) {
       document.documentElement.dataset.hideSearchInput = '';
     }
   } catch (_e) {}

--- a/apps/web/src/scripts/search-input-init.ts
+++ b/apps/web/src/scripts/search-input-init.ts
@@ -10,7 +10,7 @@
  */
 export const SEARCH_INIT_SCRIPT = `(() => {
   try {
-    var y = window.sessionStorage.getItem('hmrc-scroll-y');
+    const y = window.sessionStorage.getItem('hmrc-scroll-y');
     if ((y && parseInt(y, 10) > 0) || window.scrollY > 0) {
       document.documentElement.dataset.hideSearchInput = '';
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position persistence to only save when scrolled down (Y > 0), preventing search input from being unnecessarily hidden when the page is at the top.
  * Fixed search input visibility logic to properly restore based on valid scroll positions and prevent permanent hiding in certain edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->