### PR TITLE
feat: not surfacing the sponsor license number

### DIFF
--- a/apps/web/src/api/hmrc.ts
+++ b/apps/web/src/api/hmrc.ts
@@ -21,7 +21,6 @@ type SearchHit = {
   slugId: string;
   organisationName: string;
   nameSlug: string;
-  sponsorLicenceNumbers: string[];
   locality: string | null;
   region: string | null;
   typeRating: string;
@@ -100,11 +99,11 @@ export const searchHmrc = createServerFn()
         GROUP BY m.organisation_name
       ),
       hits AS (
-        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number, true AS direct
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, true AS direct
         FROM ${hmrcSkilledWorkers} h
         WHERE ${fuzzyMatch(orgName)}
         UNION
-        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, h.sponsor_licence_number, false AS direct
+        SELECT h.organisation_name, h.name_slug, h.type_rating, h.route, h.hash, false AS direct
         FROM ${hmrcSkilledWorkers} h
         JOIN pm ON pm.organisation_name = h.organisation_name
       ),
@@ -112,7 +111,6 @@ export const searchHmrc = createServerFn()
         SELECT min(h.hash) AS slug_id,
                h.organisation_name,
                h.name_slug,
-               coalesce(array_agg(distinct h.sponsor_licence_number order by h.sponsor_licence_number) filter (where h.sponsor_licence_number is not null), '{}') AS licences,
                h.type_rating,
                h.route,
                -- Gate the current-name score on a real direct match (the flag is
@@ -127,7 +125,7 @@ export const searchHmrc = createServerFn()
         GROUP BY h.organisation_name, h.name_slug, h.type_rating, h.route, pm.matched_name, pm.prev_score
       ),
       g AS (
-        SELECT slug_id, organisation_name, name_slug, licences, type_rating, route,
+        SELECT slug_id, organisation_name, name_slug, type_rating, route,
                GREATEST(org_score, coalesce(prev_score, 0)) AS score,
                coalesce(prev_score, 0) > org_score AS prev_won,
                CASE WHEN coalesce(prev_score, 0) > org_score
@@ -144,7 +142,6 @@ export const searchHmrc = createServerFn()
       SELECT g.slug_id AS "slugId",
              g.organisation_name AS "organisationName",
              g.name_slug AS "nameSlug",
-             g.licences AS "sponsorLicenceNumbers",
              COALESCE(c.locality, c.address_line_2) AS "locality",
              c.region AS "region",
              g.type_rating AS "typeRating",
@@ -172,8 +169,7 @@ export const searchHmrc = createServerFn()
  * `hash` slug id. Returns `null` when no matching row exists. Also returns the
  * group canonical: multi-licence orgs have one row per licence with identical
  * (org, rating, route) — search lists only min(hash), and the loader 301s the
- * sibling hashes to `canonicalSlugId`. `sponsorLicenceNumbers` carries every
- * licence in the group so the canonical page shows all of them.
+ * sibling hashes to `canonicalSlugId`.
  */
 const getHmrcBySlugId = createServerFn()
   .inputValidator((input: unknown) => input as { slugId: string })
@@ -192,10 +188,6 @@ const getHmrcBySlugId = createServerFn()
         // The loader 301s slug mismatches onto this (renames leave stale-slug
         // URLs serving 200 with a self-referential canonical otherwise)
         nameSlug: hmrcSkilledWorkers.nameSlug,
-        sponsorLicenceNumbers: sql<string[]>`(
-          SELECT coalesce(array_agg(distinct h2.sponsor_licence_number order by h2.sponsor_licence_number) filter (where h2.sponsor_licence_number is not null), '{}')
-          FROM hmrc_skilled_workers h2 WHERE ${groupFilter}
-        )`,
         typeRating: hmrcSkilledWorkers.typeRating,
         route: hmrcSkilledWorkers.route,
       })

