### PR TITLE
feat: redesign HMRC results list (rail + marker, compact responsive cards)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,33 +88,48 @@ query exists (not on the empty/hero state, where the bar is `relative` and the p
 rotates). On that empty state the cursor-positioning fix isn't needed anyway (not sticky).
 Do NOT widen this back to plain `:focus-within` and do NOT add it as a permanent inline style.
 
-## Pretext virtual list sizing — keep in sync with CSS
+## Virtual list sizing — keep in sync with CSS
 
-`HmrcResults.tsx` uses `@chenglou/pretext` for canvas-based card height estimation
-instead of DOM `measureElement`. This eliminates layout reflow during scroll (35-43%
-reduction in Layout/Recalculate style).
+`HmrcResults.tsx` uses `virtual-text-layout` (`useVirtualTextLayout`) for canvas-based
+card height estimation instead of DOM `measureElement`. This eliminates layout reflow
+during scroll (35-43% reduction in Layout/Recalculate style).
+
+The compact card has NO wrapping text by design: the org **name** truncates (one line),
+and the **metadata** (rating + location + route chip) never wraps — only the location and
+chip may truncate. So the ONLY height-varying element is the conditional italic
+"Previously …" line; everything else is a constant baked into `fixedHeight`.
+
+The metadata is responsive and so is `fixedHeight`: **≥sm (640px)** it is one inline
+line (rating · location · chip); **<sm** each item stacks onto its own line (rating /
+location / chip). `HmrcCard` switches layout on the `sm:` breakpoint and `HmrcResults`
+tracks the SAME breakpoint via `matchMedia('(min-width: 640px)')` to pick `fixedHeight`
+— they MUST use the same 640px boundary or row heights desync at that width. Because the
+location is optional, it is a `fields[]` entry that only contributes a line **when narrow
+AND present** (inline ≥sm costs nothing); rating and chip are always present and fixed.
 
 ### Two places to update when HmrcCard styling changes
 
-1. **`HmrcResults.tsx` lines ~13-29** — the `useCardMetrics` config:
-   - `fields[].font` — must match the card's CSS font (weight, size, family)
-   - `fields[].lineHeight` — must match the CSS line-height in px
-   - `fields[].getText` — must match the text transformation applied before render
-   - `fixedHeight` — sum of all fixed-height card elements (padding, margins, rating
-     line, route line) plus 4px for sub-pixel rounding
-   - Conditional lines (e.g. the italic "Previously …" previous-name line) work
-     because empty text measures as 0 lines / 0px — but the rendered element must
-     stay **margin-free**: a margin would apply once per card while the estimator
-     only counts `lineCount * lineHeight`. The previous-name text comes from
-     `previousNameText()` in `utils.ts`, called by BOTH the card and the
-     estimator's `getText` — never inline the template on one side only
-   - Single-line `truncate` fields (e.g. the MapPin + location row) measure a
-     one-glyph sentinel (`'M'` → exactly 1 line) instead of the real text: an
-     inline icon steals width the canvas can't see, so the rendered line must
-     never wrap. If a truncated line is ever allowed to wrap again, drop the
-     icon from the text flow AND restore real-text measurement together
-2. **`HmrcResults.tsx` line ~75** — the hidden measurement div's `className="px-4"` must
-   match the real container's horizontal padding class (line ~95)
+1. **`HmrcResults.tsx` `useVirtualTextLayout` config** — `fields` + `fixedHeight`:
+   - `fields[].font` / `lineHeight` — must match the card's CSS font + line-height in px
+   - `fixedHeight` — sum of every always-present constant-height element, switched on
+     the `sm` breakpoint via `isNarrow`: `py-2(8) + name(24) + mt-1(4) + base-meta +
+     py-2(8) + 4` rounding, where `base-meta = 20` (≥sm, one line) → **68**, or
+     `base-meta = 20 + gap-1(4) + 20` (<sm, the always-present rating + chip) → **92**.
+     The optional location adds **+24** (`fields[]`) only when <sm. If you change the
+     name size/line-height, the metadata layout or its gaps, or the link padding, update
+     BOTH numbers, the location field's `lineHeight`, and the breakpoint.
+   - The single remaining `fields[]` entry measures the **previous-name** line as a
+     one-glyph sentinel (`row.matchedPreviousName ? 'M' : ''`) → exactly 1 line when a
+     match exists, 0 when not — NOT the real text, because the rendered line is
+     `truncate` (never wraps) so only its presence affects height. The card still
+     renders the real `previousNameText()` from `utils.ts`; keep that line margin-free
+     so its height stays exactly `lineCount * 16px`.
+   - Invariant: nothing in the card may wrap except that previous-name line (metadata
+     items truncate, never wrap). If you ever let the name or a metadata field wrap, you
+     must convert it back into a measured `fields[]` entry (real text, real font) AND
+     remove its fixed contribution from `fixedHeight` — the two move together.
+2. **`HmrcResults.tsx`** — the hidden measurement div's `className="px-4"` (loading
+   branch) must match the real results container's horizontal padding class.
 
 ### How the readiness gating works
 
