### PR TITLE
Feat/search by previous name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,11 @@ Prev-name wins also sort below equal-score direct matches via the `prev_won`
 key — without it, renamed orgs tie prefix queries at full score and flood
 page 1 alphabetically by their unrelated current names. `prev_won` appears in
 BOTH the `g` ORDER BY and the outer re-sort; keep the two identical or OFFSET
-pages duplicate/drop rows.
+pages duplicate/drop rows. The current-name score is gated on the `direct`
+flag carried out of `hits` (`org_score` in `g0`): for prev-name-only rows,
+ungated `scoreCase` is sub-threshold word_similarity noise that would suppress
+`matchedPreviousName` and leak past the demotion. Do NOT replace the flag with
+a `fuzzyMatch(org)` recheck in `g0` — that re-runs trigram ops per grouped row.
 `public_body`/`no_match` mapping rows have NULL company_number, so they drop
 out of the prev-name join naturally.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ reduction in Layout/Recalculate style).
      because empty text measures as 0 lines / 0px — but the rendered element must
      stay **margin-free**: a margin would apply once per card while the estimator
      only counts `lineCount * lineHeight`
+   - Single-line `truncate` fields (e.g. the MapPin + location row) measure a
+     one-glyph sentinel (`'M'` → exactly 1 line) instead of the real text: an
+     inline icon steals width the canvas can't see, so the rendered line must
+     never wrap. If a truncated line is ever allowed to wrap again, drop the
+     icon from the text flow AND restore real-text measurement together
 2. **`HmrcResults.tsx` line ~75** — the hidden measurement div's `className="px-4"` must
    match the real container's horizontal padding class (line ~95)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,10 @@ reduction in Layout/Recalculate style).
    - `fields[].getText` — must match the text transformation applied before render
    - `fixedHeight` — sum of all fixed-height card elements (padding, margins, rating
      line, route line) plus 4px for sub-pixel rounding
+   - Conditional lines (e.g. the italic "Previously …" previous-name line) work
+     because empty text measures as 0 lines / 0px — but the rendered element must
+     stay **margin-free**: a margin would apply once per card while the estimator
+     only counts `lineCount * lineHeight`
 2. **`HmrcResults.tsx` line ~75** — the hidden measurement div's `className="px-4"` must
    match the real container's horizontal padding class (line ~95)
 
@@ -120,6 +124,33 @@ from fallback font measurements or missing width data.
 
 The `hmrc-scroll-y` sessionStorage restore runs in a `useEffect([ready])` — it must wait
 for items to be in the DOM at correct heights before calling `window.scrollTo`.
+
+## Home search (`searchHmrc`) — index-served predicates + previous-name matching
+
+The search WHERE pairs each pg_trgm function recheck with its index-served
+OPERATOR: `org ~* pattern`, `query <% org AND word_similarity(...) > 0.6`,
+`org % query AND similarity(...) > 0.5`. The operators let the GIN trigram
+indexes BitmapOr the candidate set (~20x faster); the function rechecks pin the
+exact thresholds independent of the `pg_trgm.*_threshold` GUCs (defaults 0.6 /
+0.3). Do NOT "simplify" either half away: bare functions can never use an
+index (full scan, ~1s), bare operators silently change semantics if a GUC moves.
+
+Previous Companies House names are searched via `ch_previous_names`
+(company_number, name) — a flattened projection of
+`companies_house_profiles.previous_company_names` with its own
+`gin_trgm_ops` index, because GIN can't trigram-index inside an array column.
+It is maintained by the DB trigger `trg_sync_ch_previous_names` (AFTER
+INSERT OR UPDATE OF previous_company_names) — never write to it from
+application code, and any environment migration must create the table, index,
+trigger, and backfill together.
+
+The query keeps prev-name hits in a separate UNION branch (probe
+`idx_hmrc_org_name` by org) rather than `OR`-ing them into the direct WHERE —
+an OR across the join would force a seq scan and lose all index use. A result's
+`matchedPreviousName` is set only when the previous-name score strictly beats
+the current-name score (ties show the current name without the line).
+`public_body`/`no_match` mapping rows have NULL company_number, so they drop
+out of the prev-name join naturally.
 
 ## Page transitions live in `transitions.css`, not `styles.css`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,9 @@ reduction in Layout/Recalculate style).
    - Conditional lines (e.g. the italic "Previously …" previous-name line) work
      because empty text measures as 0 lines / 0px — but the rendered element must
      stay **margin-free**: a margin would apply once per card while the estimator