--- a/apps/web/src/components/McpTools.tsx
+++ b/apps/web/src/components/McpTools.tsx
@@ -24,7 +24,7 @@ export function McpTools() {
     ctx.registerTool({
       name: 'search_uk_visa_sponsors',
       description:
-        'Search for UK companies licensed to sponsor skilled worker visas. Returns company name, location, visa route, sponsor rating, and sponsor licence numbers. A result may match a company’s previous registered name rather than its current one; when that happens, previousName holds the old name that matched the query.',
+        'Search for UK companies licensed to sponsor skilled worker visas. Returns company name, location, visa route, and sponsor rating. A result may match a company’s previous registered name rather than its current one; when that happens, previousName holds the old name that matched the query.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -85,7 +85,6 @@ export function McpTools() {
             location: formatLocation(row.locality, row.region),
             visaRoute: titleCase(row.route),
             rating: titleCase(row.typeRating),
-            sponsorLicenceNumbers: row.sponsorLicenceNumbers,
           }));
 
           return {
@@ -123,7 +122,7 @@ export function McpTools() {
     ctx.registerTool({
       name: 'get_uk_visa_sponsor_details',
       description:
-        'Get detailed information about a specific UK visa sponsor by company name, combining HMRC sponsorship data (location, visa routes, sponsor ratings, sponsor licence numbers) with Companies House registration data (company number, status, incorporation date, registered address, industry/SIC descriptions). Use the exact name returned by search_uk_visa_sponsors for best results.',
+        'Get detailed information about a specific UK visa sponsor by company name, combining HMRC sponsorship data (location, visa routes, sponsor ratings) with Companies House registration data (company number, status, incorporation date, registered address, industry/SIC descriptions). Use the exact name returned by search_uk_visa_sponsors for best results.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -210,8 +209,6 @@ export function McpTools() {
             .map((row) => ({
               visaRoute: titleCase(row.route),
               rating: titleCase(row.typeRating),
-              // Per-row, not top-level: licences vary by (rating, route) group
-              sponsorLicenceNumbers: row.sponsorLicenceNumbers,
             }));
 
           const details = {

--- a/apps/web/src/routes/company.$id.$slug.tsx
+++ b/apps/web/src/routes/company.$id.$slug.tsx
@@ -287,9 +287,6 @@ function CompanyDetail() {
     return () => observer.disconnect();
   }, []);
 
-  // Router match-cache can replay loaderData from an older bundle (SWR render
-  // on revisit); tolerate the field's absence instead of crashing on .length
-  const licenceNumbers = sponsor.sponsorLicenceNumbers ?? [];
   const hmrcName = titleCase(sponsor.organisationName);
   // Lead with the Companies House current name; HMRC may hold a stale former name.
   const displayName = profile?.company_name
@@ -396,19 +393,6 @@ function CompanyDetail() {
                   {titleCase(sponsor.typeRating)}
                 </dd>
               </div>
-              {/* No CH profile → the second card never renders; surface the licence here instead */}
-              {!profile && licenceNumbers.length > 0 && (
-                <div>
-                  <dt className="text-[10px] font-medium tracking-wider text-(--sea-ink-soft) uppercase">
-                    Sponsor Licence {licenceNumbers.length > 1 ? 'Nos.' : 'No.'}
-                  </dt>
-                  <dd className="mt-1 text-sm text-(--sea-ink)">
-                    <span x-apple-data-detectors="false">
-                      {licenceNumbers.join(', ')}
-                    </span>
-                  </dd>
-                </div>
-              )}
             </dl>
           </div>
 
@@ -456,20 +440,6 @@ function CompanyDetail() {
                     <dd className="mt-1 text-sm text-(--sea-ink)">
                       <span x-apple-data-detectors="false">
                         {profile.company_number}
-                      </span>
-                    </dd>
-                  </div>
-                )}
-
-                {licenceNumbers.length > 0 && (
-                  <div>
-                    <dt className="text-[10px] font-medium tracking-wider text-(--sea-ink-soft) uppercase">
-                      Sponsor Licence{' '}
-                      {licenceNumbers.length > 1 ? 'Nos.' : 'No.'}
-                    </dt>
-                    <dd className="mt-1 text-sm text-(--sea-ink)">
-                      <span x-apple-data-detectors="false">
-                        {licenceNumbers.join(', ')}
                       </span>
                     </dd>
                   </div>


### PR DESCRIPTION
- Making a judgement call here that this information shouldn't be made public

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed sponsor licence numbers from all UK visa sponsor search results and queries
  * Sponsor licence information no longer displayed on sponsor detail pages and company profiles
  * Updated visa sponsor data endpoints to exclude licence number fields from responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->