@@ -131,6 +146,33 @@ from fallback font measurements or missing width data.
 
 The `hmrc-scroll-y` sessionStorage restore runs in a `useEffect([ready])` — it must wait
 for items to be in the DOM at correct heights before calling `window.scrollTo`.
+
+### Highlight rail + Union Jack marker (NOT a per-card box)
+
+The keyboard-highlighted row is marked by a single continuous thin **rail** (1px, the
+`.guide-rail` class in styles.css — the empty-state hero `.streaks` spectrum gradient run
+vertically, so it reads as part of that colourful grid) down the left gutter plus a Union Jack **marker** that rides
+it — both rendered ONCE in `HmrcResults`
+(inside the `position: relative` content box), not per card. `HmrcCard` only turns the
+highlighted name red; it draws no box/flag, so the highlighted text never shifts right.
+
+Cross-file coupling to keep in sync:
+- **`RAIL_X` (HmrcResults)** places the rail/marker centre in the left gutter that the
+  card's `-mx-4 px-4` opens up (negative = into that gutter, `x=0` is the text edge).
+  `-16` lands it on the **content column's left edge** (the card's 16px gutter), so the
+  rail lines up with the search box and the rest of the page. If you change the card's
+  horizontal padding/margin, re-check it. `SkeletonCards`' static rail mirrors it (`left-0`,
+  i.e. the same column edge).
+- **`NAME_LINE_CENTER` (HmrcResults)** is the marker's vertical offset = the name line's
+  centre from the card top (`py-2(8) + nameLineHeight(24)/2`). It must track the card's
+  top padding and name line-height, or the marker drifts off the title.
+- The marker's `top` is the highlighted row's `start - scrollMargin + NAME_LINE_CENTER`
+  in the content box's frame (same transform the rows use). It's null — marker hidden —
+  when that row isn't in the rendered/overscan window, so it only shows where it can be
+  placed accurately. A CSS `top` transition gives the slide as the highlight moves.
+- The content box has a `minHeight` floor so the rail runs to near the page bottom even
+  for a handful of rows; tall result sets exceed it and set the height from `getTotalSize()`.
+- `SkeletonCards` draws a matching static rail (no marker) so loading→loaded doesn't pop.
 
 ## Home search (`searchHmrc`) — index-served predicates + previous-name matching
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,9 +115,14 @@ AND present** (inline ≥sm costs nothing); rating and chip are always present a
      the `sm` breakpoint via `isNarrow`: `py-2(8) + name(24) + mt-1(4) + base-meta +
      py-2(8) + 4` rounding, where `base-meta = 20` (≥sm, one line) → **68**, or
      `base-meta = 20 + gap-1(4) + 20` (<sm, the always-present rating + chip) → **92**.
