### PR TITLE
fix: trying a smaller dot size

### DIFF
--- a/apps/web/src/theme-transition.ts
+++ b/apps/web/src/theme-transition.ts
@@ -55,7 +55,7 @@ const EASING: (t: number) => number = EASINGS.easeOut;
 // Dot edge in CSS px — chunkier on desktop, finer on the narrow mobile layout
 // (see cellSizeCss). The canvas-2D grid is capped to ~MAX_CELLS dots so
 // large/HiDPI viewports don't overload CPU.
-const CELL_CSS_DESKTOP = 0.65;
+const CELL_CSS_DESKTOP = 0.95;
 const CELL_CSS_MOBILE = 1;
 const MAX_CELLS = 360000;
 // Per-dot brightness jitter (±, 0–255 scale) so the fill reads as grain.

--- a/apps/web/src/theme-transition.ts
+++ b/apps/web/src/theme-transition.ts
@@ -55,7 +55,7 @@ const EASING: (t: number) => number = EASINGS.easeOut;
 // Dot edge in CSS px — chunkier on desktop, finer on the narrow mobile layout
 // (see cellSizeCss). The canvas-2D grid is capped to ~MAX_CELLS dots so
 // large/HiDPI viewports don't overload CPU.
-const CELL_CSS_DESKTOP = 0.95;
+const CELL_CSS_DESKTOP = 0.35;
 const CELL_CSS_MOBILE = 1;
 const MAX_CELLS = 360000;
 // Per-dot brightness jitter (±, 0–255 scale) so the fill reads as grain.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of desktop theme transitions by making the dot grid larger and less dense.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->