### PR TITLE
Fix/city scape theme toggle

### DIFF
--- a/apps/web/src/components/LondonSkyline.module.css
+++ b/apps/web/src/components/LondonSkyline.module.css
@@ -20,9 +20,14 @@
   display: inline;
 }
 
-/* Sky-fill entrance: the sun / moon fill in gradually while the stars blink on
-   (staggered). Re-plays each time the skyline scrolls into view; without motion
-   the shapes simply stay filled (default fill-opacity). */
+/* Clouds drift across the light-mode sky only. */
+:global(.dark) .clouds {
+  display: none;
+}
+
+/* Sky-fill entrance: the sun / moon fill in gradually, the stars blink on
+   (staggered), and the light-mode clouds drift in. Re-plays each time the
+   skyline scrolls into view; without motion the shapes simply stay shown. */
 @keyframes skyline-fill {
   from {
     fill-opacity: 0;
@@ -45,13 +50,26 @@
     fill-opacity: 1;
   }
 }
+@keyframes skyline-cloud-drift {
+  from {
+    opacity: 0;
+    transform: translateX(-26px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
 @media (prefers-reduced-motion: no-preference) {
   /* Once JS is live, the celestial shapes rest empty until animated in, so each
-     re-entry into view starts the fill from scratch (no JS = stays filled). */
+     re-entry into view starts the fill from scratch (no JS = stays shown). */
   .js .sunDisc,
   .js .moonDisc,
   .js .star {
     fill-opacity: 0;
+  }
+  .js .cloud {
+    opacity: 0;
   }
   .animate .sunDisc,
   .animate .moonDisc {
@@ -59,5 +77,9 @@
   }
   .animate .star {
     animation: skyline-blink 0.5s ease both;
+  }
+  .animate .cloud {
+    transform-box: fill-box;
+    animation: skyline-cloud-drift 1.5s ease-out both;
   }
 }

--- a/apps/web/src/components/LondonSkyline.tsx
+++ b/apps/web/src/components/LondonSkyline.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { useIsDark } from '../hooks/useIsDark';
+
 import styles from './LondonSkyline.module.css';
 
 interface LondonSkylineProps {
@@ -175,6 +177,13 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
   const ref = useRef<SVGSVGElement>(null);
   const [mounted, setMounted] = useState(false);
   const [inView, setInView] = useState(false);
+  // Bumped on each light<->dark flip; keys the celestial groups so they remount
+  // and re-run their fill animation (display:none -> shown alone won't restart it).
+  // A counter (not `isDark` itself) keeps the SSR/first-paint key stable — keying
+  // on isDark directly would hydration-mismatch.
+  const isDark = useIsDark();
+  const [themeFlips, setThemeFlips] = useState(0);
+  const wasDark = useRef(isDark);
 
   // Re-play the sky-fill animation each time the skyline enters the viewport.
   useEffect(() => {
@@ -194,6 +203,14 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
+
+  // A light<->dark switch replays the sky-fill via the keyed remount below.
+  useEffect(() => {
+    if (wasDark.current !== isDark) {
+      wasDark.current = isDark;
+      setThemeFlips((n) => n + 1);
+    }
+  }, [isDark]);
 
   return (
     <svg
@@ -218,7 +235,7 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
       aria-label="London skyline"
     >
       {/* Sun — light mode only (disc fills in gradually + rays) */}
-      <g className={styles.sun}>
+      <g key={`sun-${themeFlips}`} className={styles.sun}>
         <circle
           className={styles.sunDisc}
           cx={CELESTIAL.cx}
@@ -232,7 +249,7 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
       </g>
 
       {/* Crescent moon (gradual fill) + stars (blink in) — dark mode only */}
-      <g className={styles.moon}>
+      <g key={`moon-${themeFlips}`} className={styles.moon}>
         <path className={styles.moonDisc} d={moonPath} fill="#ffffff" />
         {stars.map((d, i) => (
           <path

--- a/apps/web/src/components/LondonSkyline.tsx
+++ b/apps/web/src/components/LondonSkyline.tsx
@@ -166,6 +166,19 @@ const stars = [
   [1260, 132, 14],
 ].map(([x, y, s]) => buildStar(x, y, s));
 
+// Clouds drifting across the light-mode sky — a puffy 3-bump and a wide 4-bump
+// outline, placed and scaled across the upper sky (stroke width undoes the scale
+// so it matches the buildings). delay staggers their drift-in.
+const CLOUD_PUFFY =
+  'M14,40 a16,16 0 0 1 -2,-31 a18,18 0 0 1 34,-6 a20,20 0 0 1 38,5 a15,15 0 0 1 22,32 z';
+const CLOUD_WIDE =
+  'M10,44 a14,14 0 0 1 0,-22 a16,16 0 0 1 26,-10 a18,18 0 0 1 34,2 a16,16 0 0 1 30,6 a14,14 0 0 1 18,24 z';
+const clouds = [
+  { path: CLOUD_PUFFY, x: 235, y: 150, scale: 1.25, delay: 0.1 },
+  { path: CLOUD_WIDE, x: 560, y: 92, scale: 1.25, delay: 0.35 },
+  { path: CLOUD_PUFFY, x: 815, y: 180, scale: 0.95, delay: 0.6 },
+];
+
 /**
  * Clean single-stroke line drawing of the London skyline — Big Ben, the London
  * Eye, St Paul's Cathedral, Tower Bridge, the Shard and the Gherkin — sitting on
@@ -259,6 +272,23 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
             fill="#ffffff"
             style={{ animationDelay: `${0.15 + i * 0.12}s` }}
           />
+        ))}
+      </g>
+
+      {/* Clouds — light mode only (drift in) */}
+      <g key={`clouds-${themeFlips}`} className={styles.clouds}>
+        {clouds.map((c) => (
+          <g
+            key={`${c.x},${c.y}`}
+            transform={`translate(${c.x},${c.y}) scale(${c.scale})`}
+          >
+            <g
+              className={styles.cloud}
+              style={{ animationDelay: `${c.delay}s` }}
+            >
+              <path d={c.path} fill="#ffffff" strokeWidth={r(2 / c.scale)} />
+            </g>
+          </g>
         ))}
       </g>
 

--- a/apps/web/src/components/LondonSkyline.tsx
+++ b/apps/web/src/components/LondonSkyline.tsx
@@ -383,9 +383,6 @@ export default function LondonSkyline({ className }: LondonSkylineProps) {
           <path d="M1290,360 L1386,360 M1290,440 L1386,440 M1290,520 L1386,520" />
         </g>
       </g>
-
-      {/* Ground line */}
-      <path d="M30,600 L1440,600" />
     </svg>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated cloud effects that drift across the light mode skyline with smooth fade-in animations
  * Clouds now automatically replay their animations when users switch between light and dark themes for seamless visual transitions

* **Style**
  * Enhanced accessibility support by fully respecting users' reduced motion preferences
  * Removed the static ground line element from the skyline illustration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->