-     The optional location adds **+24** (`fields[]`) only when <sm. If you change the
-     name size/line-height, the metadata layout or its gaps, or the link padding, update
-     BOTH numbers, the location field's `lineHeight`, and the breakpoint.
+     The optional location adds **+24** (`fields[]`) only when <sm — and the breakpoint
+     switch lives in the location field's `lineHeight` (`isNarrow ? 24 : 0`), NOT its
+     `getText`: `virtual-text-layout` caches each row's `getText` output once (rebuilt
+     only when results shrink), so an `isNarrow`-dependent `getText` goes stale on a
+     runtime resize across 640px, whereas `lineHeight` is read fresh every estimate. Keep
+     `getText` a pure function of row data. If you change the name size/line-height, the
+     metadata layout or its gaps, or the link padding, update BOTH numbers, the location
+     field's `lineHeight`, and the breakpoint.
    - The single remaining `fields[]` entry measures the **previous-name** line as a
      one-glyph sentinel (`row.matchedPreviousName ? 'M' : ''`) → exactly 1 line when a
      match exists, 0 when not — NOT the real text, because the rendered line is
@@ -169,7 +174,9 @@ Cross-file coupling to keep in sync:
 - The marker's `top` is the highlighted row's `start - scrollMargin + NAME_LINE_CENTER`
   in the content box's frame (same transform the rows use). It's null — marker hidden —
   when that row isn't in the rendered/overscan window, so it only shows where it can be
-  placed accurately. A CSS `top` transition gives the slide as the highlight moves.
+  placed accurately. Its `top` updates with **no** transition so the marker tracks the
+  highlight instantly; a `top` transition visibly lags and jitters under fast key-repeat
+  (held-arrow scrolling), so do not add one.
 - The content box has a `minHeight` floor so the rail runs to near the page bottom even
   for a handful of rows; tall result sets exceed it and set the height from `getTotalSize()`.
 - `SkeletonCards` draws a matching static rail (no marker) so loading→loaded doesn't pop.

--- a/apps/web/src/components/HmrcCard.tsx
+++ b/apps/web/src/components/HmrcCard.tsx
@@ -4,11 +4,6 @@ import { MapPin } from 'lucide-react';
 import type { HmrcRow } from '../api/hmrc';
 import { formatLocation, previousNameText, titleCase } from '../utils';
 import RatingIcon from './RatingIcon';
-import UnionJackLens from './UnionJackLens';
-
-const prefersReducedMotion = () =>
-  typeof window !== 'undefined' &&
-  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 /**
  * Single HMRC sponsor result card, rendered as a link into the company detail
@@ -16,21 +11,21 @@ const prefersReducedMotion = () =>
  * can restore the list position on back-nav. When `isActive` is true the card
  * is given `view-transition-name: active-card`, which carves it out of the
  * `results-listing` snapshot so it can run its own slide animation while the
- * remaining cards fade.
+ * remaining cards fade. The keyboard-highlighted row only turns its name red —
+ * the Union Jack marker that points at it lives on the rail in `HmrcResults`,
+ * so the highlighted text is never shifted right.
  */
 export default function HmrcCard({
   row,
   search,
   isActive,
   isHighlighted,
-  lensRotation,
   onActivate,
 }: {
   row: HmrcRow;
   search: string;
   isActive: boolean;
   isHighlighted: boolean;
-  lensRotation: { from: number; to: number };
   onActivate: () => void;
 }) {
   const location = formatLocation(row.locality, row.region);
@@ -66,45 +61,38 @@ export default function HmrcCard({
         onActivate();
       }}
     >
-      {isHighlighted && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute top-3 -left-2 block h-4 w-4"
-        >
-          <UnionJackLens
-            className="h-full w-full"
-            fromDeg={lensRotation.from}
-            toDeg={lensRotation.to}
-            durationMs={prefersReducedMotion() ? 0 : 720}
-          />
-        </span>
-      )}
       <h3
-        className={`heading-card text-base font-semibold ${isHighlighted ? 'text-(--logo-red)' : 'text-(--sea-ink)'}`}
+        className={`heading-card truncate text-base font-semibold ${isHighlighted ? 'text-(--logo-red)' : 'text-(--sea-ink)'}`}
       >
         {titleCase(row.organisationName)}
       </h3>
       {previousName && (
-        // No vertical margins: the height estimator in HmrcResults measures
-        // this line as lineCount * 16px, so any margin here would desync it
-        <p className="text-xs text-(--sea-ink-soft) italic">{previousName}</p>
+        // Single truncated line. The estimator counts this as exactly one
+        // 16px line when a previous-name match exists (sentinel-measured), so
+        // it must never wrap — and stays margin-free to match that count.
+        <p className="truncate text-xs text-(--sea-ink-soft) italic">
+          {previousName}
+        </p>
       )}