-     only counts `lineCount * lineHeight`
+     only counts `lineCount * lineHeight`. The previous-name text comes from
+     `previousNameText()` in `utils.ts`, called by BOTH the card and the
+     estimator's `getText` — never inline the template on one side only
    - Single-line `truncate` fields (e.g. the MapPin + location row) measure a
      one-glyph sentinel (`'M'` → exactly 1 line) instead of the real text: an
      inline icon steals width the canvas can't see, so the rendered line must

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,11 @@ The query keeps prev-name hits in a separate UNION branch (probe
 an OR across the join would force a seq scan and lose all index use. A result's
 `matchedPreviousName` is set only when the previous-name score strictly beats
 the current-name score (ties show the current name without the line).
+Prev-name wins also sort below equal-score direct matches via the `prev_won`
+key — without it, renamed orgs tie prefix queries at full score and flood
+page 1 alphabetically by their unrelated current names. `prev_won` appears in
+BOTH the `g` ORDER BY and the outer re-sort; keep the two identical or OFFSET
+pages duplicate/drop rows.
 `public_body`/`no_match` mapping rows have NULL company_number, so they drop
 out of the prev-name join naturally.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,13 @@ Previous Companies House names are searched via `ch_previous_names`
 It is maintained by the DB trigger `trg_sync_ch_previous_names` (AFTER
 INSERT OR UPDATE OF previous_company_names) — never write to it from
 application code, and any environment migration must create the table, index,
-trigger, and backfill together.
+trigger, and backfill together. The function body (hardened in 0029)
+early-returns on no-op assignments (`OLD IS NOT DISTINCT FROM NEW` — upserts
+assign the column on every write, ~29x more often than it changes) and filters
+NULL array elements, which would otherwise violate `name NOT NULL` and abort
+the parent profile write (poison stream event). The OLD comparison must stay
+inside a nested `IF TG_OP = 'UPDATE'` block: plpgsql binds `OLD.x` before
+evaluating, so a combined condition errors on INSERT.
 
 The query keeps prev-name hits in a separate UNION branch (probe
 `idx_hmrc_org_name` by org) rather than `OR`-ing them into the direct WHERE —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,12 @@ The search WHERE pairs each pg_trgm function recheck with its index-served
 OPERATOR: `org ~* pattern`, `query <% org AND word_similarity(...) > 0.6`,
 `org % query AND similarity(...) > 0.5`. The operators let the GIN trigram
 indexes BitmapOr the candidate set (~20x faster); the function rechecks pin the
-exact thresholds independent of the `pg_trgm.*_threshold` GUCs (defaults 0.6 /
-0.3). Do NOT "simplify" either half away: bare functions can never use an
-index (full scan, ~1s), bare operators silently change semantics if a GUC moves.
+exact thresholds against downward drift of the `pg_trgm.*_threshold` GUCs
+(defaults 0.6 / 0.3). The pair is NOT immune upward: a GUC raised above the
+recheck's literal (0.6 / 0.5) makes the operator the binding filter and
+silently shrinks results. Do NOT "simplify" either half away: bare functions
+can never use an index (full scan, ~1s), bare operators silently change
+semantics if a GUC moves.
 
 Previous Companies House names are searched via `ch_previous_names`
 (company_number, name) — a flattened projection of

--- a/apps/ch-stream/src/mapper.ts
+++ b/apps/ch-stream/src/mapper.ts
@@ -38,7 +38,7 @@ export function mapProfileToRow(data: CHCompanyProfile) {
   if (data.has_charges !== undefined) row.hasCharges = data.has_charges ?? null;
   if (data.previous_company_names !== undefined)
     row.previousCompanyNames =
-      data.previous_company_names?.map((p) => p.name) ?? [];
+      data.previous_company_names?.map((p) => p.name).filter((n) => !!n) ?? [];
 
   if (data.accounts !== undefined) {
     const acc = data.accounts;

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -69,6 +69,12 @@ bun run db:push              # Push schema directly (no migration)
 bun run db:studio            # Open Drizzle Studio
 ```
 
+> **Don't bootstrap an environment with `db:push`.** Push derives DDL from
+> `schema.ts`, which can't express triggers, functions, or backfills — you'd
+> get `ch_previous_names` as an empty, never-synced table and previous-name
+> search would silently return nothing. Always use `db:migrate` (the journal
+> carries the trigger + backfill in migrations 0028/0029).
+
 ### Data & utilities
 
 ```bash

--- a/apps/web/scripts/hydrate-queue-proposed-profiles.ts
+++ b/apps/web/scripts/hydrate-queue-proposed-profiles.ts
@@ -228,7 +228,7 @@ function profileToDbRow(profile: CHFullProfile) {
     hasInsolvencyHistory:
       (profile.has_insolvency_history as boolean | undefined) ?? null,
     hasCharges: (profile.has_charges as boolean | undefined) ?? null,
-    previousCompanyNames: previousNames.map((p) => p.name),
+    previousCompanyNames: previousNames.map((p) => p.name).filter((n) => !!n),
     confirmationStatementLastMadeUpTo: confirmation.last_made_up_to ?? null,
     updatedAt: new Date(),
   };

--- a/apps/web/scripts/seed-companies-house.ts
+++ b/apps/web/scripts/seed-companies-house.ts
@@ -199,7 +199,8 @@ for (const row of uncached) {
       hasInsolvencyHistory: profile.has_insolvency_history ?? null,
       hasCharges: profile.has_charges ?? null,
       previousCompanyNames:
-        profile.previous_company_names?.map((p) => p.name) ?? [],
+        profile.previous_company_names?.map((p) => p.name).filter((n) => !!n) ??
+        [],
       confirmationStatementLastMadeUpTo:
         profile.confirmation_statement?.last_made_up_to || null,
       updatedAt: new Date(),
@@ -220,7 +221,9 @@ for (const row of uncached) {
         hasInsolvencyHistory: profile.has_insolvency_history ?? null,
         hasCharges: profile.has_charges ?? null,
         previousCompanyNames:
-          profile.previous_company_names?.map((p) => p.name) ?? [],
+          profile.previous_company_names
+            ?.map((p) => p.name)
+            .filter((n) => !!n) ?? [],
         confirmationStatementLastMadeUpTo:
           profile.confirmation_statement?.last_made_up_to || null,
         updatedAt: new Date(),

--- a/apps/web/src/api/companiesHouse.ts
+++ b/apps/web/src/api/companiesHouse.ts
@@ -110,7 +110,8 @@ function profileToDbRow(profile: CompanyProfile) {
     hasInsolvencyHistory: profile.has_insolvency_history ?? null,
     hasCharges: profile.has_charges ?? null,
     previousCompanyNames:
-      profile.previous_company_names?.map((p) => p.name) ?? [],
+      profile.previous_company_names?.map((p) => p.name).filter((n) => !!n) ??
+      [],
     confirmationStatementLastMadeUpTo:
       profile.confirmation_statement?.last_made_up_to || null,
     updatedAt: new Date(),
@@ -318,7 +319,9 @@ const getCompanyProfile = createServerFn()
           }
         : undefined,
       company_name: profile.company_name,
-      previousNames: profile.previous_company_names?.map((p) => p.name) ?? [],
+      previousNames:
+        profile.previous_company_names?.map((p) => p.name).filter((n) => !!n) ??
+        [],
       sicDescriptions,
     };
   });

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -35,7 +35,9 @@ type SearchHit = {
  * and, via the `ch_previous_names` projection, over previous Companies House
  * names of mapped orgs. Ranks prefix matches > word-boundary matches >
  * trigram similarity; an org found under an old name carries that name in
- * `matchedPreviousName` when it outscores the current-name match. Returns an
+ * `matchedPreviousName` when it outscores the current-name match. Prev-name
+ * wins sort below equal-score direct matches (`prev_won`) so renamed orgs
+ * can't displace literal matches on common prefix queries. Returns an
  * empty page when the query is under 3 chars. `hasMore` is derived by
  * over-fetching one row past `PAGE_SIZE`.
  *
@@ -109,12 +111,16 @@ export const searchHmrc = createServerFn()
                h.type_rating,
                h.route,
                GREATEST(${scoreCase(orgName)}, coalesce(pm.prev_score, 0)) AS score,
+               coalesce(pm.prev_score, 0) > ${scoreCase(orgName)} AS prev_won,
                CASE WHEN coalesce(pm.prev_score, 0) > ${scoreCase(orgName)}
                  THEN pm.matched_name END AS matched_previous_name
         FROM hits h
         LEFT JOIN pm ON pm.organisation_name = h.organisation_name
         GROUP BY h.organisation_name, h.name_slug, h.type_rating, h.route, pm.matched_name, pm.prev_score
-        ORDER BY score DESC, h.organisation_name ASC, min(h.hash) ASC
+        ORDER BY score DESC, prev_won ASC, h.organisation_name ASC, min(h.hash) ASC
+        -- prev_won demotes prev-name-only wins below same-score direct hits:
+        -- they tie prefix queries at full score but would tie-break by their
+        -- unrelated current name, flooding page 1 (e.g. 'london').
         -- min(hash) tiebreak: groups tie on score AND name, and unstable tie
         -- order across page fetches duplicates/drops rows at OFFSET boundaries
         LIMIT ${PAGE_SIZE + 1} OFFSET ${offset}
@@ -133,7 +139,8 @@ export const searchHmrc = createServerFn()
       LEFT JOIN ${hmrcCompanyMapping} m ON m.organisation_name = g.organisation_name
       LEFT JOIN ${companiesHouseProfiles} c ON c.company_number = m.company_number
       -- Joins don't guarantee order preservation; re-sort the ≤51-row window
-      ORDER BY g.score DESC, g.organisation_name ASC, g.slug_id ASC
+      -- (must mirror g's ORDER BY exactly or OFFSET pages duplicate/drop rows)
+      ORDER BY g.score DESC, g.prev_won ASC, g.organisation_name ASC, g.slug_id ASC
     `);
     const rows = result.rows as SearchHit[];
 

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -45,7 +45,9 @@ type SearchHit = {
  * recheck (`<%` + word_similarity, `%` + similarity): the operators let the
  * GIN trigram indexes BitmapOr the candidate set (~20x faster than the bare
  * function calls, which can never use an index), while the rechecks pin the
- * exact thresholds independent of the pg_trgm GUCs. Keep both halves.
+ * exact thresholds against downward GUC drift. NOT immune upward: a pg_trgm
+ * GUC raised above 0.6/0.5 becomes the binding filter and silently shrinks
+ * results. Keep both halves.
  */
 export const searchHmrc = createServerFn()
   .inputValidator(

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -37,7 +37,10 @@ type SearchHit = {
  * trigram similarity; an org found under an old name carries that name in
  * `matchedPreviousName` when it outscores the current-name match. Prev-name
  * wins sort below equal-score direct matches (`prev_won`) so renamed orgs
- * can't displace literal matches on common prefix queries. Returns an
+ * can't displace literal matches on common prefix queries. The current-name
+ * score only counts when the org actually passed the direct WHERE (`direct`
+ * flag → `org_score`); prev-name-only rows therefore always rank by their
+ * prev-name score and always carry `matchedPreviousName`. Returns an
  * empty page when the query is under 3 chars. `hasMore` is derived by
  * over-fetching one row past `PAGE_SIZE`.
  *
@@ -97,34 +100,45 @@ export const searchHmrc = createServerFn()
         GROUP BY m.organisation_name
       ),
       hits AS (
-        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number, true AS direct
         FROM ${hmrcSkilledWorkers} h
         WHERE ${fuzzyMatch(orgName)}
         UNION
-        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number, false AS direct
         FROM ${hmrcSkilledWorkers} h
         JOIN pm ON pm.organisation_name = h.organisation_name
       ),
-      g AS (
+      g0 AS (
         SELECT min(h.hash) AS slug_id,
                h.organisation_name,
                h.name_slug,
                coalesce(array_agg(distinct h.sponsor_licence_number order by h.sponsor_licence_number) filter (where h.sponsor_licence_number is not null), '{}') AS licences,
                h.type_rating,
                h.route,
-               GREATEST(${scoreCase(orgName)}, coalesce(pm.prev_score, 0)) AS score,
-               coalesce(pm.prev_score, 0) > ${scoreCase(orgName)} AS prev_won,
-               CASE WHEN coalesce(pm.prev_score, 0) > ${scoreCase(orgName)}
-                 THEN pm.matched_name END AS matched_previous_name
+               -- Gate the current-name score on a real direct match (the flag is
+               -- free at WHERE time): for prev-name-only rows scoreCase is
+               -- sub-threshold word_similarity noise that would suppress the
+               -- "Previously" line and leak past the prev_won demotion
+               CASE WHEN bool_or(h.direct) THEN ${scoreCase(orgName)} ELSE 0 END AS org_score,
+               pm.matched_name,
+               pm.prev_score
         FROM hits h
         LEFT JOIN pm ON pm.organisation_name = h.organisation_name
         GROUP BY h.organisation_name, h.name_slug, h.type_rating, h.route, pm.matched_name, pm.prev_score
-        ORDER BY score DESC, prev_won ASC, h.organisation_name ASC, min(h.hash) ASC
+      ),
+      g AS (
+        SELECT slug_id, organisation_name, name_slug, licences, type_rating, route,
+               GREATEST(org_score, coalesce(prev_score, 0)) AS score,
+               coalesce(prev_score, 0) > org_score AS prev_won,
+               CASE WHEN coalesce(prev_score, 0) > org_score
+                 THEN matched_name END AS matched_previous_name
+        FROM g0
+        ORDER BY score DESC, prev_won ASC, organisation_name ASC, slug_id ASC
         -- prev_won demotes prev-name-only wins below same-score direct hits:
         -- they tie prefix queries at full score but would tie-break by their
         -- unrelated current name, flooding page 1 (e.g. 'london').
-        -- min(hash) tiebreak: groups tie on score AND name, and unstable tie
-        -- order across page fetches duplicates/drops rows at OFFSET boundaries
+        -- slug_id (min hash) tiebreak: groups tie on score AND name, and unstable
+        -- tie order across page fetches duplicates/drops rows at OFFSET boundaries
         LIMIT ${PAGE_SIZE + 1} OFFSET ${offset}
       )
       SELECT g.slug_id AS "slugId",

--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -1,11 +1,12 @@
 import {
+  chPreviousNames,
   companiesHouseProfiles,
   hmrcCompanyMapping,
   hmrcSkilledWorkers,
 } from '@ss/db';
 import { queryOptions } from '@tanstack/react-query';
 import { createServerFn } from '@tanstack/react-start';
-import { asc, desc, eq, sql } from 'drizzle-orm';
+import { asc, eq, type SQL, sql } from 'drizzle-orm';
 
 import { db } from '../db.server';
 import {
@@ -16,12 +17,33 @@ import {
 
 const PAGE_SIZE = 50;
 
+type SearchHit = {
+  slugId: string;
+  organisationName: string;
+  nameSlug: string;
+  sponsorLicenceNumbers: string[];
+  locality: string | null;
+  region: string | null;
+  typeRating: string;
+  route: string;
+  score: number;
+  matchedPreviousName: string | null;
+};
+
 /**
- * Server fn performing a paginated fuzzy search over `hmrc_skilled_workers`.
- * Combines regex word-boundary matching with pg_trgm similarity, ranking
- * prefix matches > word-boundary matches > trigram similarity. Returns an
+ * Server fn performing a paginated fuzzy search over `hmrc_skilled_workers`
+ * and, via the `ch_previous_names` projection, over previous Companies House
+ * names of mapped orgs. Ranks prefix matches > word-boundary matches >
+ * trigram similarity; an org found under an old name carries that name in
+ * `matchedPreviousName` when it outscores the current-name match. Returns an
  * empty page when the query is under 3 chars. `hasMore` is derived by
  * over-fetching one row past `PAGE_SIZE`.
+ *
+ * Match predicates pair an index-served trigram OPERATOR with a function
+ * recheck (`<%` + word_similarity, `%` + similarity): the operators let the
+ * GIN trigram indexes BitmapOr the candidate set (~20x faster than the bare
+ * function calls, which can never use an index), while the rechecks pin the
+ * exact thresholds independent of the pg_trgm GUCs. Keep both halves.
  */
 export const searchHmrc = createServerFn()
   .inputValidator(
@@ -32,92 +54,88 @@ export const searchHmrc = createServerFn()
     console.log(`[HMRC Search] query="${query}" offset=${offset}`);
     const regexEscaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const wordBoundaryPattern = `\\m${regexEscaped}`;
-    const scoreExpr = sql<number>`
-      CASE
-        WHEN ${hmrcSkilledWorkers.organisationName} ~* ${`^${regexEscaped}`}
-          THEN 2.0 + word_similarity(${query}, ${hmrcSkilledWorkers.organisationName})
-        WHEN ${hmrcSkilledWorkers.organisationName} ~* ${wordBoundaryPattern}
-          THEN 1.0 + word_similarity(${query}, ${hmrcSkilledWorkers.organisationName})
-        ELSE word_similarity(${query}, ${hmrcSkilledWorkers.organisationName})
-      END`;
+    const prefixPattern = `^${regexEscaped}`;
+    /** Index-served fuzzy match (operator + threshold recheck) for a name column. */
+    const fuzzyMatch = (col: SQL) => sql`(
+      ${col} ~* ${wordBoundaryPattern}
+      OR (${query} <% ${col} AND word_similarity(${query}, ${col}) > 0.6)
+      OR (${col} % ${query} AND similarity(${query}, ${col}) > 0.5)
+    )`;
+    /** Ranking CASE for a name column: prefix > word-boundary > similarity. */
+    const scoreCase = (col: SQL) => sql`CASE
+      WHEN ${col} ~* ${prefixPattern} THEN 2.0 + word_similarity(${query}, ${col})
+      WHEN ${col} ~* ${wordBoundaryPattern} THEN 1.0 + word_similarity(${query}, ${col})
+      ELSE word_similarity(${query}, ${col})
+    END`;
+    const prevName = sql`pn.name`;
+    const orgName = sql`h.organisation_name`;
+
+    // Raw SQL throughout: the shape (CTEs + UNION) exists so every branch
+    // stays on an index — pm probes idx_ch_prev_names_trgm then
+    // idx_mapping_company_number; the direct branch BitmapOrs
+    // idx_hmrc_org_name_trgm; the pm-driven branch probes idx_hmrc_org_name.
+    // Folding pm into the direct WHERE as an OR would force a seq scan.
     // One row per (org, rating, route): the same org can hold several licences
     // with otherwise identical feed data (888 groups in the 2026-06 feed), and
     // the cards show nothing that distinguishes them. min(hash) is the
     // canonical slugId — the detail loader 301s the siblings to it.
-    // Grouping happens in the subquery, BEFORE the CH joins, so the joins stay
-    // PK probes on the returned window only and ranking/LIMIT are unaffected.
-    const grouped = db
-      .select({
-        slugId: sql<string>`min(${hmrcSkilledWorkers.hash})`.as('slug_id'),
-        organisationName: hmrcSkilledWorkers.organisationName,
-        nameSlug: hmrcSkilledWorkers.nameSlug,
-        sponsorLicenceNumbers: sql<
-          string[]
-        >`coalesce(array_agg(distinct ${hmrcSkilledWorkers.sponsorLicenceNumber} order by ${hmrcSkilledWorkers.sponsorLicenceNumber}) filter (where ${hmrcSkilledWorkers.sponsorLicenceNumber} is not null), '{}')`.as(
-          'sponsor_licence_numbers',
-        ),
-        typeRating: hmrcSkilledWorkers.typeRating,
-        route: hmrcSkilledWorkers.route,
-        score: scoreExpr.as('score'),
-      })
-      .from(hmrcSkilledWorkers)
-      .where(
-        sql`(
-          ${hmrcSkilledWorkers.organisationName} ~* ${wordBoundaryPattern}
-          OR word_similarity(${query}, ${hmrcSkilledWorkers.organisationName}) > 0.6
-          OR similarity(${query}, ${hmrcSkilledWorkers.organisationName}) > 0.5
-        )`,
-      )
-      .groupBy(
-        hmrcSkilledWorkers.organisationName,
-        hmrcSkilledWorkers.nameSlug,
-        hmrcSkilledWorkers.typeRating,
-        hmrcSkilledWorkers.route,
-      )
-      .orderBy(
-        desc(scoreExpr),
-        sql`${hmrcSkilledWorkers.organisationName} ASC`,
-        // Unique tiebreak: groups tie on score AND name, and unstable tie
-        // order across page fetches duplicates/drops rows at OFFSET boundaries
-        sql`min(${hmrcSkilledWorkers.hash}) ASC`,
-      )
-      .limit(PAGE_SIZE + 1)
-      .offset(offset)
-      .as('g');
-
+    // Grouping/LIMIT happen in `g`, BEFORE the CH location joins, so those
+    // stay PK probes on the returned window only.
     // Listing location is CH-sourced (HMRC dropped town/county from the feed).
-    const rows = await db
-      .select({
-        slugId: grouped.slugId,
-        organisationName: grouped.organisationName,
-        nameSlug: grouped.nameSlug,
-        sponsorLicenceNumbers: grouped.sponsorLicenceNumbers,
-        locality: sql<
-          string | null
-        >`COALESCE(${companiesHouseProfiles.locality}, ${companiesHouseProfiles.addressLine2})`,
-        region: companiesHouseProfiles.region,
-        typeRating: grouped.typeRating,
-        route: grouped.route,
-        score: grouped.score,
-      })
-      .from(grouped)
-      .leftJoin(
-        hmrcCompanyMapping,
-        eq(hmrcCompanyMapping.organisationName, grouped.organisationName),
+    const result = await db.execute(sql`
+      WITH pm AS (
+        SELECT m.organisation_name,
+               (array_agg(pn.name ORDER BY ${scoreCase(prevName)} DESC, pn.name ASC))[1] AS matched_name,
+               max(${scoreCase(prevName)}) AS prev_score
+        FROM ${chPreviousNames} pn
+        JOIN ${hmrcCompanyMapping} m ON m.company_number = pn.company_number
+        WHERE ${fuzzyMatch(prevName)}
+        GROUP BY m.organisation_name
+      ),
+      hits AS (
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number
+        FROM ${hmrcSkilledWorkers} h
+        WHERE ${fuzzyMatch(orgName)}
+        UNION
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number
+        FROM ${hmrcSkilledWorkers} h
+        JOIN pm ON pm.organisation_name = h.organisation_name
+      ),
+      g AS (
+        SELECT min(h.hash) AS slug_id,
+               h.organisation_name,
+               h.name_slug,
+               coalesce(array_agg(distinct h.sponsor_licence_number order by h.sponsor_licence_number) filter (where h.sponsor_licence_number is not null), '{}') AS licences,
+               h.type_rating,
+               h.route,
+               GREATEST(${scoreCase(orgName)}, coalesce(pm.prev_score, 0)) AS score,
+               CASE WHEN coalesce(pm.prev_score, 0) > ${scoreCase(orgName)}
+                 THEN pm.matched_name END AS matched_previous_name
+        FROM hits h
+        LEFT JOIN pm ON pm.organisation_name = h.organisation_name
+        GROUP BY h.organisation_name, h.name_slug, h.type_rating, h.route, pm.matched_name, pm.prev_score
+        ORDER BY score DESC, h.organisation_name ASC, min(h.hash) ASC
+        -- min(hash) tiebreak: groups tie on score AND name, and unstable tie
+        -- order across page fetches duplicates/drops rows at OFFSET boundaries
+        LIMIT ${PAGE_SIZE + 1} OFFSET ${offset}
       )
-      .leftJoin(
-        companiesHouseProfiles,
-        eq(
-          companiesHouseProfiles.companyNumber,
-          hmrcCompanyMapping.companyNumber,
-        ),
-      )
-      // Joins don't guarantee order preservation; re-sort the ≤51-row window
-      .orderBy(
-        desc(grouped.score),
-        asc(grouped.organisationName),
-        asc(grouped.slugId),
-      );
+      SELECT g.slug_id AS "slugId",
+             g.organisation_name AS "organisationName",
+             g.name_slug AS "nameSlug",
+             g.licences AS "sponsorLicenceNumbers",
+             COALESCE(c.locality, c.address_line_2) AS "locality",
+             c.region AS "region",
+             g.type_rating AS "typeRating",
+             g.route AS "route",
+             g.score AS "score",
+             g.matched_previous_name AS "matchedPreviousName"
+      FROM g
+      LEFT JOIN ${hmrcCompanyMapping} m ON m.organisation_name = g.organisation_name
+      LEFT JOIN ${companiesHouseProfiles} c ON c.company_number = m.company_number
+      -- Joins don't guarantee order preservation; re-sort the ≤51-row window
+      ORDER BY g.score DESC, g.organisation_name ASC, g.slug_id ASC
+    `);
+    const rows = result.rows as SearchHit[];
 
     const hasMore = rows.length > PAGE_SIZE;
     return {

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -81,6 +81,13 @@ export default function HmrcCard({
       >
         {titleCase(row.organisationName)}
       </h3>
+      {row.matchedPreviousName && (
+        // No vertical margins: the height estimator in HmrcResults measures
+        // this line as lineCount * 20px, so any margin here would desync it
+        <p className="text-sm text-(--sea-ink-soft) italic">
+          Previously {titleCase(row.matchedPreviousName)}
+        </p>
+      )}
       <div className="mt-0.5">
         <RatingIcon rating={row.typeRating} />
       </div>

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -2,7 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { MapPin } from 'lucide-react';
 
 import type { HmrcRow } from '../api/hmrc';
-import { formatLocation, titleCase } from '../utils';
+import { formatLocation, previousNameText, titleCase } from '../utils';
 import RatingIcon from './RatingIcon';
 import UnionJackLens from './UnionJackLens';
 
@@ -34,6 +34,7 @@ export default function HmrcCard({
   onActivate: () => void;
 }) {
   const location = formatLocation(row.locality, row.region);
+  const previousName = previousNameText(row.matchedPreviousName);
   return (
     <Link
       to="/company/$id/$slug"
@@ -83,12 +84,10 @@ export default function HmrcCard({
       >
         {titleCase(row.organisationName)}
       </h3>
-      {row.matchedPreviousName && (
+      {previousName && (
         // No vertical margins: the height estimator in HmrcResults measures
         // this line as lineCount * 16px, so any margin here would desync it
-        <p className="text-xs text-(--sea-ink-soft) italic">
-          Previously {titleCase(row.matchedPreviousName)}
-        </p>
+        <p className="text-xs text-(--sea-ink-soft) italic">{previousName}</p>
       )}
       <div className="mt-0.5">
         <RatingIcon rating={row.typeRating} />

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -84,7 +84,7 @@ export default function HmrcCard({
       </h3>
       {row.matchedPreviousName && (
         // No vertical margins: the height estimator in HmrcResults measures
-        // this line as lineCount * 20px, so any margin here would desync it
+        // this line as lineCount * 16px, so any margin here would desync it
         <p className="text-xs text-(--sea-ink-soft) italic">
           Previously {titleCase(row.matchedPreviousName)}
         </p>

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router';
+import { MapPin } from 'lucide-react';
 
 import type { HmrcRow } from '../api/hmrc';
 import { formatLocation, titleCase } from '../utils';
@@ -84,7 +85,7 @@ export default function HmrcCard({
       {row.matchedPreviousName && (
         // No vertical margins: the height estimator in HmrcResults measures
         // this line as lineCount * 20px, so any margin here would desync it
-        <p className="text-sm text-(--sea-ink-soft) italic">
+        <p className="text-sm text-(--sea-ink)">
           Previously {titleCase(row.matchedPreviousName)}
         </p>
       )}
@@ -92,9 +93,17 @@ export default function HmrcCard({
         <RatingIcon rating={row.typeRating} />
       </div>
       <div className="mt-0.5">
-        <p className="text-sm text-(--sea-ink-soft)">
-          {formatLocation(row.locality, row.region)}
-        </p>
+        {formatLocation(row.locality, row.region) && (
+          // Single truncated line: the height estimator in HmrcResults counts
+          // this as exactly one line when a location exists, so it must never
+          // wrap (the inline icon steals width the estimator can't see)
+          <p className="flex items-center gap-1.5 text-sm text-(--sea-ink-soft)">
+            <MapPin size={14} className="shrink-0" />
+            <span className="truncate">
+              {formatLocation(row.locality, row.region)}
+            </span>
+          </p>
+        )}
         <p className="mt-0.5 truncate text-xs text-(--sea-ink-soft)">
           {titleCase(row.route)}
         </p>

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -85,7 +85,7 @@ export default function HmrcCard({
       {row.matchedPreviousName && (
         // No vertical margins: the height estimator in HmrcResults measures
         // this line as lineCount * 20px, so any margin here would desync it
-        <p className="text-sm text-(--sea-ink)">
+        <p className="text-xs text-(--sea-ink-soft) italic">
           Previously {titleCase(row.matchedPreviousName)}
         </p>
       )}

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -33,6 +33,7 @@ export default function HmrcCard({
   lensRotation: { from: number; to: number };
   onActivate: () => void;
 }) {
+  const location = formatLocation(row.locality, row.region);
   return (
     <Link
       to="/company/$id/$slug"
@@ -93,15 +94,13 @@ export default function HmrcCard({
         <RatingIcon rating={row.typeRating} />
       </div>
       <div className="mt-0.5">
-        {formatLocation(row.locality, row.region) && (
+        {location && (
           // Single truncated line: the height estimator in HmrcResults counts
           // this as exactly one line when a location exists, so it must never
           // wrap (the inline icon steals width the estimator can't see)
           <p className="flex items-center gap-1.5 text-sm text-(--sea-ink-soft)">
             <MapPin size={14} className="shrink-0" />
-            <span className="truncate">
-              {formatLocation(row.locality, row.region)}
-            </span>
+            <span className="truncate">{location}</span>
           </p>
         )}
         <p className="mt-0.5 truncate text-xs text-(--sea-ink-soft)">

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -6,7 +6,7 @@ import { useVirtualTextLayout } from 'virtual-text-layout';
 
 import { useHmrcSearch } from '../hooks/useHmrcSearch';
 import { useResultsKeyboardNav } from '../hooks/useResultsKeyboardNav';
-import { formatLocation, titleCase } from '../utils';
+import { formatLocation, previousNameText, titleCase } from '../utils';
 import HmrcCard from './HmrcCard';
 import SkeletonCards from './SkeletonCards';
 
@@ -41,10 +41,7 @@ export default function HmrcResults({ search }: { search: string }) {
       {
         // Empty text measures as 0 lines / 0px, so rows without a previous-name
         // match pay no height; the rendered line is margin-free to match
-        getText: (row) =>
-          row.matchedPreviousName
-            ? `Previously ${titleCase(row.matchedPreviousName)}`
-            : '',
+        getText: (row) => previousNameText(row.matchedPreviousName),
         font: 'italic 12px Geist', // text-xs italic
         lineHeight: 16,
       },

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -45,8 +45,8 @@ export default function HmrcResults({ search }: { search: string }) {
           row.matchedPreviousName
             ? `Previously ${titleCase(row.matchedPreviousName)}`
             : '',
-        font: 'italic 14px Geist', // text-sm italic
-        lineHeight: 20,
+        font: 'italic 12px Geist', // text-xs italic
+        lineHeight: 16,
       },
       {
         // Location renders as ONE truncated line beside a MapPin icon, never

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -39,6 +39,16 @@ export default function HmrcResults({ search }: { search: string }) {
         letterSpacing: -0.4, // heading-card utility
       },
       {
+        // Empty text measures as 0 lines / 0px, so rows without a previous-name
+        // match pay no height; the rendered line is margin-free to match
+        getText: (row) =>
+          row.matchedPreviousName
+            ? `Previously ${titleCase(row.matchedPreviousName)}`
+            : '',
+        font: 'italic 14px Geist', // text-sm italic
+        lineHeight: 20,
+      },
+      {
         getText: (row) => formatLocation(row.locality, row.region),
         font: '14px Geist', // text-sm
         lineHeight: 20,

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -49,7 +49,10 @@ export default function HmrcResults({ search }: { search: string }) {
         lineHeight: 20,
       },
       {
-        getText: (row) => formatLocation(row.locality, row.region),
+        // Location renders as ONE truncated line beside a MapPin icon, never
+        // wrapping — so measure a single-glyph sentinel (always 1 line) when a
+        // location exists and '' (0 lines) when not, instead of the real text
+        getText: (row) => (formatLocation(row.locality, row.region) ? 'M' : ''),
         font: '14px Geist', // text-sm
         lineHeight: 20,
       },

--- a/apps/web/src/utils.ts
+++ b/apps/web/src/utils.ts
@@ -101,6 +101,16 @@ export function formatLocation(
   return parts.join(', ');
 }
 
+/**
+ * "Previously <name>" line for a previous-company-name match. Returns an
+ * empty string when there is no match. Single source for BOTH the rendered
+ * line in `HmrcCard` and the height estimator's `getText` in `HmrcResults` —
+ * the two must measure/render identical text, so never inline this template.
+ */
+export function previousNameText(name: string | null): string {
+  return name ? `Previously ${titleCase(name)}` : '';
+}
+
 // Trailing legal-entity suffixes stripped from a company name before searching.
 const SEARCH_SUFFIXES =
   /[\s,]+(?:limited|ltd|plc|llp|llc|lp|cic|cio|inc|incorporated|corp|corporation|unlimited)\.?\s*$/i;

--- a/packages/db/migrations/0028_normal_black_bird.sql
+++ b/packages/db/migrations/0028_normal_black_bird.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "ch_previous_names" (
+	"company_number" varchar(20) NOT NULL,
+	"name" text NOT NULL,
+	CONSTRAINT "ch_previous_names_company_number_name_pk" PRIMARY KEY("company_number","name")
+);
+--> statement-breakpoint
+ALTER TABLE "ch_previous_names" ADD CONSTRAINT "ch_previous_names_company_number_companies_house_profiles_company_number_fk" FOREIGN KEY ("company_number") REFERENCES "public"."companies_house_profiles"("company_number") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ch_prev_names_trgm" ON "ch_previous_names" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_mapping_company_number" ON "hmrc_company_mapping" USING btree ("company_number");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION sync_ch_previous_names() RETURNS trigger AS $$
+BEGIN
+	DELETE FROM ch_previous_names WHERE company_number = NEW.company_number;
+	INSERT INTO ch_previous_names (company_number, name)
+	SELECT DISTINCT NEW.company_number, n FROM unnest(NEW.previous_company_names) AS n
+	ON CONFLICT DO NOTHING;
+	RETURN NEW;
+END $$ LANGUAGE plpgsql;--> statement-breakpoint
+CREATE TRIGGER trg_sync_ch_previous_names
+	AFTER INSERT OR UPDATE OF previous_company_names ON companies_house_profiles
+	FOR EACH ROW EXECUTE FUNCTION sync_ch_previous_names();--> statement-breakpoint
+INSERT INTO ch_previous_names (company_number, name)
+	SELECT DISTINCT company_number, n FROM companies_house_profiles, unnest(previous_company_names) AS n
+	ON CONFLICT DO NOTHING;

--- a/packages/db/migrations/0029_harden-prev-names-sync.sql
+++ b/packages/db/migrations/0029_harden-prev-names-sync.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION sync_ch_previous_names() RETURNS trigger AS $$
+BEGIN
+	-- Skip no-op assignments: UPDATE OF fires whenever the column is in the
+	-- SET list (every stream/seed upsert does this), not when the value changed
+	IF TG_OP = 'UPDATE' THEN
+		IF OLD.previous_company_names IS NOT DISTINCT FROM NEW.previous_company_names THEN
+			RETURN NEW;
+		END IF;
+	END IF;
+	DELETE FROM ch_previous_names WHERE company_number = NEW.company_number;
+	-- n IS NOT NULL: a NULL array element would violate name NOT NULL and
+	-- abort the parent profile write (poison event wedging the stream listener)
+	INSERT INTO ch_previous_names (company_number, name)
+	SELECT DISTINCT NEW.company_number, n FROM unnest(NEW.previous_company_names) AS n
+	WHERE n IS NOT NULL
+	ON CONFLICT DO NOTHING;
+	RETURN NEW;
+END $$ LANGUAGE plpgsql;

--- a/packages/db/migrations/meta/0028_snapshot.json
+++ b/packages/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,990 @@
+{
+  "id": "af4ffc3e-da40-4836-9cdf-4059f9ee4407",
+  "prevId": "f1952481-19f9-4bec-b127-6153e8b8d459",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ch_previous_names": {
+      "name": "ch_previous_names",
+      "schema": "",
+      "columns": {
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_ch_prev_names_trgm": {
+          "name": "idx_ch_prev_names_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ch_previous_names_company_number_companies_house_profiles_company_number_fk": {
+          "name": "ch_previous_names_company_number_companies_house_profiles_company_number_fk",
+          "tableFrom": "ch_previous_names",
+          "tableTo": "companies_house_profiles",
+          "columnsFrom": ["company_number"],
+          "columnsTo": ["company_number"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ch_previous_names_company_number_name_pk": {
+          "name": "ch_previous_names_company_number_name_pk",
+          "columns": ["company_number", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ch_stream_state": {
+      "name": "ch_stream_state",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_timepoint": {
+          "name": "last_timepoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profile_cache": {
+      "name": "companies_house_profile_cache",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_trail_id": {
+          "name": "last_trail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profile_trails": {
+      "name": "companies_house_profile_trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_trail_company_number": {
+          "name": "idx_ch_trail_company_number",
+          "columns": [
+            {
+              "expression": "company_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_trail_created_at": {
+          "name": "idx_ch_trail_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies_house_profiles": {
+      "name": "companies_house_profiles",
+      "schema": "",
+      "columns": {
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_status": {
+          "name": "company_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_type": {
+          "name": "company_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_creation": {
+          "name": "date_of_creation",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sic_codes": {
+          "name": "sic_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "accounts_next_made_up_to": {
+          "name": "accounts_next_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_last_made_up_to": {
+          "name": "accounts_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_overdue": {
+          "name": "accounts_overdue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_been_liquidated": {
+          "name": "has_been_liquidated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_insolvency_history": {
+          "name": "has_insolvency_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_charges": {
+          "name": "has_charges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_company_names": {
+          "name": "previous_company_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "confirmation_statement_last_made_up_to": {
+          "name": "confirmation_statement_last_made_up_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ch_company_name": {
+          "name": "idx_ch_company_name",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_status": {
+          "name": "idx_ch_company_status",
+          "columns": [
+            {
+              "expression": "company_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_company_type": {
+          "name": "idx_ch_company_type",
+          "columns": [
+            {
+              "expression": "company_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_sic_codes": {
+          "name": "idx_ch_sic_codes",
+          "columns": [
+            {
+              "expression": "sic_codes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_ch_jurisdiction": {
+          "name": "idx_ch_jurisdiction",
+          "columns": [
+            {
+              "expression": "jurisdiction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ch_previous_names": {
+          "name": "idx_ch_previous_names",
+          "columns": [
+            {
+              "expression": "previous_company_names",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_company_mapping": {
+      "name": "hmrc_company_mapping",
+      "schema": "",
+      "columns": {
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_number": {
+          "name": "company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public_body": {
+          "name": "is_public_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_used": {
+          "name": "query_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mapping_method_verified": {
+          "name": "idx_mapping_method_verified",
+          "columns": [
+            {
+              "expression": "match_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mapping_company_number": {
+          "name": "idx_mapping_company_number",
+          "columns": [
+            {
+              "expression": "company_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_company_mapping_audit": {
+      "name": "hmrc_company_mapping_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_company_number": {
+          "name": "old_company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_company_number": {
+          "name": "new_company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_match_method": {
+          "name": "old_match_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_match_method": {
+          "name": "new_match_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_company_mapping_review_queue": {
+      "name": "hmrc_company_mapping_review_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existing_company_number": {
+          "name": "existing_company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "existing_match_method": {
+          "name": "existing_match_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "existing_match_score": {
+          "name": "existing_match_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_company_number": {
+          "name": "proposed_company_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_match_method": {
+          "name": "proposed_match_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_match_score": {
+          "name": "proposed_match_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_query_used": {
+          "name": "proposed_query_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ch_search_results_top5": {
+          "name": "ch_search_results_top5",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_by": {
+          "name": "detected_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_review_queue_unresolved": {
+          "name": "idx_review_queue_unresolved",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"hmrc_company_mapping_review_queue\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_queue_org": {
+          "name": "idx_review_queue_org",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ux_review_queue_unresolved_org_reason": {
+          "name": "ux_review_queue_unresolved_org_reason",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hmrc_company_mapping_review_queue\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_ingestion_meta": {
+      "name": "hmrc_ingestion_meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "csv_url": {
+          "name": "csv_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmrc_skilled_workers": {
+      "name": "hmrc_skilled_workers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_name": {
+          "name": "organisation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_slug": {
+          "name": "name_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsor_licence_number": {
+          "name": "sponsor_licence_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor_status": {
+          "name": "sponsor_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_rating": {
+          "name": "type_rating",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_hmrc_org_name": {
+          "name": "idx_hmrc_org_name",
+          "columns": [
+            {
+              "expression": "organisation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_name_slug": {
+          "name": "idx_hmrc_name_slug",
+          "columns": [
+            {
+              "expression": "name_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_licence": {
+          "name": "idx_hmrc_licence",
+          "columns": [
+            {
+              "expression": "sponsor_licence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_route": {
+          "name": "idx_hmrc_route",
+          "columns": [
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hmrc_org_name_trgm": {
+          "name": "idx_hmrc_org_name_trgm",
+          "columns": [
+            {
+              "expression": "\"organisation_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmrc_skilled_workers_hash_unique": {
+          "name": "hmrc_skilled_workers_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sic_codes": {
+      "name": "sic_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1781107776369,
       "tag": "0027_widen-sponsor-licence",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1781172651895,
+      "tag": "0028_normal_black_bird",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1781172651895,
       "tag": "0028_normal_black_bird",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1781198614018,
+      "tag": "0029_harden-prev-names-sync",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,7 @@
 export { createClient } from './client.ts';
 export { runMigrations } from './migrate.ts';
 export {
+  chPreviousNames,
   chStreamState,
   companiesHouseProfileCache,
   companiesHouseProfiles,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   numeric,
   pgTable,
+  primaryKey,
   serial,
   text,
   timestamp,
@@ -85,6 +86,29 @@ export const companiesHouseProfiles = pgTable(
   ],
 );
 
+// Flattened projection of companies_house_profiles.previous_company_names so
+// the search can trigram-match previous names (GIN can't index inside arrays).
+// Kept in sync by the DB trigger trg_sync_ch_previous_names — do not write to
+// this table from application code.
+export const chPreviousNames = pgTable(
+  'ch_previous_names',
+  {
+    companyNumber: varchar('company_number', { length: 20 })
+      .notNull()
+      .references(() => companiesHouseProfiles.companyNumber, {
+        onDelete: 'cascade',
+      }),
+    name: text('name').notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.companyNumber, table.name] }),
+    index('idx_ch_prev_names_trgm').using(
+      'gin',
+      sql`${table.name} gin_trgm_ops`,
+    ),
+  ],
+);
+
 export const hmrcCompanyMapping = pgTable(
   'hmrc_company_mapping',
   {
@@ -101,6 +125,7 @@ export const hmrcCompanyMapping = pgTable(
       table.matchMethod,
       table.verifiedAt.asc().nullsFirst(),
     ),
+    index('idx_mapping_company_number').on(table.companyNumber),
   ],
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now surfaces and flags matches by previous/historical company names.
* **Improvements**
  * More accurate, stable fuzzy search ranking and pagination.
  * Result cards show location with an icon + truncated text and an italic "Previously…" line when applicable.
  * Consistent height measurement for virtual list rows to prevent layout jitter.
* **Chores**
  * Database migration adds prior-name support and sync logic to power previous-name lookups.
* **Documentation**
  * Expanded guidance on sizing, measurement, and search predicate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->