### PR TITLE
feat: maps clientside cache

### DIFF
--- a/apps/web/src/components/CachedTileLayer.tsx
+++ b/apps/web/src/components/CachedTileLayer.tsx
@@ -72,10 +72,19 @@ class CachedLeafletTileLayer extends L.TileLayer {
         }
         const objectUrl = URL.createObjectURL(blob);
         tile._objectUrl = objectUrl;
-        tile.onload = () => done(undefined, tile);
+        tile.onload = () => {
+          if (tile._discarded) return;
+          done(undefined, tile);
+        };
         tile.onerror = () => {
-          // Undecodable body (e.g. a truncated 200): evict so the tile can recover
-          // on a later view instead of being pinned as a permanent failure.
+          // A discard mid-load revokes the object URL, which itself trips onerror —
+          // that's not a bad blob, so don't evict a healthy cache entry.
+          if (tile._discarded) return;
+          // Genuine undecodable body (e.g. a truncated 200): free the dead URL and
+          // evict so the tile can recover on a later view instead of being pinned
+          // as a permanent failure.
+          URL.revokeObjectURL(objectUrl);
+          tile._objectUrl = undefined;
           this.queryClient.removeQueries({ queryKey: ['map-tile', url] });
           done(new Error('tile decode failed'), tile);
         };