-      <div className="mt-0.5">
-        <RatingIcon rating={row.typeRating} />
-      </div>
-      <div className="mt-0.5">
+      {/* Metadata. ≥sm: one inline row (rating · location · chip). <sm: each
+          item stacks onto its own line (rating / location / chip) so nothing
+          clips. The estimator in HmrcResults switches fixedHeight on this SAME
+          `sm` (640px) breakpoint and counts the location as an extra stacked
+          line only when <sm — keep the two in sync. Nothing wraps here; the
+          location and chip truncate. */}
+      <div className="mt-1 flex flex-col items-start gap-y-1 text-sm text-(--sea-ink-soft) sm:flex-row sm:items-center sm:gap-x-3">
+        <span className="shrink-0 whitespace-nowrap">
+          <RatingIcon rating={row.typeRating} />
+        </span>
         {location && (
-          // Single truncated line: the height estimator in HmrcResults counts
-          // this as exactly one line when a location exists, so it must never
-          // wrap (the inline icon steals width the estimator can't see)
-          <p className="flex items-center gap-1.5 text-sm text-(--sea-ink-soft)">
+          <span className="flex max-w-full min-w-0 items-center gap-1.5">
             <MapPin size={14} className="shrink-0" />
             <span className="truncate">{location}</span>
-          </p>
+          </span>
         )}
-        <p className="mt-0.5 truncate text-xs text-(--sea-ink-soft)">
+        <span className="max-w-full shrink-0 truncate rounded-md bg-(--chip-bg) px-2 py-0.5 font-mono text-xs whitespace-nowrap text-(--sea-ink-soft) ring-1 ring-(--chip-line) ring-inset">
           {titleCase(row.route)}
-        </p>
+        </span>
       </div>
     </Link>
   );

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -6,9 +6,22 @@ import { useVirtualTextLayout } from 'virtual-text-layout';
 
 import { useHmrcSearch } from '../hooks/useHmrcSearch';
 import { useResultsKeyboardNav } from '../hooks/useResultsKeyboardNav';
-import { formatLocation, previousNameText, titleCase } from '../utils';
+import { formatLocation } from '../utils';
 import HmrcCard from './HmrcCard';
 import SkeletonCards from './SkeletonCards';
