### PR TITLE
feat: black hole on the empty-search state

### DIFF
--- a/apps/web/src/components/BlackHole.tsx
+++ b/apps/web/src/components/BlackHole.tsx
@@ -9,10 +9,14 @@ declare const GPUBufferUsage: {
   readonly COPY_DST: number;
 };
 
+// The single frame shown to reduced-motion users (seconds into the animation).
+// Picked for a well-formed disk; purely cosmetic, safe to tune.
+const STATIC_FRAME_TIME = 6;
+
 /**
  * A plain ring at the event-horizon radius — shown before the shader loads, and the
- * no-WebGPU / reduced-motion fallback. r = HORIZON (0.22) × the 300 viewBox = 66, so it
- * lines up with the shader's photon ring. `currentColor` keeps it visible in both themes.
+ * fallback when WebGPU is unavailable or fails. r = HORIZON (0.22) × the 300 viewBox = 66,
+ * so it lines up with the shader's photon ring. `currentColor` keeps it visible in both themes.
  */
 function PlaceholderRing({
   className,
@@ -43,9 +47,10 @@ function PlaceholderRing({
 
 /**
  * The WGSL accretion-disk black hole, on the same WebGPU setup as the theme transition.
- * A plain ring shows first (and is the no-WebGPU / reduced-motion fallback); the shader
- * fades in over it once ready. Size the square box via `className` / `style`. Used for
- * the 404 "0" and the empty-search state.
+ * A plain ring shows first and stays as the no-WebGPU / failure fallback; otherwise the
+ * shader fades in over it — animated normally, or as a single static frame under reduced
+ * motion. Size the square box via `className` / `style`. Used for the 404 "0" and the
+ * empty-search state.
  */
 export default function BlackHole({
   className,
@@ -60,10 +65,13 @@ export default function BlackHole({
   const [mode, setMode] = useState<'gpu' | 'svg'>('svg');
 
   useEffect(() => {
-    if (prefersReducedMotion() || !navigator.gpu) {
+    // No WebGPU at all → the ring is the only option. Reduced motion still gets the
+    // shader, just frozen on one frame (handled below), so it's not gated here.
+    if (!navigator.gpu) {
       setMode('svg');
       return;
     }
+    const reduce = prefersReducedMotion();
     const canvas = canvasRef.current;
     if (!canvas) return;
     let device: GPUDevice | undefined;
@@ -72,13 +80,19 @@ export default function BlackHole({
     let visible = true;
     let resize: ResizeObserver | undefined;
     let io: IntersectionObserver | undefined;
+    let themeObserver: MutationObserver | undefined;
 
-    /** Resize the drawing buffer to the canvas box; the frame loop reads it into u.resolution. */
+    /** Resize the drawing buffer to the canvas box. Idempotent — only touches the canvas
+     * when the size actually changed, so it can't needlessly clear the static frame. */
     const sizeCanvas = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
       const rect = canvas.getBoundingClientRect();
-      canvas.width = Math.max(2, Math.ceil(rect.width * dpr));
-      canvas.height = Math.max(2, Math.ceil(rect.height * dpr));
+      const w = Math.max(2, Math.ceil(rect.width * dpr));
+      const h = Math.max(2, Math.ceil(rect.height * dpr));
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+      }
     };
 
     // Fetch the shader in parallel with GPU acquisition — independent latencies, so the
@@ -180,21 +194,17 @@ export default function BlackHole({
       });
 
       const data = new Float32Array(4);
-      const start = performance.now();
-      const frame = (now: number) => {
-        // Stop the loop while unmounted, device-lost, or scrolled offscreen.
-        if (!alive || !device || !visible) {
-          raf = 0;
-          return;
-        }
+      /** Render exactly one frame at time `t` (seconds). Shared by the animation loop and
+       * the reduced-motion static render. */
+      const drawFrame = (dev: GPUDevice, t: number) => {
         data[0] = canvas.width;
         data[1] = canvas.height;
-        data[2] = (now - start) / 1000;
-        // Read the live theme each frame so the stars flip on a theme toggle.
+        data[2] = t;
+        // Read the live theme each draw so the stars match dark/light.
         data[3] = document.documentElement.classList.contains('dark') ? 1 : 0;
-        device.queue.writeBuffer(uniform, 0, data);
+        dev.queue.writeBuffer(uniform, 0, data);
 
-        const encoder = device.createCommandEncoder();
+        const encoder = dev.createCommandEncoder();
         const pass = encoder.beginRenderPass({
           colorAttachments: [
             {
@@ -209,8 +219,38 @@ export default function BlackHole({
         pass.setBindGroup(0, bindGroup);
         pass.draw(3);
         pass.end();
-        device.queue.submit([encoder.finish()]);
-        raf = window.requestAnimationFrame(frame);
+        dev.queue.submit([encoder.finish()]);
+      };
+
+      // Reduced motion: draw one static frame, then redraw only when something that
+      // changes its pixels happens — a resize (canvas clears) or a theme toggle (star
+      // colour). No rAF loop, no offscreen pausing needed.
+      if (reduce) {
+        const renderStatic = () => {
+          if (alive && device) drawFrame(device, STATIC_FRAME_TIME);
+        };
+        renderStatic();
+        resize = new ResizeObserver(() => {
+          sizeCanvas();
+          renderStatic();
+        });
+        resize.observe(canvas);
+        themeObserver = new MutationObserver(renderStatic);
+        themeObserver.observe(document.documentElement, {
+          attributeFilter: ['class'],
+        });
+        return;
+      }
+
+      const start = performance.now();
+      const animate = (now: number) => {
+        // Stop the loop while unmounted, device-lost, or scrolled offscreen.
+        if (!alive || !device || !visible) {
+          raf = 0;
+          return;
+        }
+        drawFrame(device, (now - start) / 1000);
+        raf = window.requestAnimationFrame(animate);
       };
 
       resize = new ResizeObserver(sizeCanvas);
@@ -220,12 +260,12 @@ export default function BlackHole({
       io = new IntersectionObserver(([entry]) => {
         visible = entry?.isIntersecting ?? true;
         if (visible && !raf && alive && device) {
-          raf = window.requestAnimationFrame(frame);
+          raf = window.requestAnimationFrame(animate);
         }
       });
       io.observe(canvas);
 
-      raf = window.requestAnimationFrame(frame);
+      raf = window.requestAnimationFrame(animate);
     })();
 
     return () => {
@@ -233,6 +273,7 @@ export default function BlackHole({
       if (raf) window.cancelAnimationFrame(raf);
       resize?.disconnect();
       io?.disconnect();
+      themeObserver?.disconnect();
       device?.destroy();
     };
   }, []);

--- a/apps/web/src/components/BlackHole.tsx
+++ b/apps/web/src/components/BlackHole.tsx
@@ -1,0 +1,215 @@
+import { type CSSProperties, useEffect, useRef, useState } from 'react';
+
+import { prefersReducedMotion } from '../utils';
+
+// lib.dom ships the WebGPU interfaces but not this flag constant — declare the
+// bits we use; the browser provides them at runtime (same as theme-transition).
+declare const GPUBufferUsage: {
+  readonly UNIFORM: number;
+  readonly COPY_DST: number;
+};
+
+/**
+ * A plain ring at the event-horizon radius — shown before the shader loads, and the
+ * no-WebGPU / reduced-motion fallback. r = HORIZON (0.22) × the 300 viewBox = 66, so it
+ * lines up with the shader's photon ring. `currentColor` keeps it visible in both themes.
+ */
+function PlaceholderRing({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <svg
+      viewBox="0 0 300 300"
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      <circle
+        cx="150"
+        cy="150"
+        r="66"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="4"
+        opacity="0.5"
+      />
+    </svg>
+  );
+}
+
+/**
+ * The WGSL accretion-disk black hole, on the same WebGPU setup as the theme transition.
+ * A plain ring shows first (and is the no-WebGPU / reduced-motion fallback); the shader
+ * fades in over it once ready. Size the square box via `className` / `style`. Used for
+ * the 404 "0" and the empty-search state.
+ */
+export default function BlackHole({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Show the placeholder ring first, then swap to the shader on success. The ring stays
+  // if WebGPU is unavailable or fails — it's the fallback.
+  const [mode, setMode] = useState<'gpu' | 'svg'>('svg');
+
+  useEffect(() => {
+    if (prefersReducedMotion() || !navigator.gpu) {
+      setMode('svg');
+      return;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    let device: GPUDevice | undefined;
+    let raf = 0;
+    let alive = true;
+    let resize: ResizeObserver | undefined;
+
+    /** Resize the drawing buffer to the canvas box; the frame loop reads it into u.resolution. */
+    const sizeCanvas = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.max(2, Math.ceil(rect.width * dpr));
+      canvas.height = Math.max(2, Math.ceil(rect.height * dpr));
+    };
+
+    (async () => {
+      try {
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+          setMode('svg');
+          return;
+        }
+        device = await adapter.requestDevice();
+      } catch {
+        setMode('svg');
+        return;
+      }
+      if (!alive) {
+        device?.destroy();
+        return;
+      }
+      const ctx = canvas.getContext('webgpu') as GPUCanvasContext | null;
+      if (!ctx) {
+        setMode('svg');
+        device.destroy();
+        return;
+      }
+      sizeCanvas();
+      const format = navigator.gpu.getPreferredCanvasFormat();
+
+      // Load the shader lazily so its ~7 KB stays out of the route chunk until a black
+      // hole actually renders on a WebGPU client.
+      let WGSL: string;
+      try {
+        WGSL = (await import('../notFound.wgsl?raw')).default;
+      } catch {
+        setMode('svg');
+        device.destroy();
+        return;
+      }
+
+      let pipeline: GPURenderPipeline;
+      let uniform: GPUBuffer;
+      let bindGroup: GPUBindGroup;
+      // Validation errors (e.g. a shader compile failure) surface through the
+      // error scope, not as throws — capture them so we keep the SVG fallback.
+      device.pushErrorScope('validation');
+      try {
+        ctx.configure({ device, format, alphaMode: 'premultiplied' });
+        const module = device.createShaderModule({ code: WGSL });
+        pipeline = device.createRenderPipeline({
+          layout: 'auto',
+          vertex: { module, entryPoint: 'vs' },
+          fragment: { module, entryPoint: 'fs', targets: [{ format }] },
+          primitive: { topology: 'triangle-list' },
+        });
+        uniform = device.createBuffer({
+          size: 16,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        bindGroup = device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(0),
+          entries: [{ binding: 0, resource: { buffer: uniform } }],
+        });
+      } catch {
+        setMode('svg');
+        await device.popErrorScope().catch(() => null);
+        device.destroy();
+        return;
+      }
+      const setupError = await device.popErrorScope();
+      if (setupError || !alive) {
+        if (setupError && import.meta.env.DEV) {
+          console.warn('[black-hole shader]', setupError.message);
+        }
+        if (setupError) setMode('svg');
+        device.destroy();
+        return;
+      }
+
+      setMode('gpu');
+      resize = new ResizeObserver(sizeCanvas);
+      resize.observe(canvas);
+
+      const data = new Float32Array(4);
+      const start = performance.now();
+      const frame = (now: number) => {
+        if (!alive || !device) return;
+        data[0] = canvas.width;
+        data[1] = canvas.height;
+        data[2] = (now - start) / 1000;
+        // Read the live theme each frame so the stars flip on a theme toggle.
+        data[3] = document.documentElement.classList.contains('dark') ? 1 : 0;
+        device.queue.writeBuffer(uniform, 0, data);
+
+        const encoder = device.createCommandEncoder();
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: ctx.getCurrentTexture().createView(),
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        });
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(0, bindGroup);
+        pass.draw(3);
+        pass.end();
+        device.queue.submit([encoder.finish()]);
+        raf = window.requestAnimationFrame(frame);
+      };
+      raf = window.requestAnimationFrame(frame);
+    })();
+
+    return () => {
+      alive = false;
+      if (raf) window.cancelAnimationFrame(raf);
+      resize?.disconnect();
+      device?.destroy();
+    };
+  }, []);
+
+  return (
+    <div className={`relative ${className ?? ''}`} style={style}>
+      <PlaceholderRing
+        className="absolute inset-0 h-full w-full text-(--sea-ink) transition-opacity duration-500"
+        style={{ opacity: mode === 'svg' ? 1 : 0 }}
+      />
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        className="absolute inset-0 h-full w-full transition-opacity duration-500"
+        style={{ opacity: mode === 'gpu' ? 1 : 0 }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/BlackHole.tsx
+++ b/apps/web/src/components/BlackHole.tsx
@@ -69,7 +69,9 @@ export default function BlackHole({
     let device: GPUDevice | undefined;
     let raf = 0;
     let alive = true;
+    let visible = true;
     let resize: ResizeObserver | undefined;
+    let io: IntersectionObserver | undefined;
 
     /** Resize the drawing buffer to the canvas box; the frame loop reads it into u.resolution. */
     const sizeCanvas = () => {
@@ -78,6 +80,11 @@ export default function BlackHole({
       canvas.width = Math.max(2, Math.ceil(rect.width * dpr));
       canvas.height = Math.max(2, Math.ceil(rect.height * dpr));
     };
+
+    // Fetch the shader in parallel with GPU acquisition — independent latencies, so the
+    // ~7 KB chunk download overlaps adapter/device setup instead of running after it. It
+    // stays out of the route chunk until a black hole actually renders on a WebGPU client.
+    const wgslPromise = import('../notFound.wgsl?raw').catch(() => null);
 
     (async () => {
       try {
@@ -104,16 +111,17 @@ export default function BlackHole({
       sizeCanvas();
       const format = navigator.gpu.getPreferredCanvasFormat();
 
-      // Load the shader lazily so its ~7 KB stays out of the route chunk until a black
-      // hole actually renders on a WebGPU client.
-      let WGSL: string;
-      try {
-        WGSL = (await import('../notFound.wgsl?raw')).default;
-      } catch {
+      const wgsl = await wgslPromise;
+      if (!alive) {
+        device.destroy();
+        return;
+      }
+      if (!wgsl) {
         setMode('svg');
         device.destroy();
         return;
       }
+      const WGSL = wgsl.default;
 
       let pipeline: GPURenderPipeline;
       let uniform: GPUBuffer;
@@ -144,24 +152,41 @@ export default function BlackHole({
         device.destroy();
         return;
       }
-      const setupError = await device.popErrorScope();
-      if (setupError || !alive) {
-        if (setupError && import.meta.env.DEV) {
+      // .catch guards against the device being destroyed mid-setup (an unmount between
+      // awaits) so popErrorScope can't reject on a dead device.
+      const setupError = await device.popErrorScope().catch(() => null);
+      if (!alive) {
+        device.destroy();
+        return;
+      }
+      if (setupError) {
+        if (import.meta.env.DEV) {
           console.warn('[black-hole shader]', setupError.message);
         }
-        if (setupError) setMode('svg');
+        setMode('svg');
         device.destroy();
         return;
       }
 
       setMode('gpu');
-      resize = new ResizeObserver(sizeCanvas);
-      resize.observe(canvas);
+
+      // If the GPU device is lost (driver reset, GPU-process crash, tab discard), stop
+      // and fall back to the ring rather than hammering a dead device forever.
+      void device.lost.then(() => {
+        if (!alive) return; // our own destroy() on unmount — already torn down
+        alive = false;
+        if (raf) window.cancelAnimationFrame(raf);
+        setMode('svg');
+      });
 
       const data = new Float32Array(4);
       const start = performance.now();
       const frame = (now: number) => {
-        if (!alive || !device) return;
+        // Stop the loop while unmounted, device-lost, or scrolled offscreen.
+        if (!alive || !device || !visible) {
+          raf = 0;
+          return;
+        }
         data[0] = canvas.width;
         data[1] = canvas.height;
         data[2] = (now - start) / 1000;
@@ -187,6 +212,19 @@ export default function BlackHole({
         device.queue.submit([encoder.finish()]);
         raf = window.requestAnimationFrame(frame);
       };
+
+      resize = new ResizeObserver(sizeCanvas);
+      resize.observe(canvas);
+      // Pause the draw loop while the hole is scrolled out of view (tab-hidden is already
+      // covered — browsers don't fire rAF for hidden tabs).
+      io = new IntersectionObserver(([entry]) => {
+        visible = entry?.isIntersecting ?? true;
+        if (visible && !raf && alive && device) {
+          raf = window.requestAnimationFrame(frame);
+        }
+      });
+      io.observe(canvas);
+
       raf = window.requestAnimationFrame(frame);
     })();
 
@@ -194,6 +232,7 @@ export default function BlackHole({
       alive = false;
       if (raf) window.cancelAnimationFrame(raf);
       resize?.disconnect();
+      io?.disconnect();
       device?.destroy();
     };
   }, []);

--- a/apps/web/src/components/HmrcResults.tsx
+++ b/apps/web/src/components/HmrcResults.tsx
@@ -7,6 +7,7 @@ import { useVirtualTextLayout } from 'virtual-text-layout';
 import { useHmrcSearch } from '../hooks/useHmrcSearch';
 import { useResultsKeyboardNav } from '../hooks/useResultsKeyboardNav';
 import { formatLocation, prefersReducedMotion } from '../utils';
+import BlackHole from './BlackHole';
 import HmrcCard from './HmrcCard';
 import SkeletonCards from './SkeletonCards';
 import UnionJackLens from './UnionJackLens';
@@ -260,9 +261,17 @@ export default function HmrcResults({ search }: { search: string }) {
 
   if (results.length === 0 && search.length >= 3) {
     return (
-      <p className="mt-6 text-sm text-(--sea-ink-soft)">
-        No organisations found matching &ldquo;{search}&rdquo;
-      </p>
+      <div className="mt-12 flex flex-col items-center text-center sm:mt-16">
+        <BlackHole
+          style={{
+            width: 'clamp(180px,55vw,300px)',
+            height: 'clamp(180px,55vw,300px)',
+          }}
+        />
+        <p className="mt-4 text-sm text-(--sea-ink-soft)">
+          No organisations found matching &ldquo;{search}&rdquo;
+        </p>
+      </div>
     );
   }
 

--- a/apps/web/src/components/NotFound.tsx
+++ b/apps/web/src/components/NotFound.tsx
@@ -1,202 +1,13 @@
 import { Link } from '@tanstack/react-router';
-import { type CSSProperties, useEffect, useRef, useState } from 'react';
 
-import { prefersReducedMotion } from '../utils';
-
-// lib.dom ships the WebGPU interfaces but not this flag constant — declare the
-// bits we use; the browser provides them at runtime (same as theme-transition).
-declare const GPUBufferUsage: {
-  readonly UNIFORM: number;
-  readonly COPY_DST: number;
-};
+import BlackHole from './BlackHole';
 
 /**
- * The "0" in 404 shown before the shader loads (and the no-WebGPU / reduced-motion
- * fallback): a plain ring at the event-horizon radius, so the page always reads
- * "4 O 4" and the circle morphs straight into the black hole's photon ring. The
- * radius is HORIZON (0.22) × the 300 viewBox = 66, matching the shader's horizon, so
- * the diameters line up. `currentColor` keeps it visible in both themes.
- */
-function PlaceholderRing({
-  className,
-  style,
-}: {
-  className?: string;
-  style?: CSSProperties;
-}) {
-  return (
-    <svg
-      viewBox="0 0 300 300"
-      className={className}
-      style={style}
-      aria-hidden="true"
-    >
-      <circle
-        cx="150"
-        cy="150"
-        r="66"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="4"
-        opacity="0.5"
-      />
-    </svg>
-  );
-}
-
-/**
- * 404 page: the error code reads "4 ● 4" with a black hole as the zero. The hole is
- * a WGSL accretion-disk shader on the same WebGPU setup as the theme transition. A
- * plain ring (PlaceholderRing) holds the "0" first — so it reads "4 O 4" — then the
- * shader fades in over it; that same ring is the no-WebGPU / reduced-motion fallback.
+ * 404 page: the error code reads "4 ● 4" with a black hole as the zero. The hole is the
+ * shared BlackHole (a WGSL accretion-disk shader with a plain-ring placeholder/fallback),
+ * so the page reads "4 O 4" until the shader fades in.
  */
 export default function NotFound() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  // Show the placeholder ring first (so it reads "4 O 4"), then swap to the shader on
-  // success. The ring stays if WebGPU is unavailable or fails — it's the fallback.
-  const [mode, setMode] = useState<'gpu' | 'svg'>('svg');
-
-  useEffect(() => {
-    if (prefersReducedMotion() || !navigator.gpu) {
-      setMode('svg');
-      return;
-    }
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    let device: GPUDevice | undefined;
-    let raf = 0;
-    let alive = true;
-    let resize: ResizeObserver | undefined;
-
-    /** Resize the drawing buffer to the canvas box; the frame loop reads it into u.resolution. */
-    const sizeCanvas = () => {
-      const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      const rect = canvas.getBoundingClientRect();
-      canvas.width = Math.max(2, Math.ceil(rect.width * dpr));
-      canvas.height = Math.max(2, Math.ceil(rect.height * dpr));
-    };
-
-    (async () => {
-      try {
-        const adapter = await navigator.gpu.requestAdapter();
-        if (!adapter) {
-          setMode('svg');
-          return;
-        }
-        device = await adapter.requestDevice();
-      } catch {
-        setMode('svg');
-        return;
-      }
-      if (!alive) {
-        device?.destroy();
-        return;
-      }
-      const ctx = canvas.getContext('webgpu') as GPUCanvasContext | null;
-      if (!ctx) {
-        setMode('svg');
-        device.destroy();
-        return;
-      }
-      sizeCanvas();
-      const format = navigator.gpu.getPreferredCanvasFormat();
-
-      // Load the shader lazily so its ~7 KB stays out of the always-loaded root chunk
-      // (only fetched when a 404 actually renders on a WebGPU client).
-      let WGSL: string;
-      try {
-        WGSL = (await import('../notFound.wgsl?raw')).default;
-      } catch {
-        setMode('svg');
-        device.destroy();
-        return;
-      }
-
-      let pipeline: GPURenderPipeline;
-      let uniform: GPUBuffer;
-      let bindGroup: GPUBindGroup;
-      // Validation errors (e.g. a shader compile failure) surface through the
-      // error scope, not as throws — capture them so we keep the SVG fallback.
-      device.pushErrorScope('validation');
-      try {
-        ctx.configure({ device, format, alphaMode: 'premultiplied' });
-        const module = device.createShaderModule({ code: WGSL });
-        pipeline = device.createRenderPipeline({
-          layout: 'auto',
-          vertex: { module, entryPoint: 'vs' },
-          fragment: { module, entryPoint: 'fs', targets: [{ format }] },
-          primitive: { topology: 'triangle-list' },
-        });
-        uniform = device.createBuffer({
-          size: 16,
-          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-        });
-        bindGroup = device.createBindGroup({
-          layout: pipeline.getBindGroupLayout(0),
-          entries: [{ binding: 0, resource: { buffer: uniform } }],
-        });
-      } catch {
-        setMode('svg');
-        await device.popErrorScope().catch(() => null);
-        device.destroy();
-        return;
-      }
-      const setupError = await device.popErrorScope();
-      if (setupError || !alive) {
-        // Authored blind — surface a WGSL compile failure in dev so it can be fixed
-        // (otherwise it just silently falls back to the SVG).
-        if (setupError && import.meta.env.DEV) {
-          console.warn('[404 black-hole shader]', setupError.message);
-        }
-        if (setupError) setMode('svg');
-        device.destroy();
-        return;
-      }
-
-      setMode('gpu');
-      resize = new ResizeObserver(sizeCanvas);
-      resize.observe(canvas);
-
-      const data = new Float32Array(4);
-      const start = performance.now();
-      const frame = (now: number) => {
-        if (!alive || !device) return;
-        data[0] = canvas.width;
-        data[1] = canvas.height;
-        data[2] = (now - start) / 1000;
-        // Read the live theme each frame so the stars flip on a theme toggle.
-        data[3] = document.documentElement.classList.contains('dark') ? 1 : 0;
-        device.queue.writeBuffer(uniform, 0, data);
-
-        const encoder = device.createCommandEncoder();
-        const pass = encoder.beginRenderPass({
-          colorAttachments: [
-            {
-              view: ctx.getCurrentTexture().createView(),
-              clearValue: { r: 0, g: 0, b: 0, a: 0 },
-              loadOp: 'clear',
-              storeOp: 'store',
-            },
-          ],
-        });
-        pass.setPipeline(pipeline);
-        pass.setBindGroup(0, bindGroup);
-        pass.draw(3);
-        pass.end();
-        device.queue.submit([encoder.finish()]);
-        raf = window.requestAnimationFrame(frame);
-      };
-      raf = window.requestAnimationFrame(frame);
-    })();
-
-    return () => {
-      alive = false;
-      if (raf) window.cancelAnimationFrame(raf);
-      resize?.disconnect();
-      device?.destroy();
-    };
-  }, []);
-
   const digit = 'text-[clamp(72px,17vw,165px)] font-extrabold leading-none';
 
   return (
@@ -207,25 +18,14 @@ export default function NotFound() {
         className="flex items-center justify-center tracking-tighter text-(--sea-ink) select-none"
       >
         <span className={digit}>4</span>
-        <span
-          className="relative shrink-0"
+        <BlackHole
+          className="shrink-0"
           style={{
             width: 'clamp(150px,32vw,300px)',
             height: 'clamp(150px,32vw,300px)',
             margin: '0 -0.04em',
           }}
-        >
-          <PlaceholderRing
-            className="absolute inset-0 h-full w-full text-(--sea-ink) transition-opacity duration-500"
-            style={{ opacity: mode === 'svg' ? 1 : 0 }}
-          />
-          <canvas
-            ref={canvasRef}
-            aria-hidden="true"
-            className="absolute inset-0 h-full w-full transition-opacity duration-500"
-            style={{ opacity: mode === 'gpu' ? 1 : 0 }}
-          />
-        </span>
+        />
         <span className={digit}>4</span>
       </div>
       <p className="mt-3 text-(--sea-ink-soft)">


### PR DESCRIPTION
When a company search returns no matches, the home page showed a lone line of text in a large empty space. This fills that space with the black-hole animation (the same one as the 404), minus the "4 4" digits.

### What changed
- **New `BlackHole` component** — extracts the WGSL accretion-disk shader, its WebGPU setup, the canvas, and the plain-ring placeholder/fallback out of `NotFound` into one reusable, sizable component. (Also resolves the prior review note that the WebGPU bootstrap was a 404-only one-off.)
- **`NotFound`** now composes `<BlackHole/>` as its "0" (`4 ⬤ 4`) — same 404 behavior, much less code.
- **`HmrcResults`** empty state now renders the standalone black hole above the "No organisations found matching …" message.

The shader still lazy-loads its `.wgsl` (kept out of the route chunk until a black hole renders), and degrades to the ring on no-WebGPU / reduced-motion.

A `/code-review max` is running; I'll fold any verified findings in as follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEk8H6CL4YJqSqA2ziZHvR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable black-hole visual component with an animated, GPU-rendered mode and a static fallback.
  * Integrated the visual into the 404 page and the “no results” empty state for search.

* **Bug Fixes**
  * Improved graceful degradation when motion is reduced or GPU rendering isn’t available.
  * Enhanced robustness with safer error handling and reliable animation/resize behavior during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->