--- a/apps/web/src/components/CachedTileLayer.tsx
+++ b/apps/web/src/components/CachedTileLayer.tsx
@@ -1,0 +1,122 @@
+import { type QueryClient, useQueryClient } from '@tanstack/react-query';
+import L from 'leaflet';
+import { useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+
+interface CachedTileLayerOptions extends L.TileLayerOptions {
+  queryClient: QueryClient;
+}
+
+/** Tile `<img>` augmented with the object URL we minted for it, so it can be revoked on unload. */
+interface TileImg extends HTMLImageElement {
+  _objectUrl?: string;
+}
+
+/** `L.TileLayer` that loads each tile through TanStack Query instead of letting the browser fetch `img.src` directly. Tiles are cached as Blobs keyed by their resolved URL (theme + z/x/y + retina), so repeat tiles come from the in-memory cache with no network request. */
+class CachedLeafletTileLayer extends L.TileLayer {
+  private queryClient: QueryClient;
+
+  constructor(urlTemplate: string, options: CachedTileLayerOptions) {
+    const { queryClient, ...leafletOptions } = options;
+    super(urlTemplate, leafletOptions);
+    this.queryClient = queryClient;
+  }
+
+  /** Fetch the tile blob via TanStack Query, then point the `<img>` at an object URL. Leaflet's `done` contract is honoured on load/error. */
+  createTile(coords: L.Coords, done: L.DoneCallback): HTMLElement {
+    const tile = document.createElement('img') as TileImg;
+    tile.setAttribute('role', 'presentation');
+    tile.alt = '';
+
+    const url = this.getTileUrl(coords);
+
+    this.queryClient
+      .fetchQuery({
+        queryKey: ['map-tile', url],
+        queryFn: async ({ signal }): Promise<Blob> => {
+          const res = await fetch(url, { signal });
+          if (!res.ok) throw new Error(`tile request failed: ${res.status}`);
+          return res.blob();
+        },
+        // Tiles are immutable, so never refetch; keep blobs for the session
+        // to maximise cache hits (memory vs hit-rate knob lives here).
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: Number.POSITIVE_INFINITY,
+        retry: 1,
+      })
+      .then((blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        tile._objectUrl = objectUrl;
+        tile.onload = () => done(undefined, tile);
+        tile.onerror = () => done(new Error('tile decode failed'), tile);
+        tile.src = objectUrl;
+      })
+      .catch((error: unknown) => {
+        done(
+          error instanceof Error ? error : new Error('tile fetch failed'),
+          tile,
+        );
+      });
+
+    return tile;
+  }
+
+  onAdd(map: L.Map): this {
+    super.onAdd(map);
+    this.on('tileunload', this.handleTileUnload, this);
+    return this;
+  }
+
+  onRemove(map: L.Map): this {
+    // super.onRemove fires `tileunload` per tile, so the handler revokes them
+    // all; remove our listener only afterwards.
+    super.onRemove(map);
+    this.off('tileunload', this.handleTileUnload, this);
+    return this;
+  }
+
+  /** Revoke the object URL once Leaflet discards a tile so the Blob isn't pinned in memory. */
+  private handleTileUnload(event: L.TileEvent): void {
+    const tile = event.tile as TileImg;
+    if (tile._objectUrl) {
+      URL.revokeObjectURL(tile._objectUrl);
+      tile._objectUrl = undefined;
+    }
+  }
+}
+
+interface CachedTileLayerProps {
+  url: string;
+  attribution?: string;
+}
+
+/** Drop-in replacement for react-leaflet's `<TileLayer>` that routes tiles through the TanStack Query cache. A `url` change (light/dark theme swap) re-requests tiles via Leaflet's in-place `setUrl` rather than rebuilding the layer. */
+export function CachedTileLayer({ url, attribution }: CachedTileLayerProps) {
+  const map = useMap();
+  const queryClient = useQueryClient();
+  const layerRef = useRef<CachedLeafletTileLayer | null>(null);
+  const firstUrlRun = useRef(true);
+
+  useEffect(() => {
+    const layer = new CachedLeafletTileLayer(url, { attribution, queryClient });
+    layerRef.current = layer;
+    layer.addTo(map);
+    return () => {
+      layer.remove();
+      layerRef.current = null;
+    };
+    // `url` is intentionally excluded — the effect below applies theme swaps
+    // via Leaflet's setUrl, avoiding a full layer teardown/rebuild.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, queryClient, attribution]);
+
+  useEffect(() => {
+    if (firstUrlRun.current) {
+      firstUrlRun.current = false;
+      return;
+    }
+    layerRef.current?.setUrl(url);
+  }, [url]);
+
+  return null;
+}

--- a/apps/web/src/components/CachedTileLayer.tsx
+++ b/apps/web/src/components/CachedTileLayer.tsx
@@ -7,12 +7,18 @@ interface CachedTileLayerOptions extends L.TileLayerOptions {
   queryClient: QueryClient;
 }
 
-/** Tile `<img>` augmented with the object URL we minted for it, so it can be revoked on unload. */
+/** Tile `<img>` augmented with the object URL we minted for it, plus a flag set when Leaflet discards the tile so a late-resolving fetch doesn't mint a URL nothing will revoke. */
 interface TileImg extends HTMLImageElement {
   _objectUrl?: string;
+  _discarded?: boolean;
 }
 
-/** `L.TileLayer` that loads each tile through TanStack Query instead of letting the browser fetch `img.src` directly. Tiles are cached as Blobs keyed by their resolved URL (theme + z/x/y + retina), so repeat tiles come from the in-memory cache with no network request. */
+// Tiles are immutable so they never go stale, but blobs are held in the shared
+// app QueryClient — bound retention to a session-ish window so heavy panning
+// can't grow memory without limit. Tune up for more cache hits, down for less RAM.
+const TILE_GC_TIME = 30 * 60 * 1000;
+
+/** `L.TileLayer` that loads each tile through TanStack Query instead of letting the browser fetch `img.src` directly. Tiles are cached as Blobs keyed by their resolved URL (theme + z/x/y + retina), so repeat tiles come from the in-memory cache with no network request. Object URLs are freed via Leaflet's `tileunload`/`tileabort` events, and a discard flag stops a late-resolving fetch from leaking one. */
 class CachedLeafletTileLayer extends L.TileLayer {
   private queryClient: QueryClient;
 
@@ -22,36 +28,61 @@ class CachedLeafletTileLayer extends L.TileLayer {
     this.queryClient = queryClient;
   }
 
-  /** Fetch the tile blob via TanStack Query, then point the `<img>` at an object URL. Leaflet's `done` contract is honoured on load/error. */
+  /** Fetch the tile blob via TanStack Query, then point the `<img>` at an object URL. Lifecycle guards ensure a tile removed mid-flight neither leaks its URL nor revives at a stale zoom. */
   createTile(coords: L.Coords, done: L.DoneCallback): HTMLElement {
     const tile = document.createElement('img') as TileImg;
     tile.setAttribute('role', 'presentation');
     tile.alt = '';
 
     const url = this.getTileUrl(coords);
+    const tileZoom = coords.z;
 
     this.queryClient
       .fetchQuery({
         queryKey: ['map-tile', url],
-        queryFn: async ({ signal }): Promise<Blob> => {
-          const res = await fetch(url, { signal });
+        queryFn: async (): Promise<Blob> => {
+          // `redirect: 'error'` rejects the route's 302 -> /blocked-tile.png so an
+          // auth-failure placeholder is never cached under a real tile's key.
+          const res = await fetch(url, { redirect: 'error' });
           if (!res.ok) throw new Error(`tile request failed: ${res.status}`);
+          const type = res.headers.get('content-type');
+          if (!type?.startsWith('image/')) {
+            throw new Error(`tile not an image: ${type ?? 'unknown'}`);
+          }
           return res.blob();
         },
-        // Tiles are immutable, so never refetch; keep blobs for the session
-        // to maximise cache hits (memory vs hit-rate knob lives here).
         staleTime: Number.POSITIVE_INFINITY,
-        gcTime: Number.POSITIVE_INFINITY,
-        retry: 1,
+        gcTime: TILE_GC_TIME,
+        retry: false,
       })
       .then((blob) => {
+        // Tile was discarded mid-fetch (Leaflet churns tiles, and StrictMode
+        // remounts the layer) or the map zoomed away — don't mint a URL nothing
+        // will revoke, or revive a wrong-scale tile. The blob stays cached for the
+        // re-created tile to reuse. We deliberately let the fetch run to completion
+        // rather than abort it: aborting on Leaflet's tile churn cancelled the
+        // shared (deduped) in-flight request out from under live tiles.
+        const currentZoom = (this as unknown as { _tileZoom?: number })
+          ._tileZoom;
+        if (
+          tile._discarded ||
+          (currentZoom !== undefined && tileZoom !== currentZoom)
+        ) {
+          return;
+        }
         const objectUrl = URL.createObjectURL(blob);
         tile._objectUrl = objectUrl;
         tile.onload = () => done(undefined, tile);
-        tile.onerror = () => done(new Error('tile decode failed'), tile);
+        tile.onerror = () => {
+          // Undecodable body (e.g. a truncated 200): evict so the tile can recover
+          // on a later view instead of being pinned as a permanent failure.
+          this.queryClient.removeQueries({ queryKey: ['map-tile', url] });
+          done(new Error('tile decode failed'), tile);
+        };
         tile.src = objectUrl;
       })
       .catch((error: unknown) => {
+        if (tile._discarded) return;
         done(
           error instanceof Error ? error : new Error('tile fetch failed'),
           tile,
@@ -63,21 +94,22 @@ class CachedLeafletTileLayer extends L.TileLayer {
 
   onAdd(map: L.Map): this {
     super.onAdd(map);
-    this.on('tileunload', this.handleTileUnload, this);
+    this.on('tileunload tileabort', this.handleTileDiscard, this);
     return this;
   }
 
   onRemove(map: L.Map): this {
-    // super.onRemove fires `tileunload` per tile, so the handler revokes them
-    // all; remove our listener only afterwards.
+    // super.onRemove fires `tileunload` per remaining tile, so the handler aborts
+    // and revokes them all; detach our listener only afterwards.
     super.onRemove(map);
-    this.off('tileunload', this.handleTileUnload, this);
+    this.off('tileunload tileabort', this.handleTileDiscard, this);
     return this;
   }
 
-  /** Revoke the object URL once Leaflet discards a tile so the Blob isn't pinned in memory. */
-  private handleTileUnload(event: L.TileEvent): void {
-    const tile = event.tile as TileImg;
+  /** Mark a discarded tile so its late-resolving fetch won't mint an orphan URL, and free its object URL if one was already minted. */
+  private handleTileDiscard(event: L.LeafletEvent): void {
+    const tile = (event as L.TileEvent).tile as TileImg;
+    tile._discarded = true;
     if (tile._objectUrl) {
       URL.revokeObjectURL(tile._objectUrl);
       tile._objectUrl = undefined;
@@ -95,7 +127,6 @@ export function CachedTileLayer({ url, attribution }: CachedTileLayerProps) {
   const map = useMap();
   const queryClient = useQueryClient();
   const layerRef = useRef<CachedLeafletTileLayer | null>(null);
-  const firstUrlRun = useRef(true);
 
   useEffect(() => {
     const layer = new CachedLeafletTileLayer(url, { attribution, queryClient });
@@ -105,16 +136,13 @@ export function CachedTileLayer({ url, attribution }: CachedTileLayerProps) {
       layer.remove();
       layerRef.current = null;
     };
-    // `url` is intentionally excluded — the effect below applies theme swaps
-    // via Leaflet's setUrl, avoiding a full layer teardown/rebuild.
+    // Rebuild only on map/client identity change. `url` is applied in place by the
+    // effect below (Leaflet setUrl), so a theme swap doesn't tear the layer down;
+    // `attribution` is a constant.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, queryClient, attribution]);
+  }, [map, queryClient]);
 
   useEffect(() => {
-    if (firstUrlRun.current) {
-      firstUrlRun.current = false;
-      return;
-    }
     layerRef.current?.setUrl(url);
   }, [url]);
 

--- a/apps/web/src/components/LeafletMap.tsx
+++ b/apps/web/src/components/LeafletMap.tsx
@@ -2,16 +2,12 @@ import L from 'leaflet';
 
 import 'leaflet/dist/leaflet.css';
 import { renderToStaticMarkup } from 'react-dom/server';
-import {
-  AttributionControl,
-  MapContainer,
-  Marker,
-  TileLayer,
-} from 'react-leaflet';
+import { AttributionControl, MapContainer, Marker } from 'react-leaflet';
 
 import type { Geocoded } from '../api/geocode';
 import { useIsDark } from '../hooks/useIsDark';
 import { TILE_MAX_ZOOM, TILE_MIN_ZOOM } from '../utils/tileBounds';
+import { CachedTileLayer } from './CachedTileLayer';
 
 import './LeafletMap.css';
 import UnionJackLens from './UnionJackLens';
@@ -71,7 +67,7 @@ export default function LeafletMap({
       className="absolute inset-0 isolate h-full w-full"
     >
       <AttributionControl prefix={false} />
-      <TileLayer
+      <CachedTileLayer
         attribution={TILE_ATTRIBUTION}
         url={isDark ? DARK_TILES : LIGHT_TILES}
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved map tile loading with local browser caching for faster repeat viewing and smoother theme-based tile swaps.
  * Map tiles now update in place when the map style changes, reducing visible reloads.
* **Bug Fixes**
  * Better handles failed or blocked tile requests and avoids reusing outdated tile images.
  * Prevents stale map tiles from lingering after zooming or changing layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->