+import UnionJackLens from './UnionJackLens';
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// Vertical centre of a card's name line from its top: py-2(8) + nameLine(24)/2.
+const NAME_LINE_CENTER = 20;
+// Rail/marker horizontal centre, in the content box's coordinate space (x=0 is
+// the card text edge). -16 sits it on the content column's left edge — the card's
+// `-mx-4 px-4` opens a 16px gutter, so -16 lands exactly at the search box / column
+// edge that the rest of the page aligns to.
+const RAIL_X = -16;
 
 /**
  * Virtualized list of HMRC sponsor rows for the given search query. Gates
@@ -30,31 +43,50 @@ export default function HmrcResults({ search }: { search: string }) {
   // pair it with the details wrapper and morph back. Back-nav uses a
   // page-level slide instead (see styles.css).
   const [activeId, setActiveId] = useState<string | null>(null);
+  // The card's metadata stacks below `sm` (640px): one inline line ≥sm, two
+  // lines <sm (rating+location / route chip). HmrcCard switches on the same
+  // `sm:` breakpoint, so fixedHeight must switch with it or row heights desync.
+  const [isNarrow, setIsNarrow] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      !window.matchMedia('(min-width: 640px)').matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 640px)');
+    const onChange = () => setIsNarrow(!mq.matches);
+    onChange();
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
   const { estimateSize, ready, contentWidth } = useVirtualTextLayout(results, {
     fields: [
       {
-        getText: (row) => titleCase(row.organisationName),
-        font: '600 16px Geist', // heading-card h3: text-base + font-semibold
-        lineHeight: 24,
-        letterSpacing: -0.4, // heading-card utility
-      },
-      {
-        // Empty text measures as 0 lines / 0px, so rows without a previous-name
-        // match pay no height; the rendered line is margin-free to match
-        getText: (row) => previousNameText(row.matchedPreviousName),
+        // Previous-name renders as ONE truncated line when a match exists, else
+        // nothing — so measure a single-glyph sentinel (always 1 line) when
+        // present and '' (0 lines) when not, never the real (truncated) text.
+        getText: (row) => (row.matchedPreviousName ? 'M' : ''),
         font: 'italic 12px Geist', // text-xs italic
         lineHeight: 16,
       },
       {
-        // Location renders as ONE truncated line beside a MapPin icon, never
-        // wrapping — so measure a single-glyph sentinel (always 1 line) when a
-        // location exists and '' (0 lines) when not, instead of the real text
-        getText: (row) => (formatLocation(row.locality, row.region) ? 'M' : ''),
+        // Location is inline ≥sm (no extra line) but stacks onto its OWN line
+        // <sm. Count it as one line (sentinel) only when narrow AND present;
+        // '' otherwise so it costs nothing on desktop. lineHeight 24 = the 20px
+        // line + the 4px stack gap that the extra line introduces.
+        getText: (row) =>
+          isNarrow && formatLocation(row.locality, row.region) ? 'M' : '',
         font: '14px Geist', // text-sm
-        lineHeight: 20,
+        lineHeight: 24,
       },
     ],
-    fixedHeight: 62, // py-2(8) + mt-0.5(2) + rating(20) + mt-0.5(2) + mt-0.5(2) + route(16) + py-2(8) + 4 (sub-pixel rounding)
+    // Name is single-line (truncate). Metadata is one inline line ≥sm; <sm it
+    // stacks (rating / location / chip). Rating+chip are always present so they
+    // are fixed; the variable location line is the `fields[]` entry above.
+    //   py-2(8) + name(24) + mt-1(4) + base-meta + py-2(8) + 4 (rounding)
+    //   ≥sm: base-meta = 20               -> 68
+    //   <sm: base-meta = 20 + gap-1(4) + 20 -> 92  (+24 per location line)
+    fixedHeight: isNarrow ? 92 : 68,
     containerRef: listRef,
   });
 
@@ -68,7 +100,7 @@ export default function HmrcResults({ search }: { search: string }) {
 
   useEffect(() => {
     if (contentWidth > 0) virtualizer.measure();
-  }, [contentWidth, virtualizer]);
+  }, [contentWidth, isNarrow, virtualizer]);
 
   const {
     highlightedIndex,
@@ -137,6 +169,20 @@ export default function HmrcResults({ search }: { search: string }) {
   }, [highlightedIndex, results, router, search]);
 
   const virtualItems = virtualizer.getVirtualItems();
+
+  // Vertical offset of the Union Jack marker on the rail — the name-line centre
+  // of the highlighted row, in the content box's coordinate space (same frame
+  // the rows are translated into). Null when that row isn't currently rendered
+  // (scrolled out of the overscan window), in which case the marker is hidden.
+  const highlightedItem = virtualItems.find(
+    (v) => v.index === highlightedIndex,
+  );
+  const markerY =
+    highlightedItem != null
+      ? highlightedItem.start -
+        virtualizer.options.scrollMargin +
+        NAME_LINE_CENTER
+      : null;
 
   useEffect(() => {
     if (!ready) return;
@@ -225,17 +271,49 @@ export default function HmrcResults({ search }: { search: string }) {
   if (results.length === 0) return null;
 
   return (
-    <div
-      ref={listRef}
-      className="mt-6 rounded-lg bg-(--sponsor-card-bg) px-4 py-2 shadow-(--shadow-card)"
-    >
+    <div ref={listRef} className="mt-6 px-4 py-2">
       <div
         style={{
           height: virtualizer.getTotalSize(),
+          // Floor the height so the rail runs down to near the page bottom even
+          // when only a few rows match; tall result sets exceed it and win.
+          minHeight: 'calc(100dvh - 16rem)',
           width: '100%',
           position: 'relative',
         }}
       >
+        {/* Continuous thin rail down the left gutter — the straight line the
+            Union Jack marker rides; spans the full (floored) list height. The
+            `guide-rail` class paints it with the hero "streaks" spectrum gradient
+            (see styles.css) so it reads as part of the empty-state colourful grid. */}
+        <span
+          aria-hidden
+          className="guide-rail pointer-events-none absolute top-0 bottom-0 w-px rounded-full"
+          style={{ left: RAIL_X, transform: 'translateX(-50%)' }}
+        />
+        {/* The marker sits ON the rail at the highlighted row. Its `top` updates
+            with no transition so it tracks the highlight instantly — a slide here
+            visibly lags and jitters under fast key-repeat (held arrow scrolling).
+            Hidden when that row is scrolled out of the rendered window. */}
+        {markerY != null && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute z-10 block h-5 w-5"
+            style={{
+              left: RAIL_X,
+              top: markerY,
+              transform: 'translate(-50%, -50%)',
+            }}
+          >
+            <UnionJackLens
+              key={highlightedIndex}
+              className="h-full w-full"
+              fromDeg={lensRotation.from}
+              toDeg={lensRotation.to}
+              durationMs={prefersReducedMotion() ? 0 : 720}
+            />
+          </span>
+        )}
         {virtualItems.map((virtualRow) => (
           <div
             key={virtualRow.index}
@@ -253,7 +331,6 @@ export default function HmrcResults({ search }: { search: string }) {
               search={search}
               isActive={activeId === results[virtualRow.index].slugId}
               isHighlighted={highlightedIndex === virtualRow.index}
-              lensRotation={lensRotation}
               onActivate={() => {
                 // flushSync forces React to commit the state update before
                 // TanStack Router's click handler triggers

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -70,14 +70,16 @@ export default function HmrcResults({ search }: { search: string }) {
         lineHeight: 16,
       },
       {
-        // Location is inline ≥sm (no extra line) but stacks onto its OWN line
-        // <sm. Count it as one line (sentinel) only when narrow AND present;
-        // '' otherwise so it costs nothing on desktop. lineHeight 24 = the 20px
-        // line + the 4px stack gap that the extra line introduces.
-        getText: (row) =>
-          isNarrow && formatLocation(row.locality, row.region) ? 'M' : '',
+        // Location is inline ≥sm (no extra height) but stacks onto its OWN line <sm.
+        // getText MUST stay row-data-only: virtual-text-layout caches each row's
+        // getText output once (rebuilt only when results shrink), so gating it on
+        // isNarrow would freeze the height at the first-measured breakpoint and
+        // desync after a runtime resize across 640px. The breakpoint switch lives in
+        // lineHeight, which the estimator reads fresh every call — <sm 24 (20px line
+        // + 4px stack gap), ≥sm 0 (inline, no extra height).
+        getText: (row) => (formatLocation(row.locality, row.region) ? 'M' : ''),
         font: '14px Geist', // text-sm
-        lineHeight: 24,
+        lineHeight: isNarrow ? 24 : 0,
       },
     ],
     // Name is single-line (truncate). Metadata is one inline line ≥sm; <sm it

--- a/apps/web/src/components/SkeletonCards.tsx
+++ b/apps/web/src/components/SkeletonCards.tsx
@@ -1,6 +1,7 @@
 /**
- * Single shimmer row matching the layout of `HmrcCard` (title, rating, location,
- * route) so the placeholder occupies the same vertical space as a real result.
+ * Single shimmer row matching the compact layout of `HmrcCard` (title plus one
+ * metadata row) so the placeholder occupies the same vertical space as a real
+ * result and the loading→loaded swap doesn't shift.
  */
 function SkeletonRow() {
   return (
@@ -9,30 +10,23 @@ function SkeletonRow() {
       <h3 className="heading-card text-base font-semibold text-(--sea-ink)">
         <span className="inline-block h-4 w-44 rounded bg-(--sea-ink-soft)/15" />
       </h3>
-      {/* rating — same as HmrcCard rating wrapper */}
-      <div className="mt-0.5">
-        <span className="inline-flex items-center gap-1.5 text-sm text-(--sea-ink-soft)">
-          <span className="inline-block h-3.5 w-32 rounded bg-(--sea-ink-soft)/10" />
+      {/* metadata — one row ≥sm, stacks to three lines <sm (matches HmrcCard) */}
+      <div className="mt-1 flex flex-col items-start gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="inline-block h-3.5 w-28 rounded bg-(--sea-ink-soft)/10" />
           <span className="inline-block h-2 w-2 rounded-full bg-(--sea-ink-soft)/15" />
         </span>
-      </div>
-      {/* location + route — same as HmrcCard bottom block */}
-      <div className="mt-0.5">
-        <p className="text-sm text-(--sea-ink-soft)">
-          <span className="inline-block h-3.5 w-24 rounded bg-(--sea-ink-soft)/10" />
-        </p>
-        <p className="mt-0.5 truncate text-xs text-(--sea-ink-soft)">
-          <span className="inline-block h-3 w-20 rounded bg-(--sea-ink-soft)/10" />
-        </p>
+        <span className="inline-block h-3.5 w-20 rounded bg-(--sea-ink-soft)/10" />
+        <span className="inline-block h-5 w-24 rounded-md bg-(--sea-ink-soft)/10" />
       </div>
     </div>
   );
 }
 
 /**
- * Renders `count` skeleton rows inside the sponsor-card container, or a bare
- * fragment when `bare` is true (used for the load-more footer inside an
- * existing results panel so rows don't double up their background).
+ * Renders `count` skeleton rows in a padded column, or a bare fragment when
+ * `bare` is true (used for the load-more footer inside the existing results
+ * container, which already supplies the matching padding).
  */
 export default function SkeletonCards({
   count = 6,
@@ -53,7 +47,14 @@ export default function SkeletonCards({
   }
 
   return (
-    <div className="mt-6 flex flex-col gap-6 rounded-lg bg-(--sponsor-card-bg) px-4 py-2 shadow-(--shadow-card)">
+    <div className="relative mt-6 flex flex-col gap-6 px-4 py-2">
+      {/* Static rail matching HmrcResults's RAIL_X (≈ the content column's left
+          edge) so loading→loaded doesn't pop; the marker only appears once a row
+          is highlighted */}
+      <span
+        aria-hidden
+        className="guide-rail pointer-events-none absolute top-2 bottom-2 left-0 w-px rounded-full"
+      />
       {Array.from({ length: count }).map((_, i) => (
         // oxlint-disable-next-line react/no-array-index-key -- static skeleton placeholders never reorder
         <SkeletonRow key={i} />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -47,6 +47,8 @@
   --grid-line: rgba(62, 147, 244, 0.369);
   --grid-opacity: 0.7;
   --sponsor-card-bg: #f5f6f8;
+  --chip-bg: #eceef1;
+  --chip-line: #dfe1e6;
   --footer-line: var(--gray-200);
   --logo-navy: #001c55;
   --logo-red: #c8102e;
@@ -189,6 +191,32 @@ body::after {
     black,
     transparent 70%
   );
+}
+
+/* Search results guide-rail. Reuses the empty-state hero "streaks" spectrum
+   (HeroText.module.css `.streaks`) so the rail reads as part of that colourful
+   grid rather than a plain accent. The streaks paint it 90deg across the grid;
+   the rail is a single vertical line, so it runs 180deg down its own length.
+   Same stops in both themes (theme-independent hex); only opacity differs. */
+.guide-rail {
+  /* Loops back to the start colour at 100% so the vertical repeat is seamless. */
+  background-image: linear-gradient(
+    180deg,
+    #4f7cff 0%,
+    #9a5cff 20%,
+    #ff6fae 40%,
+    #ffb347 60%,
+    #5fd0a0 80%,
+    #4f7cff 100%
+  );
+  /* One full spectrum per viewport height, repeated down the rail — so the whole
+     sweep stays visible whether the list is two rows or two hundred. */
+  background-size: 100% 100vh;
+  background-repeat: repeat-y;
+  opacity: 0.5;
+}
+.dark .guide-rail {
+  opacity: 0.6;
 }
 
 a:where(:not([class*='no-underline'])) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -197,9 +197,27 @@ body::after {
    (HeroText.module.css `.streaks`) so the rail reads as part of that colourful
    grid rather than a plain accent. The streaks paint it 90deg across the grid;
    the rail is a single vertical line, so it runs 180deg down its own length.
-   Same stops in both themes (theme-independent hex); only opacity differs. */
+   Light mode uses deeper, more saturated stops (the bright stops wash out on the
+   near-white page); dark mode keeps the brighter stops on the #0a0a0a page. */
 .guide-rail {
   /* Loops back to the start colour at 100% so the vertical repeat is seamless. */
+  background-image: linear-gradient(
+    180deg,
+    #2954d6 0%,
+    #7b3fe4 20%,
+    #e23b86 40%,
+    #e2820e 60%,
+    #18a06d 80%,
+    #2954d6 100%
+  );
+  /* One full spectrum per viewport height, repeated down the rail — so the whole
+     sweep stays visible whether the list is two rows or two hundred. */
+  background-size: 100% 100vh;
+  background-repeat: repeat-y;
+  opacity: 0.8;
+}
+.dark .guide-rail {
+  /* Brighter stops pop on the dark page; the deeper light-mode stops would muddy. */
   background-image: linear-gradient(
     180deg,
     #4f7cff 0%,
@@ -209,13 +227,6 @@ body::after {
     #5fd0a0 80%,
     #4f7cff 100%
   );
-  /* One full spectrum per viewport height, repeated down the rail — so the whole
-     sweep stays visible whether the list is two rows or two hundred. */
-  background-size: 100% 100vh;
-  background-repeat: repeat-y;
-  opacity: 0.5;
-}
-.dark .guide-rail {
   opacity: 0.6;
 }
 


### PR DESCRIPTION
## Summary
- Moves the keyboard-highlight Union Jack from a per-card box to a single continuous **guide-rail + marker** rendered once in `HmrcResults` (the highlighted row only reddens its name — its text no longer shifts right).
- Makes the result cards **compact + responsive**: metadata is one inline row at ≥640px and stacks below it; the name and route truncate; new chip styling for the route.
- Removes the card background/shadow container; adds the `.guide-rail` spectrum gradient and `--chip-bg` / `--chip-line` tokens.
- Updates the loading skeletons and the `CLAUDE.md` virtual-list invariants to match.

## Review fixes folded in
- **Virtual-list height bug:** the location estimator field gated `getText` on `isNarrow`, but `virtual-text-layout` caches each row's `getText` output and only rebuilds it when results shrink — so crossing the 640px breakpoint at runtime mis-sized located rows by ±24px, and `virtualizer.measure()` just re-read the stale cache. Fixed by moving the breakpoint switch to `lineHeight` (read fresh each estimate) and keeping `getText` a pure function of row data.
- **Doc fix:** corrected the `CLAUDE.md` marker note (no `top` transition exists) and documented the `lineHeight`-not-`getText` invariant so it can't regress.

## Test plan
- `bun lint` ✓ (0 warnings / 0 errors) · `bun run build` ✓
- Equivalence verified: row-height estimates are identical to before on the no-resize path, and correct in **both** resize directions across 640px.
- Manual: with results showing, resize a desktop window across 640px — rows stay correctly spaced (no overlap/gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MzSbdBGkXWjRkKKQvMCT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual "Union Jack" marker rail to highlight the currently selected result.

* **Style**
  * Reorganized result card metadata layout with improved responsive behavior on small screens.
  * Updated loading skeleton appearance to match the new card design.
  * Added new theme variables for chip styling.

* **Documentation**
  * Revised virtual list sizing guidance to reflect updated height estimation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->